### PR TITLE
Dev/date picker bs 캘린더 바텀시트 선택 불가 날짜 처리 & 바텀시트,모달 배경 오파시티 80%

### DIFF
--- a/core/ui/src/main/java/com/emotionstorage/ui/component/BottomSheet.kt
+++ b/core/ui/src/main/java/com/emotionstorage/ui/component/BottomSheet.kt
@@ -23,10 +23,12 @@ import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.LocalView
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
+import androidx.compose.ui.window.DialogWindowProvider
 import com.emotionstorage.ui.theme.MooiTheme
 import kotlinx.coroutines.launch
 
@@ -71,6 +73,9 @@ fun BottomSheet(
         containerColor = MooiTheme.colorScheme.blueGrayBackground,
         contentColor = Color.White,
     ) {
+        // set dim amount to 0.8f
+        (LocalView.current.parent as DialogWindowProvider).window.setDimAmount(0.8f)
+
         Column(
             modifier = Modifier.padding(contentPadding),
             verticalArrangement = Arrangement.Top,

--- a/core/ui/src/main/java/com/emotionstorage/ui/component/DatePickerBottomSheet.kt
+++ b/core/ui/src/main/java/com/emotionstorage/ui/component/DatePickerBottomSheet.kt
@@ -68,24 +68,27 @@ fun DatePickerBottomSheet(
         contentPadding = PaddingValues(horizontal = 16.dp, vertical = 20.dp),
     ) {
         Column(
-            modifier = modifier
-                .fillMaxWidth()
-                .height(356.dp),
+            modifier =
+                modifier
+                    .fillMaxWidth()
+                    .height(356.dp),
         ) {
             // year & month selection
             Box(
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .padding(bottom = 18.dp),
+                modifier =
+                    Modifier
+                        .fillMaxWidth()
+                        .padding(bottom = 18.dp),
             ) {
                 if (YearMonth.from(minDate) < calendarYearMonth) {
                     Image(
-                        modifier = Modifier
-                            .align(Alignment.CenterStart)
-                            .size(width = 8.dp, height = 14.dp)
-                            .clickable {
-                                onYearMonthSelect(calendarYearMonth.minusMonths(1))
-                            },
+                        modifier =
+                            Modifier
+                                .align(Alignment.CenterStart)
+                                .size(width = 8.dp, height = 14.dp)
+                                .clickable {
+                                    onYearMonthSelect(calendarYearMonth.minusMonths(1))
+                                },
                         painter = painterResource(id = R.drawable.arrow_back),
                         colorFilter = ColorFilter.tint(MooiTheme.colorScheme.gray600),
                         contentDescription = "",
@@ -93,12 +96,13 @@ fun DatePickerBottomSheet(
                 }
 
                 Row(
-                    modifier = Modifier
-                        .align(Alignment.Center)
-                        .clickable(
-                            enabled = (calendarYearMonth < YearMonth.from(maxDate)),
-                            onClick = onYearMonthDropdownClick,
-                        ),
+                    modifier =
+                        Modifier
+                            .align(Alignment.Center)
+                            .clickable(
+                                enabled = (calendarYearMonth < YearMonth.from(maxDate)),
+                                onClick = onYearMonthDropdownClick,
+                            ),
                     verticalAlignment = Alignment.CenterVertically,
                     horizontalArrangement = Arrangement.spacedBy(6.dp),
                 ) {
@@ -118,13 +122,14 @@ fun DatePickerBottomSheet(
 
                 if (calendarYearMonth < YearMonth.from(maxDate)) {
                     Image(
-                        modifier = Modifier
-                            .align(Alignment.CenterEnd)
-                            .size(width = 8.dp, height = 14.dp)
-                            .rotate(180f)
-                            .clickable {
-                                onYearMonthSelect(calendarYearMonth.plusMonths(1))
-                            },
+                        modifier =
+                            Modifier
+                                .align(Alignment.CenterEnd)
+                                .size(width = 8.dp, height = 14.dp)
+                                .rotate(180f)
+                                .clickable {
+                                    onYearMonthSelect(calendarYearMonth.plusMonths(1))
+                                },
                         painter = painterResource(id = R.drawable.arrow_back),
                         colorFilter = ColorFilter.tint(MooiTheme.colorScheme.gray600),
                         contentDescription = "",
@@ -142,9 +147,10 @@ fun DatePickerBottomSheet(
                     key = { it },
                 ) { label ->
                     Text(
-                        modifier = Modifier
-                            .weight(1f)
-                            .padding(bottom = 11.dp),
+                        modifier =
+                            Modifier
+                                .weight(1f)
+                                .padding(bottom = 11.dp),
                         text = label,
                         style = MooiTheme.typography.caption5,
                         color = MooiTheme.colorScheme.gray400,
@@ -157,42 +163,45 @@ fun DatePickerBottomSheet(
                     key = { it.toString() },
                 ) { date ->
                     Box(
-                        modifier = Modifier
-                            .weight(1f)
-                            .padding(vertical = 8.dp),
+                        modifier =
+                            Modifier
+                                .weight(1f)
+                                .padding(vertical = 8.dp),
                     ) {
                         if (date.year == calendarYearMonth.year && date.month == calendarYearMonth.month) {
                             Box(
-                                modifier = Modifier
-                                    .align(Alignment.Center)
-                                    .size(29.dp)
-                                    .offset(y = -0.5.dp)
-                                    .background(
-                                        if (selectedDate != date) {
-                                            Color.Transparent
-                                        } else {
-                                            MooiTheme.colorScheme.secondary
-                                        },
-                                        CircleShape,
-                                    )
-                                    .clip(CircleShape)
-                                    .clickable(
-                                        enabled = date.isAfter(minDate) && date.isBefore(maxDate),
-                                        onClick = {
-                                            scope.launch { sheetState.hide() }.invokeOnCompletion {
-                                                if (!sheetState.isVisible) {
-                                                    onDateSelect(date)
+                                modifier =
+                                    Modifier
+                                        .align(Alignment.Center)
+                                        .size(29.dp)
+                                        .offset(y = -0.5.dp)
+                                        .background(
+                                            if (selectedDate != date) {
+                                                Color.Transparent
+                                            } else {
+                                                MooiTheme.colorScheme.secondary
+                                            },
+                                            CircleShape,
+                                        ).clip(CircleShape)
+                                        .clickable(
+                                            enabled = date.isAfter(minDate) && date.isBefore(maxDate),
+                                            onClick = {
+                                                scope.launch { sheetState.hide() }.invokeOnCompletion {
+                                                    if (!sheetState.isVisible) {
+                                                        onDateSelect(date)
+                                                    }
                                                 }
-                                            }
-                                        }),
+                                            },
+                                        ),
                             )
                             Text(
                                 modifier = Modifier.align(Alignment.Center),
                                 text = date.dayOfMonth.toString(),
                                 style = MooiTheme.typography.body8,
-                                color = Color.White.copy(
-                                    alpha = if (date.isAfter(minDate) && date.isBefore(maxDate)) 1f else 0.13f
-                                ),
+                                color =
+                                    Color.White.copy(
+                                        alpha = if (date.isAfter(minDate) && date.isBefore(maxDate)) 1f else 0.13f,
+                                    ),
                             )
                         }
                     }
@@ -208,15 +217,17 @@ fun DatePickerBottomSheet(
 private fun DatePickerBottomSheetPreview() {
     MooiTheme {
         Box(
-            modifier = Modifier
-                .fillMaxSize()
-                .background(MooiTheme.colorScheme.background),
+            modifier =
+                Modifier
+                    .fillMaxSize()
+                    .background(MooiTheme.colorScheme.background),
         ) {
             DatePickerBottomSheet(
                 // open sheet state for preview
-                sheetState = rememberStandardBottomSheetState(
-                    initialValue = SheetValue.Expanded,
-                ),
+                sheetState =
+                    rememberStandardBottomSheetState(
+                        initialValue = SheetValue.Expanded,
+                    ),
                 selectedDate = LocalDate.now(),
                 minDate = LocalDate.now().minusDays(7),
                 maxDate = LocalDate.now().plusDays(10),

--- a/core/ui/src/main/java/com/emotionstorage/ui/component/DatePickerBottomSheet.kt
+++ b/core/ui/src/main/java/com/emotionstorage/ui/component/DatePickerBottomSheet.kt
@@ -68,27 +68,24 @@ fun DatePickerBottomSheet(
         contentPadding = PaddingValues(horizontal = 16.dp, vertical = 20.dp),
     ) {
         Column(
-            modifier =
-                modifier
-                    .fillMaxWidth()
-                    .height(356.dp),
+            modifier = modifier
+                .fillMaxWidth()
+                .height(356.dp),
         ) {
             // year & month selection
             Box(
-                modifier =
-                    Modifier
-                        .fillMaxWidth()
-                        .padding(bottom = 18.dp),
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(bottom = 18.dp),
             ) {
                 if (YearMonth.from(minDate) < calendarYearMonth) {
                     Image(
-                        modifier =
-                            Modifier
-                                .align(Alignment.CenterStart)
-                                .size(width = 8.dp, height = 14.dp)
-                                .clickable {
-                                    onYearMonthSelect(calendarYearMonth.minusMonths(1))
-                                },
+                        modifier = Modifier
+                            .align(Alignment.CenterStart)
+                            .size(width = 8.dp, height = 14.dp)
+                            .clickable {
+                                onYearMonthSelect(calendarYearMonth.minusMonths(1))
+                            },
                         painter = painterResource(id = R.drawable.arrow_back),
                         colorFilter = ColorFilter.tint(MooiTheme.colorScheme.gray600),
                         contentDescription = "",
@@ -96,13 +93,12 @@ fun DatePickerBottomSheet(
                 }
 
                 Row(
-                    modifier =
-                        Modifier
-                            .align(Alignment.Center)
-                            .clickable(
-                                enabled = (calendarYearMonth < YearMonth.from(maxDate)),
-                                onClick = onYearMonthDropdownClick,
-                            ),
+                    modifier = Modifier
+                        .align(Alignment.Center)
+                        .clickable(
+                            enabled = (calendarYearMonth < YearMonth.from(maxDate)),
+                            onClick = onYearMonthDropdownClick,
+                        ),
                     verticalAlignment = Alignment.CenterVertically,
                     horizontalArrangement = Arrangement.spacedBy(6.dp),
                 ) {
@@ -122,14 +118,13 @@ fun DatePickerBottomSheet(
 
                 if (calendarYearMonth < YearMonth.from(maxDate)) {
                     Image(
-                        modifier =
-                            Modifier
-                                .align(Alignment.CenterEnd)
-                                .size(width = 8.dp, height = 14.dp)
-                                .rotate(180f)
-                                .clickable {
-                                    onYearMonthSelect(calendarYearMonth.plusMonths(1))
-                                },
+                        modifier = Modifier
+                            .align(Alignment.CenterEnd)
+                            .size(width = 8.dp, height = 14.dp)
+                            .rotate(180f)
+                            .clickable {
+                                onYearMonthSelect(calendarYearMonth.plusMonths(1))
+                            },
                         painter = painterResource(id = R.drawable.arrow_back),
                         colorFilter = ColorFilter.tint(MooiTheme.colorScheme.gray600),
                         contentDescription = "",
@@ -147,10 +142,9 @@ fun DatePickerBottomSheet(
                     key = { it },
                 ) { label ->
                     Text(
-                        modifier =
-                            Modifier
-                                .weight(1f)
-                                .padding(bottom = 11.dp),
+                        modifier = Modifier
+                            .weight(1f)
+                            .padding(bottom = 11.dp),
                         text = label,
                         style = MooiTheme.typography.caption5,
                         color = MooiTheme.colorScheme.gray400,
@@ -163,43 +157,42 @@ fun DatePickerBottomSheet(
                     key = { it.toString() },
                 ) { date ->
                     Box(
-                        modifier =
-                            Modifier
-                                .weight(1f)
-                                .padding(vertical = 8.dp),
+                        modifier = Modifier
+                            .weight(1f)
+                            .padding(vertical = 8.dp),
                     ) {
                         if (date.year == calendarYearMonth.year && date.month == calendarYearMonth.month) {
                             Box(
-                                modifier =
-                                    Modifier
-                                        .align(Alignment.Center)
-                                        .size(29.dp)
-                                        .offset(y = -0.5.dp)
-                                        .background(
-                                            if (selectedDate !=
-                                                date
-                                            ) {
-                                                Color.Transparent
-                                            } else {
-                                                MooiTheme.colorScheme.secondary
-                                            },
-                                            CircleShape,
-                                        ).clip(CircleShape)
-                                        .clickable {
+                                modifier = Modifier
+                                    .align(Alignment.Center)
+                                    .size(29.dp)
+                                    .offset(y = -0.5.dp)
+                                    .background(
+                                        if (selectedDate != date) {
+                                            Color.Transparent
+                                        } else {
+                                            MooiTheme.colorScheme.secondary
+                                        },
+                                        CircleShape,
+                                    )
+                                    .clip(CircleShape)
+                                    .clickable(
+                                        enabled = date.isAfter(minDate) && date.isBefore(maxDate),
+                                        onClick = {
                                             scope.launch { sheetState.hide() }.invokeOnCompletion {
                                                 if (!sheetState.isVisible) {
                                                     onDateSelect(date)
                                                 }
                                             }
-                                        },
+                                        }),
                             )
                             Text(
-                                modifier =
-                                    Modifier
-                                        .align(Alignment.Center),
+                                modifier = Modifier.align(Alignment.Center),
                                 text = date.dayOfMonth.toString(),
                                 style = MooiTheme.typography.body8,
-                                color = Color.White,
+                                color = Color.White.copy(
+                                    alpha = if (date.isAfter(minDate) && date.isBefore(maxDate)) 1f else 0.13f
+                                ),
                             )
                         }
                     }
@@ -214,22 +207,20 @@ fun DatePickerBottomSheet(
 @Composable
 private fun DatePickerBottomSheetPreview() {
     MooiTheme {
-        MooiTheme {
-            Box(
-                modifier =
-                    Modifier
-                        .fillMaxSize()
-                        .background(MooiTheme.colorScheme.background),
-            ) {
-                DatePickerBottomSheet(
-                    // open sheet state for preview
-                    sheetState =
-                        rememberStandardBottomSheetState(
-                            initialValue = SheetValue.Expanded,
-                        ),
-                    selectedDate = LocalDate.now(),
-                )
-            }
+        Box(
+            modifier = Modifier
+                .fillMaxSize()
+                .background(MooiTheme.colorScheme.background),
+        ) {
+            DatePickerBottomSheet(
+                // open sheet state for preview
+                sheetState = rememberStandardBottomSheetState(
+                    initialValue = SheetValue.Expanded,
+                ),
+                selectedDate = LocalDate.now(),
+                minDate = LocalDate.now().minusDays(7),
+                maxDate = LocalDate.now().plusDays(10),
+            )
         }
     }
 }

--- a/core/ui/src/main/java/com/emotionstorage/ui/component/Modal.kt
+++ b/core/ui/src/main/java/com/emotionstorage/ui/component/Modal.kt
@@ -17,11 +17,13 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.LocalView
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import androidx.compose.ui.window.Dialog
+import androidx.compose.ui.window.DialogWindowProvider
 import com.emotionstorage.ui.theme.MooiTheme
 
 @Composable
@@ -38,6 +40,9 @@ fun Modal(
     content: @Composable (() -> Unit)? = null,
 ) {
     Dialog(onDismissRequest = onDismissRequest) {
+        // set dim amount to 0.8f
+        (LocalView.current.parent as DialogWindowProvider).window.setDimAmount(0.8f)
+
         Column(
             modifier =
                 Modifier


### PR DESCRIPTION
## Related Issue
- Issue #88 

## 작업 상세 내용
- 캘린더 바텀시트 선택 불가 날짜 처리
  - 선택 가능 최소 날짜 이전 & 최대 날짜 이후 - 오파시티 13% 설정, 클릭 불가 처리
- 바텀시트, 모달 컴포넌트 뒤 배경 dim 80% 설정


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- 신규 기능
  - 모달과 바텀시트의 배경 흐림 강도를 높여(더 어둡게) 화면 집중도를 개선했습니다.
- 버그 수정
  - 날짜 선택이 최소/최대 범위를 정확히 준수하도록 수정했습니다(범위 밖 날짜는 선택 불가).
  - 범위 밖 날짜는 반투명 표시로 구분됩니다.
  - 날짜 선택 콜백이 바텀시트가 완전히 닫힌 뒤에만 호출되도록 조정해 중복 동작을 방지했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->