### PR TITLE
feat: add main branch protection action 메인 브랜치 보호용 깃허브 액션 추가

### DIFF
--- a/.github/workflows/branch-protection.yml
+++ b/.github/workflows/branch-protection.yml
@@ -1,0 +1,26 @@
+name: Validate Source Branch
+
+on:
+    pull_request:
+        branches:
+            - main
+
+jobs:
+    check-source-branch:
+        runs-on: ubuntu-latest
+        steps:
+            -   name: Display branch ref
+                run: |
+                    echo "Base Branch: ${{ github.base_ref }}"
+                    echo "Head Branch: ${{ github.head_ref }}"
+
+            -   name: Check source branch
+                run: |
+                    if [ "${{ github.base_ref }}" != "main" ]; then
+                        echo "Error: Target branch must be 'main'."
+                        exit 1
+                    fi
+                    if [[ "${{ github.head_ref }}" != "develop" && ! "${{ github.head_ref }}" =~ ^hotfix/ ]]; then
+                        echo "Error: Only 'develop' branch or branches starting with 'hotfix/' are allowed to merge into 'main'."
+                        exit 1
+                    fi


### PR DESCRIPTION
## 작업 상세 내용
- 메인 브랜치 보호용 깃허브 액션 추가
  - `develop` 브랜치 혹은 `hotfix/~` 브랜치에서만 메인 브랜치로 PR 생성할 수 있도록 설정