### PR TITLE
Fix/design qa 1014

### DIFF
--- a/core/ui/src/main/java/com/emotionstorage/ui/component/TimeWheelSpinner.kt
+++ b/core/ui/src/main/java/com/emotionstorage/ui/component/TimeWheelSpinner.kt
@@ -6,10 +6,8 @@ import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.width
-import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment

--- a/core/ui/src/main/java/com/emotionstorage/ui/component/TimeWheelSpinner.kt
+++ b/core/ui/src/main/java/com/emotionstorage/ui/component/TimeWheelSpinner.kt
@@ -38,15 +38,6 @@ fun TimeWheelSpinner(
                 .background(Color.Transparent)
                 .padding(horizontal = 20.dp),
     ) {
-        Box(
-            modifier =
-                Modifier
-                    .align(Alignment.Center)
-                    .height(38.dp)
-                    .fillMaxWidth()
-                    .background(MooiTheme.colorScheme.dropBox, RoundedCornerShape(15.dp)),
-        )
-
         Row(
             modifier =
                 Modifier

--- a/feat/ai-chat/src/main/java/com/emotionstorage/ai_chat/ui/component/ChatMessageInputBox.kt
+++ b/feat/ai-chat/src/main/java/com/emotionstorage/ai_chat/ui/component/ChatMessageInputBox.kt
@@ -2,6 +2,7 @@ package com.emotionstorage.ai_chat.ui.component
 
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
+import androidx.compose.foundation.border
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.layout.Box
@@ -85,7 +86,8 @@ fun ChatMessageInputBox(
                             Modifier
                                 .fillMaxWidth()
                                 .fillMaxHeight()
-                                .background(MooiTheme.colorScheme.gray800, shape)
+                                .border(width = 1.dp, color = MooiTheme.colorScheme.gray800, shape)
+                                .background(Color(0xFF26262C), shape)
                                 .padding(horizontal = 12.dp, vertical = 8.dp),
                         verticalAlignment = Alignment.CenterVertically,
                     ) {

--- a/feat/daily-report/src/main/java/com/emotionstorage/daily_report/ui/component/DailyReportEmotionLog.kt
+++ b/feat/daily-report/src/main/java/com/emotionstorage/daily_report/ui/component/DailyReportEmotionLog.kt
@@ -152,7 +152,7 @@ private fun LogLine(modifier: Modifier = Modifier) {
             modifier =
                 Modifier
                     .align(Alignment.Center)
-                    .offset(x=0.25.dp)
+                    .offset(x = 0.25.dp)
                     .fillMaxHeight()
                     .width(3.dp)
                     .background(

--- a/feat/daily-report/src/main/java/com/emotionstorage/daily_report/ui/component/DailyReportEmotionLog.kt
+++ b/feat/daily-report/src/main/java/com/emotionstorage/daily_report/ui/component/DailyReportEmotionLog.kt
@@ -137,7 +137,7 @@ private fun LogLine(modifier: Modifier = Modifier) {
                     .align(Alignment.Center)
                     .fillMaxHeight()
                     .width(3.dp)
-                    .offset(x = (-1.5).dp)
+                    .offset(x = (-0.75).dp)
                     .dropShadow(
                         color = Color(0xFF849BEA).copy(alpha = 0.7f),
                         blur = 5.dp,
@@ -152,6 +152,7 @@ private fun LogLine(modifier: Modifier = Modifier) {
             modifier =
                 Modifier
                     .align(Alignment.Center)
+                    .offset(x=0.25.dp)
                     .fillMaxHeight()
                     .width(3.dp)
                     .background(

--- a/feat/my/src/main/java/com/emotionstorage/my/ui/KeyDescriptionScreen.kt
+++ b/feat/my/src/main/java/com/emotionstorage/my/ui/KeyDescriptionScreen.kt
@@ -141,7 +141,9 @@ fun StatelessKeyDescriptionScreen(navToBack: () -> Unit = {}) {
             }
         }
         if (showWhenToUseDialog) {
-            WhenToUseKeyDialog { showWhenToUseDialog = false }
+            WhenToUseKeyDialog(
+                modifier = Modifier.padding(horizontal = 16.dp)
+            ) { showWhenToUseDialog = false }
         }
     }
 }

--- a/feat/my/src/main/java/com/emotionstorage/my/ui/KeyDescriptionScreen.kt
+++ b/feat/my/src/main/java/com/emotionstorage/my/ui/KeyDescriptionScreen.kt
@@ -142,7 +142,7 @@ fun StatelessKeyDescriptionScreen(navToBack: () -> Unit = {}) {
         }
         if (showWhenToUseDialog) {
             WhenToUseKeyDialog(
-                modifier = Modifier.padding(horizontal = 16.dp)
+                modifier = Modifier.padding(horizontal = 16.dp),
             ) { showWhenToUseDialog = false }
         }
     }

--- a/feat/my/src/main/java/com/emotionstorage/my/ui/NicknameChangeScreen.kt
+++ b/feat/my/src/main/java/com/emotionstorage/my/ui/NicknameChangeScreen.kt
@@ -1,5 +1,8 @@
 package com.emotionstorage.my.ui
 
+import androidx.compose.animation.core.Spring
+import androidx.compose.animation.core.animateDpAsState
+import androidx.compose.animation.core.spring
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -16,6 +19,7 @@ import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalDensity
@@ -119,6 +123,19 @@ private fun StatelessNicknameChangeScreen(
                     )
                 }
 
+                val animatedPadding by animateDpAsState(
+                    if (imeVisible) {
+                        24.dp
+                    } else {
+                        39.dp
+                    },
+                    label = "padding",
+                    animationSpec = spring(
+                        dampingRatio = Spring.DampingRatioNoBouncy,
+                        stiffness = Spring.StiffnessVeryLow,
+                    )
+                )
+
                 CtaButton(
                     modifier =
                         Modifier
@@ -127,7 +144,7 @@ private fun StatelessNicknameChangeScreen(
                             .navigationBarsPadding()
                             .imePadding()
                             .padding(
-                                bottom = if (imeVisible) 24.dp else 40.dp,
+                                bottom = animatedPadding
                             ),
                     labelString = "변경하기",
                     isDefaultWidth = false,

--- a/feat/my/src/main/java/com/emotionstorage/my/ui/NicknameChangeScreen.kt
+++ b/feat/my/src/main/java/com/emotionstorage/my/ui/NicknameChangeScreen.kt
@@ -130,10 +130,11 @@ private fun StatelessNicknameChangeScreen(
                         39.dp
                     },
                     label = "padding",
-                    animationSpec = spring(
-                        dampingRatio = Spring.DampingRatioNoBouncy,
-                        stiffness = Spring.StiffnessVeryLow,
-                    )
+                    animationSpec =
+                        spring(
+                            dampingRatio = Spring.DampingRatioNoBouncy,
+                            stiffness = Spring.StiffnessVeryLow,
+                        ),
                 )
 
                 CtaButton(
@@ -144,7 +145,7 @@ private fun StatelessNicknameChangeScreen(
                             .navigationBarsPadding()
                             .imePadding()
                             .padding(
-                                bottom = animatedPadding
+                                bottom = animatedPadding,
                             ),
                     labelString = "변경하기",
                     isDefaultWidth = false,

--- a/feat/my/src/main/java/com/emotionstorage/my/ui/component/WhenToUseKeyDialog.kt
+++ b/feat/my/src/main/java/com/emotionstorage/my/ui/component/WhenToUseKeyDialog.kt
@@ -34,7 +34,10 @@ import com.emotionstorage.ui.R
 import com.emotionstorage.ui.theme.MooiTheme
 
 @Composable
-fun WhenToUseKeyDialog(onDismiss: () -> Unit) {
+fun WhenToUseKeyDialog(
+    modifier : Modifier = Modifier,
+    onDismiss: () -> Unit
+) {
     Dialog(
         onDismissRequest = onDismiss,
         properties = DialogProperties(usePlatformDefaultWidth = false),
@@ -45,8 +48,7 @@ fun WhenToUseKeyDialog(onDismiss: () -> Unit) {
             shadowElevation = 12.dp,
             color = MooiTheme.colorScheme.background,
             modifier =
-                Modifier
-                    .padding(16.dp)
+                modifier
                     .widthIn(328.dp)
                     .heightIn(451.dp),
         ) {
@@ -58,7 +60,7 @@ fun WhenToUseKeyDialog(onDismiss: () -> Unit) {
                     modifier =
                         Modifier
                             .fillMaxWidth()
-                            .padding(horizontal = 20.dp, vertical = 16.dp),
+                            .padding(top = 17.dp, start = 20.dp, end = 20.dp),
                     horizontalAlignment = Alignment.CenterHorizontally,
                 ) {
                     Box(
@@ -94,13 +96,14 @@ fun WhenToUseKeyDialog(onDismiss: () -> Unit) {
                     Spacer(modifier = Modifier.size(6.dp))
 
                     Text(
+                        modifier = Modifier.fillMaxWidth(),
                         text = "열쇠는 이럴 때 쓰면 좋아요!",
-                        style = MooiTheme.typography.head2,
+                        style = MooiTheme.typography.head2.copy(lineHeight = 30.sp),
                         color = MooiTheme.colorScheme.primary,
                         textAlign = TextAlign.Center,
                     )
 
-                    Spacer(Modifier.size(8.dp))
+                    Spacer(Modifier.size(19.dp))
 
                     // TODO : 이모지 확인 필요
                     TipItem(
@@ -110,6 +113,9 @@ fun WhenToUseKeyDialog(onDismiss: () -> Unit) {
                         reverse = false,
                         content = "감정이 벅차오를 땐, 과거의 나 또는\n모이의 말이 위로가 될 수 있어요.",
                     )
+
+                    Spacer(modifier = Modifier.size(15.dp))
+
                     TipItem(
                         emoji = "\uD83E\uDD14",
                         title = "호기심 폭발! ",
@@ -117,6 +123,9 @@ fun WhenToUseKeyDialog(onDismiss: () -> Unit) {
                         reverse = false,
                         content = "어떤 감정을 적었는지 너무 궁금해서,\n하루도 기다리기 힘든 순간이 있죠.",
                     )
+
+                    Spacer(modifier = Modifier.size(15.dp))
+
                     TipItem(
                         emoji = "\uD83D\uDC91",
                         title = "이 달라졌을 때",
@@ -124,6 +133,9 @@ fun WhenToUseKeyDialog(onDismiss: () -> Unit) {
                         reverse = true,
                         content = "상황이 바뀌면, 과거의 내가 남긴\n감정을 다시 꺼내보고 싶어져요.",
                     )
+
+                    Spacer(modifier = Modifier.size(15.dp))
+
                     TipItem(
                         emoji = "\uD83D\uDD51",
                         title = "를 비교하고 싶을 때",
@@ -146,7 +158,7 @@ private fun TipItem(
     content: String,
 ) {
     Row(
-        modifier = Modifier.padding(vertical = 10.dp),
+        modifier = Modifier.padding(horizontal = 5.dp)
     ) {
         Text(
             text = emoji,
@@ -207,7 +219,7 @@ private fun TipItem(
                 )
             }
 
-            Spacer(modifier = Modifier.size(6.dp))
+            Spacer(modifier = Modifier.size(5.dp))
 
             Text(
                 text = content,

--- a/feat/my/src/main/java/com/emotionstorage/my/ui/component/WhenToUseKeyDialog.kt
+++ b/feat/my/src/main/java/com/emotionstorage/my/ui/component/WhenToUseKeyDialog.kt
@@ -35,8 +35,8 @@ import com.emotionstorage.ui.theme.MooiTheme
 
 @Composable
 fun WhenToUseKeyDialog(
-    modifier : Modifier = Modifier,
-    onDismiss: () -> Unit
+    modifier: Modifier = Modifier,
+    onDismiss: () -> Unit,
 ) {
     Dialog(
         onDismissRequest = onDismiss,
@@ -158,7 +158,7 @@ private fun TipItem(
     content: String,
 ) {
     Row(
-        modifier = Modifier.padding(horizontal = 5.dp)
+        modifier = Modifier.padding(horizontal = 5.dp),
     ) {
         Text(
             text = emoji,

--- a/feat/time-capsule-detail/src/main/java/com/emotionstorage/time_capsule_detail/ui/TimeCapsuleDetailScreen.kt
+++ b/feat/time-capsule-detail/src/main/java/com/emotionstorage/time_capsule_detail/ui/TimeCapsuleDetailScreen.kt
@@ -2,9 +2,11 @@ package com.emotionstorage.time_capsule_detail.ui
 
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.Scaffold
@@ -310,10 +312,11 @@ private fun StatelessTimeCapsuleDetailScreen(
                         .fillMaxSize()
                         .background(MooiTheme.colorScheme.background)
                         .padding(innerPadding)
-                        .padding(top = 31.dp)
                         .padding(horizontal = 16.dp)
                         .verticalScroll(scrollState),
             ) {
+                Spacer(modifier = Modifier.size(31.dp))
+
                 TimeCapsuleSummary(
                     title = state.timeCapsule.title,
                     summary = state.timeCapsule.summary,

--- a/feat/tutorial/src/main/java/com/emotionstorage/tutorial/ui/onBoarding/NicknameScreen.kt
+++ b/feat/tutorial/src/main/java/com/emotionstorage/tutorial/ui/onBoarding/NicknameScreen.kt
@@ -1,16 +1,12 @@
 package com.emotionstorage.tutorial.ui.onBoarding
 
-import android.view.animation.DecelerateInterpolator
-import androidx.compose.animation.core.FastOutSlowInEasing
 import androidx.compose.animation.core.Spring
 import androidx.compose.animation.core.animateDpAsState
 import androidx.compose.animation.core.spring
-import androidx.compose.animation.core.tween
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.WindowInsets
-import androidx.compose.foundation.layout.asPaddingValues
 import androidx.compose.foundation.layout.consumeWindowInsets
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
@@ -21,7 +17,6 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.Scaffold
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
-import androidx.compose.runtime.derivedStateOf
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
@@ -154,10 +149,11 @@ private fun StatelessNicknameScreen(
                         39.dp
                     },
                     label = "padding",
-                    animationSpec = spring(
-                        dampingRatio = Spring.DampingRatioNoBouncy,
-                        stiffness = Spring.StiffnessVeryLow,
-                    )
+                    animationSpec =
+                        spring(
+                            dampingRatio = Spring.DampingRatioNoBouncy,
+                            stiffness = Spring.StiffnessVeryLow,
+                        ),
                 )
 
                 CtaButton(

--- a/feat/tutorial/src/main/java/com/emotionstorage/tutorial/ui/onBoarding/NicknameScreen.kt
+++ b/feat/tutorial/src/main/java/com/emotionstorage/tutorial/ui/onBoarding/NicknameScreen.kt
@@ -130,6 +130,7 @@ private fun StatelessNicknameScreen(
                         onValueChange = event::onNicknameChange,
                         showCharCount = true,
                         maxCharCount = 8,
+                        placeHolder = "최소 2글자 이상의 이름을 적어주세요",
                         state =
                             when (state.nicknameInputState) {
                                 InputState.EMPTY -> TextInputState.Empty(infoMessage = state.nicknameHelperMessage)

--- a/feat/tutorial/src/main/java/com/emotionstorage/tutorial/ui/onBoarding/NicknameScreen.kt
+++ b/feat/tutorial/src/main/java/com/emotionstorage/tutorial/ui/onBoarding/NicknameScreen.kt
@@ -1,10 +1,16 @@
 package com.emotionstorage.tutorial.ui.onBoarding
 
+import android.view.animation.DecelerateInterpolator
+import androidx.compose.animation.core.FastOutSlowInEasing
+import androidx.compose.animation.core.Spring
 import androidx.compose.animation.core.animateDpAsState
+import androidx.compose.animation.core.spring
+import androidx.compose.animation.core.tween
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.WindowInsets
+import androidx.compose.foundation.layout.asPaddingValues
 import androidx.compose.foundation.layout.consumeWindowInsets
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
@@ -15,6 +21,7 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.Scaffold
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.derivedStateOf
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
@@ -147,7 +154,12 @@ private fun StatelessNicknameScreen(
                         39.dp
                     },
                     label = "padding",
+                    animationSpec = spring(
+                        dampingRatio = Spring.DampingRatioNoBouncy,
+                        stiffness = Spring.StiffnessVeryLow,
+                    )
                 )
+
                 CtaButton(
                     modifier =
                         Modifier


### PR DESCRIPTION
## Related Issue
- Issue #99

## 작업 상세 내용
- 온보딩 과정 닉네임 설정 화면 TextInput PlaceHolder 추가
- 닉네임 설정/수정 시 Button Padding 차이에 따라 Button이 움직이는 애니메이션 수정
- 타임 캡슐 상세 화면에 스크롤 되는 영역 상단의 Top padding 제거
- 이모지 연결 Line Offset 수정
- 채팅 화면 TextInputBox에  Border 추가
- 마이페이지 열쇠 설명 Dialog 내 자간 수정 및 내부 위치 조정

💡 마이페이지 Bottom Sheet는 Navigation bar 추가 여부에 따라 수정이 필요할 것 같아 roll back 해뒀습니다.
+ TopAppbar 와 statusbar 사이 추가 공간 작업 필요


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **새 기능**
  * 화면 키보드 표시 시 부드러운 애니메이션 적용(패딩 애니메이션)

* **스타일**
  * 이름 입력 필드에 플레이스홀더 텍스트 추가
  * 대화 입력창의 테두리 및 내부 배경 스타일 변경(캡슐형 입력 스타일 개선)
  * 다양한 화면에서 간격·정렬·타이포그래피 미세 조정

* **버그 수정**
  * 시간 선택 휠의 배경 레이어 제거로 렌더링 및 인터랙션 영역 정리
  * 로그 라인의 미세 위치 보정으로 시각 정렬 개선
<!-- end of auto-generated comment: release notes by coderabbit.ai -->