### PR TITLE
Dev/timer 카운트다운 컴포넌트 추가, 바텀시트 타임 캡슐 아이템 타이머 표시

### DIFF
--- a/core/ui/src/main/java/com/emotionstorage/ui/component/CountDownTimer.kt
+++ b/core/ui/src/main/java/com/emotionstorage/ui/component/CountDownTimer.kt
@@ -34,7 +34,9 @@ fun CountDownTimer(
                     60 * 60 * 1000
                 } else if (optimizeSecondTick && remainingTime >= 60 * 1000) {
                     60 * 1000
-                } else 1000
+                } else {
+                    1000
+                }
             delay(tick.toLong())
 
             remainingTime = deadlineMillis - System.currentTimeMillis()

--- a/core/ui/src/main/java/com/emotionstorage/ui/component/CountDownTimer.kt
+++ b/core/ui/src/main/java/com/emotionstorage/ui/component/CountDownTimer.kt
@@ -1,0 +1,35 @@
+package com.emotionstorage.ui.component
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import kotlinx.coroutines.delay
+import java.time.LocalDateTime
+import java.time.ZoneId
+
+@Composable
+fun CountDownTimer(
+    deadline: LocalDateTime,
+    content: @Composable (hours: Long, minutes: Long, seconds: Long) -> Unit,
+) {
+    val deadlineMillis = deadline.atZone(ZoneId.of("JST")).toInstant().toEpochMilli()
+    var remainingTime by remember {
+        mutableStateOf(deadlineMillis - System.currentTimeMillis())
+    }
+
+    LaunchedEffect(key1 = deadlineMillis) {
+        while (remainingTime > 0) {
+            delay(1000L)
+            remainingTime = deadlineMillis - System.currentTimeMillis()
+        }
+    }
+
+    val seconds = (remainingTime / 1000) % 60
+    val minutes = (remainingTime / (1000 * 60)) % 60
+    val hours = (remainingTime / (1000 * 60 * 60))
+
+    content(hours, minutes, seconds)
+}

