### PR TITLE
Dev/timecapsule detail temp  타임캡슐 상세 화면 '임시저장' 상태 UI 작업

### DIFF
--- a/core/common/src/main/java/com/emotionstorage/common/LocalDateTimeUtil.kt
+++ b/core/common/src/main/java/com/emotionstorage/common/LocalDateTimeUtil.kt
@@ -1,6 +1,7 @@
 package com.emotionstorage.common
 
 import java.time.LocalDateTime
+import java.time.ZoneId
 import java.time.format.DateTimeFormatter
 
 fun LocalDateTime.formatToKorDateTime(): String =
@@ -8,3 +9,6 @@ fun LocalDateTime.formatToKorDateTime(): String =
 
 fun LocalDateTime.formatToKorTime(): String =
     (if (this.hour >= 12) "오후" else "오전") + " " + DateTimeFormatter.ofPattern("hh:mm").format(this)
+
+fun LocalDateTime.toEpochMillis(zoneId: String = "Asia/Seoul"): Long =
+    this.atZone(ZoneId.of(zoneId)).toInstant().toEpochMilli()

--- a/core/ui/src/main/java/com/emotionstorage/ui/component/CountDownTimer.kt
+++ b/core/ui/src/main/java/com/emotionstorage/ui/component/CountDownTimer.kt
@@ -6,9 +6,9 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableLongStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
+import com.emotionstorage.common.toEpochMillis
 import kotlinx.coroutines.delay
 import java.time.LocalDateTime
