### PR TITLE
Build/closed test 비공개 테스트 번들 빌드용 설정

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -18,7 +18,7 @@ android {
     defaultConfig {
         applicationId = "com.emotionstorage.emotionstorage"
         versionCode = 1
-        versionName = "v0.0.0-beta"
+        versionName = "0.0.0"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
 

--- a/build-logic/convention/src/main/java/com/emotionstorage/helper/ApplicationConfig.kt
+++ b/build-logic/convention/src/main/java/com/emotionstorage/helper/ApplicationConfig.kt
@@ -5,6 +5,6 @@ import org.gradle.api.JavaVersion
 internal object ApplicationConfig {
     val compileSdk = 35
     val minSdk = 27
-    val targetSdk = 37
+    val targetSdk = 36
     val javaVersion = JavaVersion.VERSION_17
 }


### PR DESCRIPTION
## 작업 상세 내용
- 빌드 버전 변경 '0.0.0'
  - Semantic Versioning 방식으로 버전 네이밍
  - 비공개 테스트 0.0.0 부터 시작 -> 프로덕션 1.0.0부터 시작
  - 참고 - [앱 버전 관리하기 | 올리브영 테크 블로그](https://oliveyoung.tech/2021-07-01/Manage-Oliveyoung-Android-App-Version/)
- 앱 Target SDK 버전 37 -> 36으로 다운그레이드 (구글 플레이 스토어 정책에 따름)
- 번들 빌드에 필요한 키스토어 파일은 노션 FE Secrets 페이지에 업로드해두었습니다!

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Chores
  - 앱 버전명이 v0.0.0-beta에서 0.0.0으로 변경되었습니다. 설정의 앱 정보 화면과 스토어 업데이트 내역 등 사용자 화면의 버전 표기가 새 값으로 표시됩니다.
  - Android 대상 SDK가 37에서 36으로 조정되었습니다. 일부 기기의 설치/실행 호환성에 변동이 있을 수 있으나, 앱 내 기능이나 동작 방식에는 변화가 없습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->