--- a/core/ui/src/main/java/com/emotionstorage/ui/component/CountDownTimer.kt
+++ b/core/ui/src/main/java/com/emotionstorage/ui/component/CountDownTimer.kt
@@ -3,7 +3,7 @@ package com.emotionstorage.ui.component
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.mutableLongStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import kotlinx.coroutines.delay
@@ -13,16 +13,30 @@ import java.time.ZoneId
 @Composable
 fun CountDownTimer(
     deadline: LocalDateTime,
+    // tick duration set to 1h if optimized & remaining time >= 1h
+    optimizeMinuteTick: Boolean = false,
+    // tick duration set to 1m if optimized & remaining time >= 1m
+    optimizeSecondTick: Boolean = false,
     content: @Composable (hours: Long, minutes: Long, seconds: Long) -> Unit,
 ) {
-    val deadlineMillis = deadline.atZone(ZoneId.of("JST")).toInstant().toEpochMilli()
-    var remainingTime by remember {
-        mutableStateOf(deadlineMillis - System.currentTimeMillis())
+    val deadlineMillis = deadline.atZone(ZoneId.of("Asia/Seoul")).toInstant().toEpochMilli()
+
+    var remainingTime by remember(key1 = deadlineMillis) {
+        mutableLongStateOf(deadlineMillis - System.currentTimeMillis())
     }
 
     LaunchedEffect(key1 = deadlineMillis) {
+        if (remainingTime <= 0) remainingTime = 0
+
         while (remainingTime > 0) {
-            delay(1000L)
+            val tick =
+                if (optimizeMinuteTick && remainingTime >= 60 * 60 * 1000) {
+                    60 * 60 * 1000
+                } else if (optimizeSecondTick && remainingTime >= 60 * 1000) {
+                    60 * 1000
+                } else 1000
+            delay(tick.toLong())
+
             remainingTime = deadlineMillis - System.currentTimeMillis()
         }
     }

--- a/feat/time-capsule/src/main/java/com/emotionstorage/time_capsule/ui/component/TimeCapsuleItem.kt
+++ b/feat/time-capsule/src/main/java/com/emotionstorage/time_capsule/ui/component/TimeCapsuleItem.kt
@@ -144,7 +144,9 @@ private fun TimeCapsuleItemInfo(
                 )
                 CountDownTimer(
                     deadline = createdAt.plusHours(25),
-                ) { hours, minutes, seconds ->
+                    optimizeMinuteTick = true,
+                    optimizeSecondTick = true,
+                ) { hours, minutes, _ ->
                     Text(
                         text =
                             "임시저장 보관기간이 " +

--- a/feat/time-capsule/src/main/java/com/emotionstorage/time_capsule/ui/component/TimeCapsuleItem.kt
+++ b/feat/time-capsule/src/main/java/com/emotionstorage/time_capsule/ui/component/TimeCapsuleItem.kt
@@ -22,6 +22,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.blur
+import androidx.compose.ui.draw.clip
 import androidx.compose.ui.draw.rotate
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.ColorFilter
@@ -37,6 +38,7 @@ import com.emotionstorage.domain.model.TimeCapsule
 import com.emotionstorage.domain.model.TimeCapsule.Emotion
 import com.emotionstorage.time_capsule.ui.model.TimeCapsuleItemState
 import com.emotionstorage.ui.R
+import com.emotionstorage.ui.component.CountDownTimer
 import com.emotionstorage.ui.component.RoundedToggleButton
 import com.emotionstorage.ui.theme.MooiTheme
 import com.emotionstorage.ui.util.LinearGradient
@@ -90,7 +92,9 @@ fun TimeCapsuleItem(
                         .background(
                             Color.Transparent,
                             RoundedCornerShape(15.dp),
-                        ).clickable(onClick = onClick),
+                        )
+                        .clip(RoundedCornerShape(15.dp))
+                        .clickable(onClick = onClick),
             ) {
                 // overlay
                 if (timeCapsule.status == TimeCapsule.STATUS.LOCKED) {
@@ -139,12 +143,17 @@ private fun TimeCapsuleItemInfo(
                     contentDescription = "",
                     colorFilter = ColorFilter.tint(MooiTheme.colorScheme.errorRed),
                 )
-                Text(
-                    // todo: set timer
-                    text = "임시저장 보관기간이 N시간 남았어요.",
-                    style = MooiTheme.typography.body5.copy(fontWeight = FontWeight.Normal),
-                    color = MooiTheme.colorScheme.errorRed,
-                )
+                CountDownTimer(
+                    deadline = createdAt.plusHours(25),
+                ) { hours, minutes, seconds ->
+                    Text(
+                        text = "임시저장 보관기간이 "
+                            + (if (hours >= 1) "${hours}시간 " else "${minutes}분 ")
+                            + "남았어요.",
+                        style = MooiTheme.typography.body5.copy(fontWeight = FontWeight.Normal),
+                        color = MooiTheme.colorScheme.errorRed,
+                    )
+                }
             }
         }
 
@@ -225,7 +234,9 @@ private fun TemporaryContent(
                 .errorRedBackground(
                     true,
                     RoundedCornerShape(15.dp),
-                ).clickable(onClick = onClick)
+                )
+                .clip(RoundedCornerShape(15.dp))
+                .clickable(onClick = onClick)
                 .padding(top = 17.dp, bottom = 23.dp, start = 15.dp, end = 19.dp),
         verticalAlignment = Alignment.CenterVertically,
     ) {
@@ -304,7 +315,8 @@ private fun ArrivedContentOverLay(
                 .background(
                     Color(0xFF262736).copy(alpha = 0.85f),
                     RoundedCornerShape(15.dp),
-                ).border(
+                )
+                .border(
                     1.dp,
                     LinearGradient(
                         colors =
@@ -315,7 +327,8 @@ private fun ArrivedContentOverLay(
                         angleInDegrees = -17f,
                     ),
                     RoundedCornerShape(15.dp),
-                ).dropShadow(
+                )
+                .dropShadow(
                     shape = RoundedCornerShape(15.dp),
                     color = Color(0xFF849BEA).copy(alpha = 0.15f),
                     offsetX = 0.dp,
@@ -357,14 +370,16 @@ private fun TimeCapsuleContent(
                 .background(
                     Color(0x1A849BEA),
                     RoundedCornerShape(15.dp),
-                ).run {
+                )
+                .run {
                     // blur content if not opened
                     if (blurContent) {
                         this.blur(4.dp)
                     } else {
                         this
                     }
-                }.padding(TimeCapsuleItemDesignToken.contentPadding),
+                }
+                .padding(TimeCapsuleItemDesignToken.contentPadding),
         verticalAlignment = Alignment.CenterVertically,
         horizontalArrangement = Arrangement.spacedBy(11.dp),
     ) {

--- a/feat/time-capsule/src/main/java/com/emotionstorage/time_capsule/ui/component/TimeCapsuleItem.kt
+++ b/feat/time-capsule/src/main/java/com/emotionstorage/time_capsule/ui/component/TimeCapsuleItem.kt
@@ -92,8 +92,7 @@ fun TimeCapsuleItem(
                         .background(
                             Color.Transparent,
                             RoundedCornerShape(15.dp),
-                        )
-                        .clip(RoundedCornerShape(15.dp))
+                        ).clip(RoundedCornerShape(15.dp))
                         .clickable(onClick = onClick),
             ) {
                 // overlay
@@ -147,9 +146,10 @@ private fun TimeCapsuleItemInfo(
                     deadline = createdAt.plusHours(25),
                 ) { hours, minutes, seconds ->
                     Text(
-                        text = "임시저장 보관기간이 "
-                            + (if (hours >= 1) "${hours}시간 " else "${minutes}분 ")
-                            + "남았어요.",
+                        text =
+                            "임시저장 보관기간이 " +
+                                (if (hours >= 1) "${hours}시간 " else "${minutes}분 ") +
+                                "남았어요.",
                         style = MooiTheme.typography.body5.copy(fontWeight = FontWeight.Normal),
                         color = MooiTheme.colorScheme.errorRed,
                     )
@@ -234,8 +234,7 @@ private fun TemporaryContent(
                 .errorRedBackground(
                     true,
                     RoundedCornerShape(15.dp),
-                )
-                .clip(RoundedCornerShape(15.dp))
+                ).clip(RoundedCornerShape(15.dp))
                 .clickable(onClick = onClick)
                 .padding(top = 17.dp, bottom = 23.dp, start = 15.dp, end = 19.dp),
         verticalAlignment = Alignment.CenterVertically,
@@ -315,8 +314,7 @@ private fun ArrivedContentOverLay(
                 .background(
                     Color(0xFF262736).copy(alpha = 0.85f),
                     RoundedCornerShape(15.dp),
-                )
-                .border(
+                ).border(
                     1.dp,
                     LinearGradient(
                         colors =
@@ -327,8 +325,7 @@ private fun ArrivedContentOverLay(
                         angleInDegrees = -17f,
                     ),
                     RoundedCornerShape(15.dp),
-                )
-                .dropShadow(
+                ).dropShadow(
                     shape = RoundedCornerShape(15.dp),
                     color = Color(0xFF849BEA).copy(alpha = 0.15f),
                     offsetX = 0.dp,
@@ -370,16 +367,14 @@ private fun TimeCapsuleContent(
                 .background(
                     Color(0x1A849BEA),
                     RoundedCornerShape(15.dp),
-                )
-                .run {
+                ).run {
                     // blur content if not opened
                     if (blurContent) {
                         this.blur(4.dp)
                     } else {
                         this
                     }
-                }
-                .padding(TimeCapsuleItemDesignToken.contentPadding),
+                }.padding(TimeCapsuleItemDesignToken.contentPadding),
         verticalAlignment = Alignment.CenterVertically,
         horizontalArrangement = Arrangement.spacedBy(11.dp),
     ) {


### PR DESCRIPTION
## Related Issue
- Issue #36 

## 작업 상세 내용
- 카운트다운 컴포넌트 추가
  - 카운트다운 로직을 담은 Composable 함수 -> UI 랜더링은 `content` 파라미터로 전달하여 사용합니다
- 바텀시트 타임 캡슐 아이템 타이머 표시
  - 임시저장 상태 타임캡슐 - 임시저장 보관 기간 타이머 표시
  - 1시간 이상 남은 경우, 시간 표시 / 1시간 미만 남은 경우, 분 표시


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* 신기능
  * 타임캡슐(임시 상태)에 마감 시점까지 남은 시간을 시·분·초 단위로 실시간 카운트다운해 표시합니다. 시간이 흐름에 따라 자동 갱신되어 남은 시간을 직관적으로 확인할 수 있습니다.
* 스타일
  * 타임캡슐 항목에 라운드 처리 및 클리핑을 적용해 시각적 일관성 및 터치(히트) 영역을 개선했습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->