-import java.time.ZoneId
 
 @Composable
 fun CountDownTimer(
@@ -19,13 +19,11 @@ fun CountDownTimer(
     optimizeSecondTick: Boolean = false,
     content: @Composable (hours: Long, minutes: Long, seconds: Long) -> Unit,
 ) {
-    val deadlineMillis = deadline.atZone(ZoneId.of("Asia/Seoul")).toInstant().toEpochMilli()
-
-    var remainingTime by remember(key1 = deadlineMillis) {
-        mutableLongStateOf(deadlineMillis - System.currentTimeMillis())
+    var remainingTime by remember(key1 = deadline) {
+        mutableLongStateOf(deadline.toEpochMillis() - LocalDateTime.now().toEpochMillis())
     }
 
-    LaunchedEffect(key1 = deadlineMillis) {
+    LaunchedEffect(key1 = deadline) {
         if (remainingTime <= 0) remainingTime = 0
 
         while (remainingTime > 0) {
@@ -39,7 +37,7 @@ fun CountDownTimer(
                 }
             delay(tick.toLong())
 
-            remainingTime = deadlineMillis - System.currentTimeMillis()
+            remainingTime = deadline.toEpochMillis() - LocalDateTime.now().toEpochMillis()
         }
     }
 

--- a/core/ui/src/main/java/com/emotionstorage/ui/component/Modal.kt
+++ b/core/ui/src/main/java/com/emotionstorage/ui/component/Modal.kt
@@ -6,6 +6,7 @@ import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.shape.RoundedCornerShape
@@ -27,9 +28,10 @@ import com.orhanobut.logger.Logger
 fun Modal(
     title: String,
     confirmLabel: String,
-    dismissLabel: String,
     onDismissRequest: () -> Unit,
-    subTitle: String? = null,
+    topDescription: String? = null,
+    bottomDescription: String? = null,
+    dismissLabel: String? = null,
     onConfirm: () -> Unit = {},
     onDismiss: () -> Unit = {},
 ) {
@@ -40,46 +42,66 @@ fun Modal(
                     .clip(RoundedCornerShape(15.dp))
                     .background(MooiTheme.colorScheme.background)
                     .padding(top = 22.dp, bottom = 28.dp, start = 30.dp, end = 30.dp),
-            verticalArrangement = Arrangement.Top,
+            verticalArrangement = Arrangement.spacedBy(18.dp),
             horizontalAlignment = Alignment.CenterHorizontally,
         ) {
-            if (!subTitle.isNullOrEmpty()) {
+            // title & descriptions
+            Column(
+                modifier = Modifier.fillMaxWidth(),
+                verticalArrangement = Arrangement.spacedBy(6.dp),
+                horizontalAlignment = Alignment.CenterHorizontally
+            ) {
+                if (!topDescription.isNullOrEmpty()) {
+                    Text(
+                        text = topDescription,
+                        style = MooiTheme.typography.body2,
+                        color = MooiTheme.colorScheme.gray500,
+                        textAlign = TextAlign.Center,
+                    )
+                }
                 Text(
-                    modifier = Modifier.padding(bottom = 5.dp),
-                    text = subTitle,
-                    style = MooiTheme.typography.body2,
-                    color = MooiTheme.colorScheme.gray500,
+                    text = title,
+                    style =
+                        MooiTheme.typography.head2.copy(
+                            lineHeight = 30.sp,
+                        ),
+                    color = Color.White,
                     textAlign = TextAlign.Center,
                 )
+                if (!bottomDescription.isNullOrEmpty()) {
+                    Text(
+                        text = bottomDescription,
+                        style = MooiTheme.typography.body5,
+                        color = MooiTheme.colorScheme.gray500,
+                        textAlign = TextAlign.Center,
+                    )
+                }
             }
-            Text(
-                modifier = Modifier.padding(bottom = 19.dp),
-                text = title,
-                style =
-                    MooiTheme.typography.head2.copy(
-                        lineHeight = 30.sp,
-                    ),
-                color = Color.White,
-                textAlign = TextAlign.Center,
-            )
-            ModalButton(
-                label = confirmLabel,
-                onClick = {
-                    Logger.v("confirm button clicked")
-                    onConfirm()
-                    onDismissRequest()
-                },
-            )
-            Spacer(modifier = Modifier.height(12.dp))
-            ModalButton(
-                label = dismissLabel,
-                onClick = {
-                    Logger.v("dismiss button clicked")
-                    onDismiss()
-                    onDismissRequest()
-                },
-                type = CtaButtonType.TONAL,
-            )
+
+            // buttons
+            Column(
+                modifier = Modifier.fillMaxWidth(),
+                verticalArrangement = Arrangement.spacedBy(12.dp),
+                horizontalAlignment = Alignment.CenterHorizontally
+            ) {
+                ModalButton(
+                    label = confirmLabel,
+                    onClick = {
+                        onConfirm()
+                        onDismissRequest()
+                    },
+                )
+                if (dismissLabel != null) {
+                    ModalButton(
+                        label = dismissLabel,
+                        onClick = {
+                            onDismiss()
+                            onDismissRequest()
+                        },
+                        type = CtaButtonType.TONAL,
+                    )
+                }
+            }
         }
     }
 }
@@ -104,12 +126,14 @@ private fun ModalButton(
 @Preview(showBackground = true)
 @Composable
 private fun ModalPreview() {
+    // background ui
     Box(modifier = Modifier.fillMaxSize())
+
     Modal(
-        subTitle = "지금 돌아가면 회원가입을\n다시 시작해야 해요.",
+        topDescription = "지금 돌아가면 회원가입을\n다시 시작해야 해요.",
         title = "그래도 메인 화면으로\n돌아갈까요?",
         confirmLabel = "회원가입을 계속 할게요.",
-        dismissLabel = "메인 화면으로 나갈래요. ",
+        dismissLabel = "메인 화면으로 나갈래요.",
         onDismissRequest = { },
         onConfirm = { },
         onDismiss = { },

--- a/core/ui/src/main/java/com/emotionstorage/ui/component/Modal.kt
+++ b/core/ui/src/main/java/com/emotionstorage/ui/component/Modal.kt
@@ -4,7 +4,6 @@ import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
@@ -22,7 +21,6 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import androidx.compose.ui.window.Dialog
 import com.emotionstorage.ui.theme.MooiTheme
-import com.orhanobut.logger.Logger
 
 @Composable
 fun Modal(
@@ -49,7 +47,7 @@ fun Modal(
             Column(
                 modifier = Modifier.fillMaxWidth(),
                 verticalArrangement = Arrangement.spacedBy(6.dp),
-                horizontalAlignment = Alignment.CenterHorizontally
+                horizontalAlignment = Alignment.CenterHorizontally,
             ) {
                 if (!topDescription.isNullOrEmpty()) {
                     Text(
@@ -82,7 +80,7 @@ fun Modal(
             Column(
                 modifier = Modifier.fillMaxWidth(),
                 verticalArrangement = Arrangement.spacedBy(12.dp),
-                horizontalAlignment = Alignment.CenterHorizontally
+                horizontalAlignment = Alignment.CenterHorizontally,
             ) {
                 ModalButton(
                     label = confirmLabel,

--- a/feat/auth/src/main/java/com/emotionstorage/auth/ui/SignupCompleteScreen.kt
+++ b/feat/auth/src/main/java/com/emotionstorage/auth/ui/SignupCompleteScreen.kt
@@ -106,7 +106,6 @@ private fun StatelessSignupCompleteScreen(
                     text = "비밀은 지켜드릴게요,\n당신의 감정을 편하게 나누어보세요.",
                     tail = BubbleTail.BottomCenter,
                     sizeParam = DpSize(265.dp, 84.dp),
-                    bgBrush = MooiTheme.brushScheme.subButtonBackground,
                 )
 
                 CtaButton(

--- a/feat/time-capsule-detail/src/main/java/com/emotionstorage/time_capsule_detail/presentation/TimeCapsuleDetailViewModel.kt
+++ b/feat/time-capsule-detail/src/main/java/com/emotionstorage/time_capsule_detail/presentation/TimeCapsuleDetailViewModel.kt
@@ -3,9 +3,11 @@ package com.emotionstorage.time_capsule_detail.presentation
 import androidx.lifecycle.ViewModel
 import com.emotionstorage.domain.common.collectDataState
 import com.emotionstorage.domain.model.TimeCapsule
+import com.emotionstorage.domain.useCase.key.GetKeyCountUseCase
 import com.emotionstorage.domain.useCase.timeCapsule.ToggleFavoriteUseCase
 import com.emotionstorage.domain.useCase.timeCapsule.ToggleFavoriteUseCase.ToggleToastResult
 import com.emotionstorage.time_capsule_detail.presentation.TimeCapsuleDetailSideEffect.ShowToast
+import com.orhanobut.logger.Logger
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.coroutineScope
 import org.orbitmvi.orbit.Container
@@ -52,6 +54,7 @@ sealed class TimeCapsuleDetailSideEffect {
 
 @HiltViewModel
 class TimeCapsuleDetailViewModel @Inject constructor(
+    private val getKeyCount: GetKeyCountUseCase,
     private val toggleFavorite: ToggleFavoriteUseCase,
 ) : ViewModel(),
     ContainerHost<TimeCapsuleDetailState, TimeCapsuleDetailSideEffect> {
@@ -76,12 +79,23 @@ class TimeCapsuleDetailViewModel @Inject constructor(
 
     private fun handleInit(id: String) =
         intent {
-            // todo: get key count
-            // todo: get time capsule detail of id
+            // get key count
+            coroutineScope {
+                collectDataState(
+                    flow = getKeyCount(),
+                    onSuccess = {
+                        reduce { state.copy(keyCount = it) }
+                    },
+                    onError = { throwable, data ->
+                        Logger.e("error getting key count: $throwable")
+                        reduce { state.copy(keyCount = 0) }
+                    },
+                )
+            }
 
+            // todo: get time capsule detail of id
             reduce {
                 state.copy(
-                    keyCount = 5,
                     timeCapsule =
                         TimeCapsule(
                             id = "id",

--- a/feat/time-capsule-detail/src/main/java/com/emotionstorage/time_capsule_detail/presentation/TimeCapsuleDetailViewModel.kt
+++ b/feat/time-capsule-detail/src/main/java/com/emotionstorage/time_capsule_detail/presentation/TimeCapsuleDetailViewModel.kt
@@ -85,7 +85,7 @@ class TimeCapsuleDetailViewModel @Inject constructor(
                     timeCapsule =
                         TimeCapsule(
                             id = "id",
-                            status = TimeCapsule.STATUS.OPENED,
+                            status = TimeCapsule.STATUS.TEMPORARY,
                             title = "오늘 아침에 친구를 만났는데, 친구가 늦었어..",
                             summary =
                                 "오늘 친구를 만났는데 친구가 지각해놓고 미안하단 말을 하지 않아서 집에 갈 때 기분이 좋지 않았어." +

--- a/feat/time-capsule-detail/src/main/java/com/emotionstorage/time_capsule_detail/presentation/TimeCapsuleDetailViewModel.kt
+++ b/feat/time-capsule-detail/src/main/java/com/emotionstorage/time_capsule_detail/presentation/TimeCapsuleDetailViewModel.kt
@@ -27,13 +27,13 @@ sealed class TimeCapsuleDetailAction {
         val id: String,
     ) : TimeCapsuleDetailAction()
 
-    object OnExpireTrigger: TimeCapsuleDetailAction()
+    object OnExpireTrigger : TimeCapsuleDetailAction()
 
     data class OnToggleFavorite(
         val id: String,
     ) : TimeCapsuleDetailAction()
 
-    object OnDeleteTrigger: TimeCapsuleDetailAction()
+    object OnDeleteTrigger : TimeCapsuleDetailAction()
 
     data class OnDeleteTimeCapsule(
         val id: String,

--- a/feat/time-capsule-detail/src/main/java/com/emotionstorage/time_capsule_detail/presentation/TimeCapsuleDetailViewModel.kt
+++ b/feat/time-capsule-detail/src/main/java/com/emotionstorage/time_capsule_detail/presentation/TimeCapsuleDetailViewModel.kt
@@ -27,9 +27,13 @@ sealed class TimeCapsuleDetailAction {
         val id: String,
     ) : TimeCapsuleDetailAction()
 
+    object OnExpireTrigger: TimeCapsuleDetailAction()
+
     data class OnToggleFavorite(
         val id: String,
     ) : TimeCapsuleDetailAction()
+
+    object OnDeleteTrigger: TimeCapsuleDetailAction()
 
     data class OnDeleteTimeCapsule(
         val id: String,
@@ -38,6 +42,10 @@ sealed class TimeCapsuleDetailAction {
 
 sealed class TimeCapsuleDetailSideEffect {
     object DeleteTimeCapsuleSuccess : TimeCapsuleDetailSideEffect()
+
+    object ShowExpiredModal : TimeCapsuleDetailSideEffect()
+
+    object ShowDeleteModal : TimeCapsuleDetailSideEffect()
 
     data class ShowToast(
         val toast: TimeCapsuleDetailToast,
@@ -67,8 +75,22 @@ class TimeCapsuleDetailViewModel @Inject constructor(
                 handleInit(action.id)
             }
 
+            is TimeCapsuleDetailAction.OnExpireTrigger -> {
+                // trigger side effect
+                intent {
+                    postSideEffect(TimeCapsuleDetailSideEffect.ShowExpiredModal)
+                }
+            }
+
             is TimeCapsuleDetailAction.OnToggleFavorite -> {
                 handleToggleFavorite(action.id)
+            }
+
+            is TimeCapsuleDetailAction.OnDeleteTrigger -> {
+                // trigger side effect
+                intent {
+                    postSideEffect(TimeCapsuleDetailSideEffect.ShowDeleteModal)
+                }
             }
 
             is TimeCapsuleDetailAction.OnDeleteTimeCapsule -> {

--- a/feat/time-capsule-detail/src/main/java/com/emotionstorage/time_capsule_detail/ui/TimeCapsuleDetailScreen.kt
+++ b/feat/time-capsule-detail/src/main/java/com/emotionstorage/time_capsule_detail/ui/TimeCapsuleDetailScreen.kt
@@ -1,5 +1,6 @@
 package com.emotionstorage.time_capsule_detail.ui
 
+import SpeechBubble
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
 import androidx.compose.foundation.border
@@ -33,6 +34,7 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.DpSize
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import androidx.hilt.navigation.compose.hiltViewModel
@@ -54,6 +56,7 @@ import com.emotionstorage.ui.util.getIconResId
 import java.time.LocalDateTime
 import java.time.format.DateTimeFormatter
 import com.emotionstorage.ui.R
+import com.emotionstorage.ui.component.CountDownTimer
 import com.emotionstorage.ui.component.SuccessToast
 import com.emotionstorage.ui.component.Toast
 
@@ -187,29 +190,30 @@ private fun StatelessTimeCapsuleDetailScreen(
                         .padding(horizontal = 16.dp)
                         .verticalScroll(scrollState),
             ) {
-                TimeCapsuleSummary(
-                    title = state.timeCapsule.title,
-                    summary = state.timeCapsule.summary,
-                )
-
-                DecorativeDots(modifier = Modifier.padding(vertical = 31.dp))
-
-                TimeCapsuleEmotionComments(
-                    emotions = state.timeCapsule.emotions,
-                    comments = state.timeCapsule.comments,
-                )
-
-                if (state.timeCapsule.status == TimeCapsule.STATUS.OPENED) {
-                    TimeCapsuleNote(
-                        modifier = Modifier.padding(top = 53.dp),
-                        note = state.timeCapsule.note,
-                        onNoteChange = {
-                            // todo: save note content
-                        },
-                    )
-                }
+//                TimeCapsuleSummary(
+//                    title = state.timeCapsule.title,
+//                    summary = state.timeCapsule.summary,
+//                )
+//
+//                DecorativeDots(modifier = Modifier.padding(vertical = 31.dp))
+//
+//                TimeCapsuleEmotionComments(
+//                    emotions = state.timeCapsule.emotions,
+//                    comments = state.timeCapsule.comments,
+//                )
+//
+//                if (state.timeCapsule.status == TimeCapsule.STATUS.OPENED) {
+//                    TimeCapsuleNote(
+//                        modifier = Modifier.padding(top = 53.dp),
+//                        note = state.timeCapsule.note,
+//                        onNoteChange = {
+//                            // todo: save note content
+//                        },
+//                    )
+//                }
 
                 TimeCapsuleDetailActionButtons(
+                    createdAt = state.timeCapsule.createdAt,
                     status = state.timeCapsule.status,
                     onSaveTimeCapsule = {
                         navToSaveTimeCapsule(id)
@@ -455,6 +459,7 @@ private fun TimeCapsuleNote(
 
 @Composable
 private fun TimeCapsuleDetailActionButtons(
+    createdAt: LocalDateTime,
     status: TimeCapsule.STATUS,
     modifier: Modifier = Modifier,
     onSaveTimeCapsule: () -> Unit = {},
@@ -466,12 +471,43 @@ private fun TimeCapsuleDetailActionButtons(
         verticalArrangement = Arrangement.spacedBy(16.7.dp),
         horizontalAlignment = Alignment.End,
     ) {
-        // todo: change action button according to status
-        CtaButton(
-            modifier = Modifier.fillMaxWidth(),
-            label = "타임캡슐 보관하기",
-            isDefaultWidth = false,
-        )
+        if (status == TimeCapsule.STATUS.TEMPORARY) {
+            Column(
+                modifier = Modifier.fillMaxWidth(),
+                verticalArrangement = Arrangement.spacedBy(15.dp),
+                horizontalAlignment = Alignment.CenterHorizontally
+            ) {
+                CountDownTimer(
+                    deadline = createdAt.plusHours(25)
+                ) { hours, minutes, seconds ->
+                    // todo: trigger time capsule closed when remaining time = 0
+
+                    val timerString = String.format("%02d:%02d:%02d", hours, minutes, seconds)
+                    SpeechBubble(
+                        text = "이 캡슐을 보관할 수 있는 시간이\n${timerString} 남았어요!",
+                        tail = BubbleTail.BottomCenter,
+                        sizeParam = DpSize(265.dp, 84.dp),
+                        textColor = MooiTheme.colorScheme.errorRed
+                    )
+                }
+
+                CtaButton(
+                    modifier = Modifier.fillMaxWidth(),
+                    label = "타임캡슐 보관하기",
+                    onClick = {
+                        onSaveTimeCapsule()
+                    },
+                    isDefaultWidth = false,
+                )
+            }
+        } else {
+            // todo: change action button according to status
+            CtaButton(
+                modifier = Modifier.fillMaxWidth(),
+                label = "타임캡슐 저장하기",
+                isDefaultWidth = false,
+            )
+        }
 
         // delete button
         Row(
@@ -508,7 +544,7 @@ private fun TimeCapsuleDetailScreenPreview() {
                     timeCapsule =
                         TimeCapsule(
                             id = "id",
-                            status = TimeCapsule.STATUS.OPENED,
+                            status = TimeCapsule.STATUS.TEMPORARY,
                             title = "오늘 아침에 친구를 만났는데, 친구가 늦었어..",
                             summary =
                                 "오늘 친구를 만났는데 친구가 지각해놓고 미안하단 말을 하지 않아서 집에 갈 때 기분이 좋지 않았어." +

--- a/feat/time-capsule-detail/src/main/java/com/emotionstorage/time_capsule_detail/ui/TimeCapsuleDetailScreen.kt
+++ b/feat/time-capsule-detail/src/main/java/com/emotionstorage/time_capsule_detail/ui/TimeCapsuleDetailScreen.kt
@@ -221,27 +221,27 @@ private fun StatelessTimeCapsuleDetailScreen(
                         .padding(horizontal = 16.dp)
                         .verticalScroll(scrollState),
             ) {
-//                TimeCapsuleSummary(
-//                    title = state.timeCapsule.title,
-//                    summary = state.timeCapsule.summary,
-//                )
-//
-//                DecorativeDots(modifier = Modifier.padding(vertical = 31.dp))
-//
-//                TimeCapsuleEmotionComments(
-//                    emotions = state.timeCapsule.emotions,
-//                    comments = state.timeCapsule.comments,
-//                )
-//
-//                if (state.timeCapsule.status == TimeCapsule.STATUS.OPENED) {
-//                    TimeCapsuleNote(
-//                        modifier = Modifier.padding(top = 53.dp),
-//                        note = state.timeCapsule.note,
-//                        onNoteChange = {
-//                            // todo: save note content
-//                        },
-//                    )
-//                }
+                TimeCapsuleSummary(
+                    title = state.timeCapsule.title,
+                    summary = state.timeCapsule.summary,
+                )
+
+                DecorativeDots(modifier = Modifier.padding(vertical = 31.dp))
+
+                TimeCapsuleEmotionComments(
+                    emotions = state.timeCapsule.emotions,
+                    comments = state.timeCapsule.comments,
+                )
+
+                if (state.timeCapsule.status == TimeCapsule.STATUS.OPENED) {
+                    TimeCapsuleNote(
+                        modifier = Modifier.padding(top = 53.dp),
+                        note = state.timeCapsule.note,
+                        onNoteChange = {
+                            // todo: save note content
+                        },
+                    )
+                }
 
                 TimeCapsuleDetailActionButtons(
                     createdAt = state.timeCapsule.createdAt,
@@ -513,8 +513,7 @@ private fun TimeCapsuleDetailActionButtons(
                 horizontalAlignment = Alignment.CenterHorizontally
             ) {
                 CountDownTimer(
-//                    deadline = createdAt.plusHours(25)
-                    deadline = createdAt.plusSeconds(5)
+                    deadline = createdAt.plusHours(25)
                 ) { hours, minutes, seconds ->
                     if (hours == 0L && minutes == 0L && seconds == 0L) {
                         onTimeCapsuleExpired()

--- a/feat/time-capsule-detail/src/main/java/com/emotionstorage/time_capsule_detail/ui/TimeCapsuleDetailScreen.kt
+++ b/feat/time-capsule-detail/src/main/java/com/emotionstorage/time_capsule_detail/ui/TimeCapsuleDetailScreen.kt
@@ -510,10 +510,10 @@ private fun TimeCapsuleDetailActionButtons(
             Column(
                 modifier = Modifier.fillMaxWidth(),
                 verticalArrangement = Arrangement.spacedBy(15.dp),
-                horizontalAlignment = Alignment.CenterHorizontally
+                horizontalAlignment = Alignment.CenterHorizontally,
             ) {
                 CountDownTimer(
-                    deadline = createdAt.plusHours(25)
+                    deadline = createdAt.plusHours(25),
                 ) { hours, minutes, seconds ->
                     if (hours == 0L && minutes == 0L && seconds == 0L) {
                         onTimeCapsuleExpired()
@@ -521,10 +521,10 @@ private fun TimeCapsuleDetailActionButtons(
 
                     val timerString = String.format("%02d:%02d:%02d", hours, minutes, seconds)
                     SpeechBubble(
-                        text = "이 캡슐을 보관할 수 있는 시간이\n${timerString} 남았어요!",
+                        text = "이 캡슐을 보관할 수 있는 시간이\n$timerString 남았어요!",
                         tail = BubbleTail.BottomCenter,
                         sizeParam = DpSize(265.dp, 84.dp),
-                        textColor = MooiTheme.colorScheme.errorRed
+                        textColor = MooiTheme.colorScheme.errorRed,
                     )
                 }
 

--- a/feat/time-capsule-detail/src/main/java/com/emotionstorage/time_capsule_detail/ui/TimeCapsuleDetailScreen.kt
+++ b/feat/time-capsule-detail/src/main/java/com/emotionstorage/time_capsule_detail/ui/TimeCapsuleDetailScreen.kt
@@ -88,9 +88,8 @@ fun TimeCapsuleDetailScreen(
                 }
 
                 is ShowExpiredModal -> {
-                    // hide other modals before showing expired modal
+                    // dismiss other modals before showing expired modal
                     setDeleteModalOpen(false)
-
                     setExpiredModalOpen(true)
                 }
 
@@ -101,7 +100,6 @@ fun TimeCapsuleDetailScreen(
                 is ShowToast -> {
                     // dismiss current snackbar if exists
                     snackState.currentSnackbarData?.dismiss()
-                    // show new snackbar
                     snackState.showSnackbar(sideEffect.toast.message)
                 }
             }
@@ -515,8 +513,10 @@ private fun TimeCapsuleDetailActionButtons(
                 CountDownTimer(
                     deadline = createdAt.plusHours(25),
                 ) { hours, minutes, seconds ->
-                    if (hours == 0L && minutes == 0L && seconds == 0L) {
-                        onTimeCapsuleExpired()
+                    LaunchedEffect(hours, minutes, seconds) {
+                        if (hours == 0L && minutes == 0L && seconds == 0L) {
+                            onTimeCapsuleExpired()
+                        }
                     }
 
                     val timerString = String.format("%02d:%02d:%02d", hours, minutes, seconds)

--- a/feat/time-capsule-detail/src/main/java/com/emotionstorage/time_capsule_detail/ui/component/TimeCapsuleDeleteModal.kt
+++ b/feat/time-capsule-detail/src/main/java/com/emotionstorage/time_capsule_detail/ui/component/TimeCapsuleDeleteModal.kt
@@ -15,8 +15,8 @@ fun TimeCapsuleDeleteModal(
                 "타임캡슐은 삭제하면\n" +
                     "다시 되돌릴 수 없어요.\n" +
                     "그래도 삭제할까요?",
-            confirmLabel = "아니요, 유지할게요",
-            dismissLabel = "네, 삭제할게요",
+            confirmLabel = "아니요, 유지할게요.",
+            dismissLabel = "네, 삭제할게요.",
             onDismissRequest = onDismissRequest,
             onDismiss = onDelete,
         )

--- a/feat/time-capsule-detail/src/main/java/com/emotionstorage/time_capsule_detail/ui/component/TimeCapsuleExpiredModal.kt
+++ b/feat/time-capsule-detail/src/main/java/com/emotionstorage/time_capsule_detail/ui/component/TimeCapsuleExpiredModal.kt
@@ -1,0 +1,25 @@
+package com.emotionstorage.time_capsule_detail.ui.component
+
+import androidx.compose.runtime.Composable
+import com.emotionstorage.ui.component.Modal
+
+
+@Composable
+fun TimeCapsuleExpiredModal(
+    isModalOpen: Boolean = false,
+    onConfirm: () -> Unit = {},
+) {
+    if (isModalOpen) {
+        Modal(
+            title =
+                "보관 기한이 만료되어\n캡슐을 보관할 수 없어요.",
+            bottomDescription = "새로운 감정은 새 타임캡슐에 담아보세요.",
+            confirmLabel = "네, 확인했어요.",
+            onConfirm = onConfirm,
+            onDismissRequest = {
+                // do nothing
+                // cannot dismiss modal unless confirm button is clicked
+            },
+        )
+    }
+}

--- a/feat/time-capsule-detail/src/main/java/com/emotionstorage/time_capsule_detail/ui/component/TimeCapsuleExpiredModal.kt
+++ b/feat/time-capsule-detail/src/main/java/com/emotionstorage/time_capsule_detail/ui/component/TimeCapsuleExpiredModal.kt
@@ -3,7 +3,6 @@ package com.emotionstorage.time_capsule_detail.ui.component
 import androidx.compose.runtime.Composable
 import com.emotionstorage.ui.component.Modal
 
-
 @Composable
 fun TimeCapsuleExpiredModal(
     isModalOpen: Boolean = false,

--- a/feat/tutorial/src/main/java/com/emotionstorage/tutorial/ui/onBoarding/NicknameScreen.kt
+++ b/feat/tutorial/src/main/java/com/emotionstorage/tutorial/ui/onBoarding/NicknameScreen.kt
@@ -140,7 +140,7 @@ private fun OnBoardingExitModel(
 ) {
     if (isModelOpen) {
         Modal(
-            subTitle = "지금 돌아가면 회원가입을\n다시 시작해야 해요.",
+            topDescription = "지금 돌아가면 회원가입을\n다시 시작해야 해요.",
             title = "그래도 로그인 화면으로\n돌아갈까요?",
             confirmLabel = "회원가입을 계속 할게요.",
             dismissLabel = "로그인 화면으로 나갈래요.",


### PR DESCRIPTION
## Related Issue
- Issue #49

## 작업 상세 내용
- 타임캡슐 보관하기 버튼 & 만료 카운트다운 말풍선 추가
  - `CountDown` 컴포넌트 로직 - `System.currentTimeMillis()` -> `LocalDataTime.toEpochMillis()` 변경
  - 만료 카운트다운 00:00:00 -> 타입캡슐 만료 팝업 표시 -> 전 화면으로 이동
- 타임캡슐 화면 팝업 표시 로직 변경
  - Composable 함수 내부 state로 관리 -> 뷰모델 인텐트(`onAction()`) & 사이드 이펙트로 관리
  - 참고 커밋: 132115432e7a4b6ed8870f05d0e6d28f5b00e401


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- 신기능
  - 타임캡슐 상세에 만료 카운트다운 및 만료/삭제 모달 추가, 삭제 성공 시 이전 화면으로 이동.
  - 만료 전용 모달(TimeCapsuleExpiredModal) 및 카운트다운 컴포넌트 제공.
  - 상세 화면에서 키 수 표시 및 관련 동작(만료/삭제) 흐름 추가.
- 리팩터링
  - 시간 계산을 LocalDateTime 기반으로 통일(에폭 밀리초 변환 유틸 추가).
  - 공통 모달 레이아웃 개선: 상단/하단 설명 영역과 버튼 동작 정교화.
- 스타일
  - 삭제 모달 문구에 마침표 추가로 문장 표현 개선.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->