### PR TITLE
Qa/onboarding 온보딩 QA 반영 작업 공유

### DIFF
--- a/feat/auth/src/main/java/com/emotionstorage/auth/ui/LoginScreen.kt
+++ b/feat/auth/src/main/java/com/emotionstorage/auth/ui/LoginScreen.kt
@@ -1,16 +1,12 @@
 package com.emotionstorage.auth.ui
 
-import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
-import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.Button
@@ -20,15 +16,9 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
-import androidx.compose.ui.text.TextStyle
-import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.tooling.preview.PreviewScreenSizes
 import androidx.compose.ui.unit.dp
-import androidx.compose.ui.unit.em
-import androidx.compose.ui.unit.sp
 import androidx.hilt.navigation.compose.hiltViewModel
 import com.emotionstorage.auth.R
 import com.emotionstorage.auth.presentation.LoginAction
@@ -37,7 +27,6 @@ import com.emotionstorage.auth.presentation.LoginViewModel
 import com.emotionstorage.auth.ui.component.SocialLoginButton
 import com.emotionstorage.domain.model.User.AuthProvider
 import com.emotionstorage.ui.theme.MooiTheme
-import com.emotionstorage.ui.theme.pretendard
 
 @Composable
 fun LoginScreen(

--- a/feat/auth/src/main/java/com/emotionstorage/auth/ui/LoginScreen.kt
+++ b/feat/auth/src/main/java/com/emotionstorage/auth/ui/LoginScreen.kt
@@ -1,5 +1,6 @@
 package com.emotionstorage.auth.ui
 
+import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
@@ -20,6 +21,7 @@ import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.font.FontWeight
@@ -65,6 +67,9 @@ fun LoginScreen(
     StatelessLoginScreen(
         modifier = modifier,
         onAction = viewModel::onAction,
+        navToOnboarding = {
+            navToOnBoarding(AuthProvider.KAKAO, "")
+        },
         navToHome = navToHome,
     )
 }
@@ -74,6 +79,7 @@ private fun StatelessLoginScreen(
     modifier: Modifier = Modifier,
     onAction: (LoginAction) -> Unit = {},
     // todo: delete after testing
+    navToOnboarding: () -> Unit = {},
     navToHome: () -> Unit = {},
 ) {
     val scrollState = rememberScrollState()
@@ -89,57 +95,29 @@ private fun StatelessLoginScreen(
                     .background(MooiTheme.colorScheme.background)
                     .fillMaxSize()
                     .padding(padding)
+                    .padding(top = 67.dp, bottom = 36.dp)
                     .verticalScroll(scrollState),
             verticalArrangement = Arrangement.SpaceBetween,
             horizontalAlignment = Alignment.CenterHorizontally,
         ) {
-            Column(
-                modifier =
-                    Modifier
-                        .padding(top = 67.dp),
-                horizontalAlignment = Alignment.CenterHorizontally,
-            ) {
-                Text(
-                    modifier = Modifier.height(37.dp),
-                    style = MooiTheme.typography.body1,
-                    color = MooiTheme.colorScheme.primary,
-                    text = stringResource(id = R.string.login_title),
-                )
-                Text(
-                    modifier = Modifier.height(56.dp),
-                    color = Color.White,
-                    style =
-                        TextStyle(
-                            fontFamily = pretendard,
-                            fontWeight = FontWeight.Medium,
-                            fontSize = 40.sp,
-                            letterSpacing = (-0.02).em,
-                            lineHeight = (40 * 1.4).sp,
-                        ),
-                    text = stringResource(id = R.string.login_app_name),
-                )
-            }
-
-            Spacer(modifier = Modifier.height(10.dp))
-            Box(
-                modifier =
-                    Modifier
-                        .background(Color.Black)
-                        .width(148.dp)
-                        .height(148.dp),
+            Text(
+                modifier = Modifier.height(37.dp),
+                style = MooiTheme.typography.body2,
+                color = MooiTheme.colorScheme.primary,
+                text = stringResource(id = R.string.login_title),
             )
-            Spacer(modifier = Modifier.height(20.dp))
-
             Column(
                 modifier =
                     Modifier
-                        .fillMaxWidth()
-                        .padding(bottom = 36.dp),
+                        .fillMaxWidth(),
                 horizontalAlignment = Alignment.CenterHorizontally,
                 verticalArrangement = Arrangement.spacedBy(12.dp),
             ) {
                 Button(onClick = navToHome) {
                     Text("홈 화면 이동")
+                }
+                Button(onClick = navToOnboarding) {
+                    Text("온보딩 이동")
                 }
                 SocialLoginButton(
                     provider = AuthProvider.KAKAO,

--- a/feat/auth/src/main/res/values/strings.xml
+++ b/feat/auth/src/main/res/values/strings.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
 <!--    Login Screen    -->
-    <string name="login_title">진짜 내 감정을 되돌아보는 시간</string>
+    <string name="login_title">감정을 묻다, 나를 꺼내다</string>
     <string name="login_app_name">MOOI</string>
 
     <string name="login_btn_kako">카카오로 시작하기</string>

--- a/feat/tutorial/src/main/java/com/emotionstorage/tutorial/presentation/onBoarding/GenderBirthViewModel.kt
+++ b/feat/tutorial/src/main/java/com/emotionstorage/tutorial/presentation/onBoarding/GenderBirthViewModel.kt
@@ -29,116 +29,118 @@ interface GenderBirthEvent {
 
 @HiltViewModel
 class GenderBirthViewModel
-@Inject
-constructor() :
+    @Inject
+    constructor() :
     ViewModel(),
-    GenderBirthEvent {
-    private val pGender = MutableStateFlow<GENDER?>(null)
-    private val pBirthYear = MutableStateFlow<String?>(null)
-    private val pBirthMonth = MutableStateFlow<String?>(null)
-    private val pBirthDay = MutableStateFlow<String?>(null)
-    private val pBirthDayRange: MutableStateFlow<IntRange> = MutableStateFlow(1..31)
+        GenderBirthEvent {
+        private val pGender = MutableStateFlow<GENDER?>(null)
+        private val pBirthYear = MutableStateFlow<String?>(null)
+        private val pBirthMonth = MutableStateFlow<String?>(null)
+        private val pBirthDay = MutableStateFlow<String?>(null)
+        private val pBirthDayRange: MutableStateFlow<IntRange> = MutableStateFlow(1..31)
 
-    val state =
-        combine(
-            pGender,
-            pBirthYear,
-            pBirthMonth,
-            pBirthDay,
-            pBirthDayRange,
-        ) { gender, birthYear, birthMonth, birthDay, birthDayRange ->
-            State(
-                gender = gender,
-                yearPickerState =
-                    PickerState(
-                        selectedValue = birthYear,
-                        range = (MIN_YEAR..LocalDate.now().minusYears(MIN_AGE).year).toList().reversed().map { it.toString() },
-                        enabled = true,
-                    ),
-                monthPickerState =
-                    PickerState(
-                        selectedValue = birthMonth,
-                        range = (1..12).toList().map { it.toString() },
-                        enabled = birthYear != null,
-                    ),
-                dayPickerState =
-                    PickerState(
-                        selectedValue = birthDay,
-                        range = birthDayRange.toList().map { it.toString() },
-                        enabled = birthYear != null && birthMonth != null,
-                    ),
+        val state =
+            combine(
+                pGender,
+                pBirthYear,
+                pBirthMonth,
+                pBirthDay,
+                pBirthDayRange,
+            ) { gender, birthYear, birthMonth, birthDay, birthDayRange ->
+                State(
+                    gender = gender,
+                    yearPickerState =
+                        PickerState(
+                            selectedValue = birthYear,
+                            range =
+                                (MIN_YEAR..
+                                    LocalDate.now().minusYears(MIN_AGE).year).toList().reversed().map { it.toString() },
+                            enabled = true,
+                        ),
+                    monthPickerState =
+                        PickerState(
+                            selectedValue = birthMonth,
+                            range = (1..12).toList().map { it.toString() },
+                            enabled = birthYear != null,
+                        ),
+                    dayPickerState =
+                        PickerState(
+                            selectedValue = birthDay,
+                            range = birthDayRange.toList().map { it.toString() },
+                            enabled = birthYear != null && birthMonth != null,
+                        ),
+                )
+            }.stateIn(
+                scope = viewModelScope,
+                started = SharingStarted.WhileSubscribed(5000),
+                initialValue = State(),
             )
-        }.stateIn(
-            scope = viewModelScope,
-            started = SharingStarted.WhileSubscribed(5000),
-            initialValue = State(),
-        )
-    val event: GenderBirthEvent = this@GenderBirthViewModel
+        val event: GenderBirthEvent = this@GenderBirthViewModel
 
-    init {
-        viewModelScope.launch {
-            combine(pBirthYear, pBirthMonth) { year, month ->
-                year to month
-            }.collect { (year, month) ->
-                pBirthDayRange.update {
-                    if (year == null || month == null) {
-                        1..31
-                    } else {
-                        1..LocalDate.of(year.toInt(), month.toInt(), 1).lengthOfMonth()
+        init {
+            viewModelScope.launch {
+                combine(pBirthYear, pBirthMonth) { year, month ->
+                    year to month
+                }.collect { (year, month) ->
+                    pBirthDayRange.update {
+                        if (year == null || month == null) {
+                            1..31
+                        } else {
+                            1..LocalDate.of(year.toInt(), month.toInt(), 1).lengthOfMonth()
+                        }
                     }
                 }
             }
         }
-    }
 
-    override fun onGenderSelect(gender: GENDER?) {
-        pGender.update { gender }
-    }
+        override fun onGenderSelect(gender: GENDER?) {
+            pGender.update { gender }
+        }
 
-    override fun onYearPickerSelect(year: String) {
-        pBirthYear.update { year }
-        pBirthMonth.update { null }
-        pBirthDay.update { null }
-    }
+        override fun onYearPickerSelect(year: String) {
+            pBirthYear.update { year }
+            pBirthMonth.update { null }
+            pBirthDay.update { null }
+        }
 
-    override fun onMonthPickerSelect(month: String) {
-        pBirthMonth.update { month }
-        pBirthDay.update { null }
-    }
+        override fun onMonthPickerSelect(month: String) {
+            pBirthMonth.update { month }
+            pBirthDay.update { null }
+        }
 
-    override fun onDayPickerSelect(day: String) {
-        pBirthDay.update { day }
-    }
+        override fun onDayPickerSelect(day: String) {
+            pBirthDay.update { day }
+        }
 
-    data class State(
-        val gender: GENDER? = null,
-        val yearPickerState: PickerState =
-            PickerState(
-                range = (LocalDate.now().year - MIN_AGE..MIN_YEAR).toList().map { it.toString() },
-                enabled = true,
-            ),
-        val monthPickerState: PickerState =
-            PickerState(
-                range = (1..12).toList().map { it.toString().format("%2d") },
-                enabled = true,
-            ),
-        val dayPickerState: PickerState =
-            PickerState(
-                range = (1..31).toList().map { it.toString().format("%2d") },
-                enabled = true,
-            ),
-    ) {
-        val isNextButtonEnabled: Boolean
-            get() =
-                gender != null &&
-                    yearPickerState.selectedValue != null &&
-                    monthPickerState.selectedValue != null &&
-                    dayPickerState.selectedValue != null
+        data class State(
+            val gender: GENDER? = null,
+            val yearPickerState: PickerState =
+                PickerState(
+                    range = (LocalDate.now().year - MIN_AGE..MIN_YEAR).toList().map { it.toString() },
+                    enabled = true,
+                ),
+            val monthPickerState: PickerState =
+                PickerState(
+                    range = (1..12).toList().map { it.toString().format("%2d") },
+                    enabled = true,
+                ),
+            val dayPickerState: PickerState =
+                PickerState(
+                    range = (1..31).toList().map { it.toString().format("%2d") },
+                    enabled = true,
+                ),
+        ) {
+            val isNextButtonEnabled: Boolean
+                get() =
+                    gender != null &&
+                        yearPickerState.selectedValue != null &&
+                        monthPickerState.selectedValue != null &&
+                        dayPickerState.selectedValue != null
 
-        data class PickerState(
-            val selectedValue: String? = null,
-            val range: List<String> = emptyList(),
-            val enabled: Boolean = true,
-        )
+            data class PickerState(
+                val selectedValue: String? = null,
+                val range: List<String> = emptyList(),
+                val enabled: Boolean = true,
+            )
+        }
     }
-}

--- a/feat/tutorial/src/main/java/com/emotionstorage/tutorial/presentation/onBoarding/GenderBirthViewModel.kt
+++ b/feat/tutorial/src/main/java/com/emotionstorage/tutorial/presentation/onBoarding/GenderBirthViewModel.kt
@@ -14,7 +14,7 @@ import kotlinx.coroutines.launch
 import java.time.LocalDate
 import javax.inject.Inject
 
-private const val MIN_AGE = 14
+private const val MIN_AGE = 14L
 private const val MIN_YEAR = 1970
 
 interface GenderBirthEvent {
@@ -29,116 +29,116 @@ interface GenderBirthEvent {
 
 @HiltViewModel
 class GenderBirthViewModel
-    @Inject
-    constructor() :
+@Inject
+constructor() :
     ViewModel(),
-        GenderBirthEvent {
-        private val pGender = MutableStateFlow<GENDER?>(null)
-        private val pBirthYear = MutableStateFlow<String?>(null)
-        private val pBirthMonth = MutableStateFlow<String?>(null)
-        private val pBirthDay = MutableStateFlow<String?>(null)
-        private val pBirthDayRange: MutableStateFlow<IntRange> = MutableStateFlow(1..31)
+    GenderBirthEvent {
+    private val pGender = MutableStateFlow<GENDER?>(null)
+    private val pBirthYear = MutableStateFlow<String?>(null)
+    private val pBirthMonth = MutableStateFlow<String?>(null)
+    private val pBirthDay = MutableStateFlow<String?>(null)
+    private val pBirthDayRange: MutableStateFlow<IntRange> = MutableStateFlow(1..31)
 
-        val state =
-            combine(
-                pGender,
-                pBirthYear,
-                pBirthMonth,
-                pBirthDay,
-                pBirthDayRange,
-            ) { gender, birthYear, birthMonth, birthDay, birthDayRange ->
-                State(
-                    gender = gender,
-                    yearPickerState =
-                        PickerState(
-                            selectedValue = birthYear,
-                            range = (MIN_YEAR..LocalDate.now().year).toList().map { it.toString() },
-                            enabled = true,
-                        ),
-                    monthPickerState =
-                        PickerState(
-                            selectedValue = birthMonth,
-                            range = (1..12).toList().map { it.toString() },
-                            enabled = birthYear != null,
-                        ),
-                    dayPickerState =
-                        PickerState(
-                            selectedValue = birthDay,
-                            range = birthDayRange.toList().map { it.toString() },
-                            enabled = birthYear != null && birthMonth != null,
-                        ),
-                )
-            }.stateIn(
-                scope = viewModelScope,
-                started = SharingStarted.WhileSubscribed(5000),
-                initialValue = State(),
+    val state =
+        combine(
+            pGender,
+            pBirthYear,
+            pBirthMonth,
+            pBirthDay,
+            pBirthDayRange,
+        ) { gender, birthYear, birthMonth, birthDay, birthDayRange ->
+            State(
+                gender = gender,
+                yearPickerState =
+                    PickerState(
+                        selectedValue = birthYear,
+                        range = (MIN_YEAR..LocalDate.now().minusYears(MIN_AGE).year).toList().reversed().map { it.toString() },
+                        enabled = true,
+                    ),
+                monthPickerState =
+                    PickerState(
+                        selectedValue = birthMonth,
+                        range = (1..12).toList().map { it.toString() },
+                        enabled = birthYear != null,
+                    ),
+                dayPickerState =
+                    PickerState(
+                        selectedValue = birthDay,
+                        range = birthDayRange.toList().map { it.toString() },
+                        enabled = birthYear != null && birthMonth != null,
+                    ),
             )
-        val event: GenderBirthEvent = this@GenderBirthViewModel
+        }.stateIn(
+            scope = viewModelScope,
+            started = SharingStarted.WhileSubscribed(5000),
+            initialValue = State(),
+        )
+    val event: GenderBirthEvent = this@GenderBirthViewModel
 
-        init {
-            viewModelScope.launch {
-                combine(pBirthYear, pBirthMonth) { year, month ->
-                    year to month
-                }.collect { (year, month) ->
-                    pBirthDayRange.update {
-                        if (year == null || month == null) {
-                            1..31
-                        } else {
-                            1..LocalDate.of(year.toInt(), month.toInt(), 1).lengthOfMonth()
-                        }
+    init {
+        viewModelScope.launch {
+            combine(pBirthYear, pBirthMonth) { year, month ->
+                year to month
+            }.collect { (year, month) ->
+                pBirthDayRange.update {
+                    if (year == null || month == null) {
+                        1..31
+                    } else {
+                        1..LocalDate.of(year.toInt(), month.toInt(), 1).lengthOfMonth()
                     }
                 }
             }
         }
-
-        override fun onGenderSelect(gender: GENDER?) {
-            pGender.update { gender }
-        }
-
-        override fun onYearPickerSelect(year: String) {
-            pBirthYear.update { year }
-            pBirthMonth.update { null }
-            pBirthDay.update { null }
-        }
-
-        override fun onMonthPickerSelect(month: String) {
-            pBirthMonth.update { month }
-            pBirthDay.update { null }
-        }
-
-        override fun onDayPickerSelect(day: String) {
-            pBirthDay.update { day }
-        }
-
-        data class State(
-            val gender: GENDER? = null,
-            val yearPickerState: PickerState =
-                PickerState(
-                    range = (LocalDate.now().year - MIN_AGE..MIN_YEAR).toList().map { it.toString() },
-                    enabled = true,
-                ),
-            val monthPickerState: PickerState =
-                PickerState(
-                    range = (1..12).toList().map { it.toString().format("%2d") },
-                    enabled = true,
-                ),
-            val dayPickerState: PickerState =
-                PickerState(
-                    range = (1..31).toList().map { it.toString().format("%2d") },
-                    enabled = true,
-                ),
-        ) {
-            val isNextButtonEnabled: Boolean
-                get() =
-                    gender != null &&
-                        yearPickerState.selectedValue != null &&
-                        monthPickerState.selectedValue != null &&
-                        dayPickerState.selectedValue != null
-
-            data class PickerState(
-                val selectedValue: String? = null,
-                val range: List<String> = emptyList(),
-                val enabled: Boolean = true,
-            )
-        }
     }
+
+    override fun onGenderSelect(gender: GENDER?) {
+        pGender.update { gender }
+    }
+
+    override fun onYearPickerSelect(year: String) {
+        pBirthYear.update { year }
+        pBirthMonth.update { null }
+        pBirthDay.update { null }
+    }
+
+    override fun onMonthPickerSelect(month: String) {
+        pBirthMonth.update { month }
+        pBirthDay.update { null }
+    }
+
+    override fun onDayPickerSelect(day: String) {
+        pBirthDay.update { day }
+    }
+
+    data class State(
+        val gender: GENDER? = null,
+        val yearPickerState: PickerState =
+            PickerState(
+                range = (LocalDate.now().year - MIN_AGE..MIN_YEAR).toList().map { it.toString() },
+                enabled = true,
+            ),
+        val monthPickerState: PickerState =
+            PickerState(
+                range = (1..12).toList().map { it.toString().format("%2d") },
+                enabled = true,
+            ),
+        val dayPickerState: PickerState =
+            PickerState(
+                range = (1..31).toList().map { it.toString().format("%2d") },
+                enabled = true,
+            ),
+    ) {
+        val isNextButtonEnabled: Boolean
+            get() =
+                gender != null &&
+                    yearPickerState.selectedValue != null &&
+                    monthPickerState.selectedValue != null &&
+                    dayPickerState.selectedValue != null
+
+        data class PickerState(
+            val selectedValue: String? = null,
+            val range: List<String> = emptyList(),
+            val enabled: Boolean = true,
+        )
+    }
+}

--- a/feat/tutorial/src/main/java/com/emotionstorage/tutorial/presentation/onBoarding/GenderBirthViewModel.kt
+++ b/feat/tutorial/src/main/java/com/emotionstorage/tutorial/presentation/onBoarding/GenderBirthViewModel.kt
@@ -53,8 +53,9 @@ class GenderBirthViewModel
                         PickerState(
                             selectedValue = birthYear,
                             range =
-                                (MIN_YEAR..
-                                    LocalDate.now().minusYears(MIN_AGE).year).toList().reversed().map { it.toString() },
+                                (
+                                    MIN_YEAR..LocalDate.now().minusYears(MIN_AGE).year
+                                ).toList().reversed().map { it.toString() },
                             enabled = true,
                         ),
                     monthPickerState =

--- a/feat/tutorial/src/main/java/com/emotionstorage/tutorial/ui/onBoarding/GenderBirthScreen.kt
+++ b/feat/tutorial/src/main/java/com/emotionstorage/tutorial/ui/onBoarding/GenderBirthScreen.kt
@@ -197,8 +197,7 @@ private fun GenderInput(
                             .subBackground(isSelected, defaultBackground = Color.Black)
                             .clickable {
                                 if (isSelected) onGenderSelect(null) else onGenderSelect(it)
-                            }
-                            .padding(14.dp),
+                            }.padding(14.dp),
                 ) {
                     Text(
                         style = MooiTheme.typography.body3.copy(fontSize = 15.sp),

--- a/feat/tutorial/src/main/java/com/emotionstorage/tutorial/ui/onBoarding/GenderBirthScreen.kt
+++ b/feat/tutorial/src/main/java/com/emotionstorage/tutorial/ui/onBoarding/GenderBirthScreen.kt
@@ -135,12 +135,11 @@ private fun StatelessGenderBirthScreen(
                 )
             }
 
-            // todo: add bottom padding when keyboard is hidden
             CtaButton(
                 modifier =
                     Modifier
-                        .fillMaxWidth(),
-                //                    .padding(bottom = 39.dp),
+                        .fillMaxWidth()
+                        .padding(bottom = 39.dp),
                 labelString = "다음으로",
                 enabled = state.isNextButtonEnabled,
                 onClick = {
@@ -198,7 +197,8 @@ private fun GenderInput(
                             .subBackground(isSelected, defaultBackground = Color.Black)
                             .clickable {
                                 if (isSelected) onGenderSelect(null) else onGenderSelect(it)
-                            }.padding(14.dp),
+                            }
+                            .padding(14.dp),
                 ) {
                     Text(
                         style = MooiTheme.typography.body3.copy(fontSize = 15.sp),

--- a/feat/tutorial/src/main/java/com/emotionstorage/tutorial/ui/onBoarding/NicknameScreen.kt
+++ b/feat/tutorial/src/main/java/com/emotionstorage/tutorial/ui/onBoarding/NicknameScreen.kt
@@ -13,6 +13,7 @@ import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalFocusManager
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.PreviewScreenSizes
 import androidx.compose.ui.unit.dp
@@ -66,6 +67,7 @@ private fun StatelessNicknameScreen(
         onExit = navToBack,
     )
 
+    val focusManager = LocalFocusManager.current
     Scaffold(
         modifier =
             modifier
@@ -118,7 +120,7 @@ private fun StatelessNicknameScreen(
                             InputState.EMPTY -> TextInputState.Empty(infoMessage = state.nicknameHelperMessage)
                             InputState.INVALID -> TextInputState.Error(errorMessage = state.nicknameHelperMessage)
                             InputState.VALID -> TextInputState.Success(successMessage = state.nicknameHelperMessage)
-                        } as TextInputState,
+                        },
                 )
             }
 
@@ -131,6 +133,7 @@ private fun StatelessNicknameScreen(
                 labelString = "다음으로",
                 enabled = state.nicknameInputState == InputState.VALID,
                 onClick = {
+                    focusManager.clearFocus()
                     onNicknameInputComplete(state.nickname)
                     navToGenderBirth()
                 },

--- a/feat/tutorial/src/main/java/com/emotionstorage/tutorial/ui/onBoarding/OnBoardingTitle.kt
+++ b/feat/tutorial/src/main/java/com/emotionstorage/tutorial/ui/onBoarding/OnBoardingTitle.kt
@@ -25,7 +25,7 @@ import androidx.compose.ui.zIndex
 import com.emotionstorage.ui.theme.MooiTheme
 import com.emotionstorage.ui.util.buildHighlightAnnotatedString
 
-private const val ON_BOARDING_STEP_COUNT = 4
+private const val ON_BOARDING_MAX_STEP = 3
 
 @Composable
 fun OnBoardingTitle(
@@ -34,7 +34,7 @@ fun OnBoardingTitle(
     titleHighlights: List<String> = emptyList(),
     showSteps: Boolean = true,
     currentStep: Int = 0,
-    totalStep: Int = ON_BOARDING_STEP_COUNT,
+    totalStep: Int = ON_BOARDING_MAX_STEP,
 ) {
     Box(
         modifier = modifier,
@@ -53,7 +53,7 @@ fun OnBoardingTitle(
         if (showSteps) {
             OnBoardingStep(
                 currentStep = currentStep,
-                totalStep = totalStep,
+                maxStep = totalStep,
                 modifier = Modifier.align(Alignment.TopEnd),
             )
         }
@@ -64,17 +64,20 @@ fun OnBoardingTitle(
 private fun OnBoardingStep(
     modifier: Modifier = Modifier,
     currentStep: Int = 0,
-    totalStep: Int = ON_BOARDING_STEP_COUNT,
+    maxStep: Int = ON_BOARDING_MAX_STEP,
 ) {
     Row(
-        modifier = modifier,
+        modifier = modifier
+            .padding(
+                end = if (currentStep != maxStep) 10.dp else 0.dp
+            )
+            .offset(x = 5.dp),
         verticalAlignment = Alignment.CenterVertically,
     ) {
-        repeat(totalStep) { step ->
+        repeat(maxStep + 1) { step ->
             OnBoardingStepItem(
                 isCurrentStep = step == currentStep,
-                isLastStep = step == totalStep - 1,
-                modifier = Modifier.padding(start = if (step == 0) 5.dp else 0.dp),
+                isLastStep = step == maxStep,
             )
         }
     }
@@ -82,9 +85,9 @@ private fun OnBoardingStep(
 
 @Composable
 private fun RowScope.OnBoardingStepItem(
+    modifier: Modifier = Modifier,
     isCurrentStep: Boolean = false,
     isLastStep: Boolean = false,
-    modifier: Modifier = Modifier,
 ) {
     Box(modifier = modifier) {
         Row(
@@ -130,10 +133,10 @@ private fun RowScope.OnBoardingStepItem(
 private fun OnBoardingStepPreview() {
     MooiTheme {
         Column {
-            OnBoardingStep(currentStep = 0)
+            OnBoardingStep(currentStep = 0, modifier = Modifier.background(Color.Red))
             OnBoardingStep(currentStep = 1)
             OnBoardingStep(currentStep = 2)
-            OnBoardingStep(currentStep = 3)
+            OnBoardingStep(currentStep = 3, modifier = Modifier.background(Color.Red))
         }
     }
 }
@@ -142,14 +145,25 @@ private fun OnBoardingStepPreview() {
 @Composable
 private fun OnBoardingTitlePreview() {
     MooiTheme {
-        OnBoardingTitle(
-            title = "어떤 이름으로\n불러드릴까요?",
-            currentStep = 0,
-            titleHighlights = listOf("어떤", "이름"),
-            modifier =
-                Modifier
-                    .background(MooiTheme.colorScheme.background)
-                    .fillMaxWidth(),
-        )
+        Column {
+            OnBoardingTitle(
+                title = "어떤 이름으로\n불러드릴까요?",
+                currentStep = 0,
+                titleHighlights = listOf("어떤", "이름"),
+                modifier =
+                    Modifier
+                        .background(MooiTheme.colorScheme.background)
+                        .fillMaxWidth(),
+            )
+            OnBoardingTitle(
+                title = "마지막으로,\n이용약관에 동의해주세요.",
+                currentStep = 3,
+                titleHighlights = listOf("이용약관"),
+                modifier =
+                    Modifier
+                        .background(MooiTheme.colorScheme.background)
+                        .fillMaxWidth(),
+            )
+        }
     }
 }

--- a/feat/tutorial/src/main/java/com/emotionstorage/tutorial/ui/onBoarding/OnBoardingTitle.kt
+++ b/feat/tutorial/src/main/java/com/emotionstorage/tutorial/ui/onBoarding/OnBoardingTitle.kt
@@ -67,11 +67,11 @@ private fun OnBoardingStep(
     maxStep: Int = ON_BOARDING_MAX_STEP,
 ) {
     Row(
-        modifier = modifier
-            .padding(
-                end = if (currentStep != maxStep) 10.dp else 0.dp
-            )
-            .offset(x = 5.dp),
+        modifier =
+            modifier
+                .padding(
+                    end = if (currentStep != maxStep) 10.dp else 0.dp,
+                ).offset(x = 5.dp),
         verticalAlignment = Alignment.CenterVertically,
     ) {
         repeat(maxStep + 1) { step ->


### PR DESCRIPTION
## Related Issue
- Issue #71

## 작업 상세 내용
- 닉네임 입력 화면 
  - 다음 화면 이동 시, 키보드 닫기 (004)
- 성별, 생년월일 선택 화면
  - 다음으로 버튼 하단 패딩 고침 (007)
  - 생년월일 선택 년도 내림차순 정렬로 변경 (005)
  - 생년월일 선택 최대 년도 -> 현재 년도 - 14으로 설정(006)
- 약관 동의 화면 -
  - 타이틀 스텝 컴포넌트 여백 고침 (001)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - 로그인 화면에 온보딩 바로가기 버튼 추가 및 온보딩으로 이동하는 신규 내비게이션 경로 지원
- Bug Fixes
  - 닉네임 단계에서 다음 클릭 시 키보드 포커스 해제하여 키보드 잔존 개선
  - 출생연도 선택에서 최소 연령 반영하도록 연도 계산 로직 수정
  - 성별/생년 화면 하단 CTA 간격 보정으로 버튼 가림 완화
- Refactor
  - 로그인 화면 레이아웃 단순화 및 타이포/여백 조정
  - 온보딩 단계 컴포넌트 파라미터·기본값을 maxStep 기준으로 정리
- Style
  - 로그인 타이틀 문구 업데이트
<!-- end of auto-generated comment: release notes by coderabbit.ai -->