### PR TITLE
Fix/bug#107 즐겨찾기 해제 버그 고침 & 즐겨찾기 목록 다 찬 경우 처리

### DIFF
--- a/core/remote/src/main/java/com/emotionstorage/remote/dataSourceImpl/DailyReportRemoteDataSourceImpl.kt
+++ b/core/remote/src/main/java/com/emotionstorage/remote/dataSourceImpl/DailyReportRemoteDataSourceImpl.kt
@@ -23,7 +23,7 @@ class DailyReportRemoteDataSourceImpl @Inject constructor(
                 throw Exception("getDailyReport response data is empty, $response")
             }
         } catch (e: Exception) {
-            throw Exception("getDailyReport api fail, $e")
+            throw Exception("getDailyReport api fail", e)
         }
     }
 }

--- a/core/remote/src/main/java/com/emotionstorage/remote/dataSourceImpl/TimeCapsuleRemoteDataSourceImpl.kt
+++ b/core/remote/src/main/java/com/emotionstorage/remote/dataSourceImpl/TimeCapsuleRemoteDataSourceImpl.kt
@@ -24,7 +24,7 @@ class TimeCapsuleRemoteDataSourceImpl @Inject constructor(
             apiService.patchTimeCapsuleOpen(id)
             return true
         } catch (e: Exception) {
-            throw Exception("patchTimeCapsuleOpen api fail, $e")
+            throw Exception("patchTimeCapsuleOpen api fail", e)
         }
     }
 
@@ -39,7 +39,7 @@ class TimeCapsuleRemoteDataSourceImpl @Inject constructor(
             )
             return true
         } catch (e: Exception) {
-            throw Exception("patchTimeCapsuleNote api fail, $e")
+            throw Exception("patchTimeCapsuleNote api fail", e)
         }
     }
 
@@ -76,7 +76,7 @@ class TimeCapsuleRemoteDataSourceImpl @Inject constructor(
                 throw e
             }
         } catch (e: Exception) {
-            throw Exception("patchTimeCapsuleFavorite api fail, $e")
+            throw Exception("patchTimeCapsuleFavorite api fail", e)
         }
 
     override suspend fun getFavoriteTimeCapsules(
@@ -97,7 +97,7 @@ class TimeCapsuleRemoteDataSourceImpl @Inject constructor(
                 throw Exception("getFavoriteTimeCapsules response data is empty, $response")
             }
         } catch (e: Exception) {
-            throw Exception("getFavoriteTimeCapsules api fail, $e")
+            throw Exception("getFavoriteTimeCapsules api fail", e)
         }
     }
 
@@ -123,7 +123,7 @@ class TimeCapsuleRemoteDataSourceImpl @Inject constructor(
                 throw Exception("getTimeCapsules response data is empty, $response")
             }
         } catch (e: Exception) {
-            throw Exception("getTimeCapsules api fail, $e")
+            throw Exception("getTimeCapsules api fail", e)
         }
     }
 
@@ -136,7 +136,7 @@ class TimeCapsuleRemoteDataSourceImpl @Inject constructor(
                 throw Exception("getTimeCapsuleDetail response data is empty, $response")
             }
         } catch (e: Exception) {
-            throw Exception("getTimeCapsuleDetail api fail, $e")
+            throw Exception("getTimeCapsuleDetail api fail", e)
         }
     }
 
@@ -150,7 +150,7 @@ class TimeCapsuleRemoteDataSourceImpl @Inject constructor(
                 throw Exception("getTimeCapsuleDates response data is empty, $response")
             }
         } catch (e: Exception) {
-            throw Exception("getTimeCapsuleDates api fail, $e")
+            throw Exception("getTimeCapsuleDates api fail", e)
         }
     }
 
@@ -159,7 +159,7 @@ class TimeCapsuleRemoteDataSourceImpl @Inject constructor(
             apiService.deleteTimeCapsule(id)
             return true
         } catch (e: Exception) {
-            throw Exception("deleteTimeCapsule api fail, $e")
+            throw Exception("deleteTimeCapsule api fail", e)
         }
     }
 }

--- a/core/remote/src/main/java/com/emotionstorage/remote/dataSourceImpl/TimeCapsuleRemoteDataSourceImpl.kt
+++ b/core/remote/src/main/java/com/emotionstorage/remote/dataSourceImpl/TimeCapsuleRemoteDataSourceImpl.kt
@@ -7,6 +7,10 @@ import com.emotionstorage.remote.api.TimeCapsuleApiService
 import com.emotionstorage.remote.modelMapper.TimeCapsuleResponseMapper
 import com.emotionstorage.remote.request.timeCapsule.PatchTimeCapsuleFavoriteRequest
 import com.emotionstorage.remote.request.timeCapsule.PatchTimeCapsuleNoteRequest
+import com.emotionstorage.remote.response.ResponseDto
+import com.orhanobut.logger.Logger
+import kotlinx.serialization.json.Json
+import retrofit2.HttpException
 import java.time.LocalDate
 import java.time.YearMonth
 import java.time.format.DateTimeFormatter
@@ -42,24 +46,38 @@ class TimeCapsuleRemoteDataSourceImpl @Inject constructor(
     override suspend fun patchTimeCapsuleFavorite(
         id: Long,
         isFavorite: Boolean,
-    ): FavoriteResultEntity {
+    ): FavoriteResultEntity =
         try {
             val response =
                 apiService.patchTimeCapsuleFavorite(
                     id,
                     PatchTimeCapsuleFavoriteRequest(isFavorite),
                 )
-            return if (response.status == 400 && response.code == "TIME_CAPSULE_FAVORITE_LIMIT_EXCEEDED") {
-                FavoriteResultEntity.FULL
-            } else if (response.data != null) {
+            if (response.data != null) {
                 if (isFavorite) FavoriteResultEntity.ADDED else FavoriteResultEntity.REMOVED
             } else {
                 throw Exception("patchTimeCapsuleFavorite response data is empty, $response")
             }
+        } catch (e: HttpException) {
+            // parse error response body
+            val errorResponse = try {
+                e.response()?.errorBody()?.string()?.let {
+                    Json.decodeFromString<ResponseDto<Nothing>>(it)
+                }
+            } catch (parseError: Exception) {
+                Logger.e("patchTimeCapsuleFavorite error body parse fail: $parseError")
+                null
+            }
+
+            if (errorResponse?.code == "TIME_CAPSULE_FAVORITE_LIMIT_EXCEEDED") {
+                FavoriteResultEntity.FULL
+            } else {
+                throw e
+            }
         } catch (e: Exception) {
             throw Exception("patchTimeCapsuleFavorite api fail, $e")
         }
-    }
+
 
     override suspend fun getFavoriteTimeCapsules(
         page: Int,

--- a/core/remote/src/main/java/com/emotionstorage/remote/dataSourceImpl/TimeCapsuleRemoteDataSourceImpl.kt
+++ b/core/remote/src/main/java/com/emotionstorage/remote/dataSourceImpl/TimeCapsuleRemoteDataSourceImpl.kt
@@ -1,5 +1,6 @@
 package com.emotionstorage.remote.dataSourceImpl
 
+import com.emotionstorage.data.dataSource.FavoriteResultEntity
 import com.emotionstorage.data.dataSource.TimeCapsuleRemoteDataSource
 import com.emotionstorage.data.model.TimeCapsuleEntity
 import com.emotionstorage.remote.api.TimeCapsuleApiService
@@ -41,17 +42,17 @@ class TimeCapsuleRemoteDataSourceImpl @Inject constructor(
     override suspend fun patchTimeCapsuleFavorite(
         id: Long,
         isFavorite: Boolean,
-    ): Boolean {
+    ): FavoriteResultEntity {
         try {
             val response =
                 apiService.patchTimeCapsuleFavorite(
                     id,
                     PatchTimeCapsuleFavoriteRequest(isFavorite),
                 )
-
-            // todo: handle time capsule favorite fail - list is full
-            if (response.data != null) {
-                return response.data!!.isFavorite
+            return if (response.status == 400 && response.code == "TIME_CAPSULE_FAVORITE_LIMIT_EXCEEDED") {
+                FavoriteResultEntity.FULL
+            } else if (response.data != null) {
+                if (isFavorite) FavoriteResultEntity.ADDED else FavoriteResultEntity.REMOVED
             } else {
                 throw Exception("patchTimeCapsuleFavorite response data is empty, $response")
             }

--- a/core/remote/src/main/java/com/emotionstorage/remote/dataSourceImpl/TimeCapsuleRemoteDataSourceImpl.kt
+++ b/core/remote/src/main/java/com/emotionstorage/remote/dataSourceImpl/TimeCapsuleRemoteDataSourceImpl.kt
@@ -60,14 +60,15 @@ class TimeCapsuleRemoteDataSourceImpl @Inject constructor(
             }
         } catch (e: HttpException) {
             // parse error response body
-            val errorResponse = try {
-                e.response()?.errorBody()?.string()?.let {
-                    Json.decodeFromString<ResponseDto<Nothing>>(it)
+            val errorResponse =
+                try {
+                    e.response()?.errorBody()?.string()?.let {
+                        Json.decodeFromString<ResponseDto<Nothing>>(it)
+                    }
+                } catch (parseError: Exception) {
+                    Logger.e("patchTimeCapsuleFavorite error body parse fail: $parseError")
+                    null
                 }
-            } catch (parseError: Exception) {
-                Logger.e("patchTimeCapsuleFavorite error body parse fail: $parseError")
-                null
-            }
 
             if (errorResponse?.code == "TIME_CAPSULE_FAVORITE_LIMIT_EXCEEDED") {
                 FavoriteResultEntity.FULL
@@ -77,7 +78,6 @@ class TimeCapsuleRemoteDataSourceImpl @Inject constructor(
         } catch (e: Exception) {
             throw Exception("patchTimeCapsuleFavorite api fail, $e")
         }
-
 
     override suspend fun getFavoriteTimeCapsules(
         page: Int,

--- a/core/remote/src/main/java/com/emotionstorage/remote/di/RetrofitModule.kt
+++ b/core/remote/src/main/java/com/emotionstorage/remote/di/RetrofitModule.kt
@@ -9,8 +9,10 @@ import dagger.Provides
 import dagger.hilt.InstallIn
 import dagger.hilt.components.SingletonComponent
 import kotlinx.serialization.json.Json
+import okhttp3.Interceptor
 import okhttp3.MediaType.Companion.toMediaType
 import okhttp3.OkHttpClient
+import okhttp3.ResponseBody
 import okhttp3.logging.HttpLoggingInterceptor
 import retrofit2.Retrofit
 import java.util.concurrent.TimeUnit
@@ -32,29 +34,52 @@ object RetrofitModule {
     @Singleton
     @Provides
     fun provideRetrofit(
-        loggingInterceptor: HttpLoggingInterceptor,
         requestHeaderInterceptor: RequestHeaderInterceptor,
-    ) = Retrofit
-        .Builder()
-        .baseUrl(BASE_URL)
-        .addConverterFactory(json.asConverterFactory("application/json".toMediaType()))
-        .client(
-            OkHttpClient
-                .Builder()
-                .connectTimeout(TIMEOUT, TimeUnit.SECONDS)
-                .readTimeout(TIMEOUT, TimeUnit.SECONDS)
-                .writeTimeout(TIMEOUT, TimeUnit.SECONDS)
-                .addInterceptor(loggingInterceptor)
-                .addInterceptor(requestHeaderInterceptor)
-                .build(),
-        ).build()
+    ): Retrofit {
+        val cloneErrorBodyInterceptor = Interceptor { chain ->
+            val request = chain.request()
+            val response = chain.proceed(request)
 
-    @Singleton
-    @Provides
-    fun provideLoggingInterceptor() =
-        HttpLoggingInterceptor().apply {
+            if (response.isSuccessful) return@Interceptor response
+
+            // get error body
+            val sourceBody = response.body
+            if (sourceBody == null) {
+                return@Interceptor response
+            }
+
+            // clone error body stream to byte array input stream
+            val bytes = sourceBody.bytes()
+            val contentType = sourceBody.contentType()
+            val newResponseBody = bytes.inputStream().use {
+                ResponseBody.create(contentType, bytes)
+            }
+
+            response.newBuilder()
+                .body(newResponseBody)
+                .build()
+        }
+
+        val loggingInterceptor = HttpLoggingInterceptor().apply {
             level = HttpLoggingInterceptor.Level.BODY
         }
+
+        return Retrofit
+            .Builder()
+            .baseUrl(BASE_URL)
+            .addConverterFactory(json.asConverterFactory("application/json".toMediaType()))
+            .client(
+                OkHttpClient
+                    .Builder()
+                    .connectTimeout(TIMEOUT, TimeUnit.SECONDS)
+                    .readTimeout(TIMEOUT, TimeUnit.SECONDS)
+                    .writeTimeout(TIMEOUT, TimeUnit.SECONDS)
+                    .addInterceptor(requestHeaderInterceptor)
+                    .addInterceptor(cloneErrorBodyInterceptor)
+                    .addInterceptor(loggingInterceptor)
+                    .build(),
+            ).build()
+    }
 
     @Singleton
     @Provides

--- a/core/remote/src/main/java/com/emotionstorage/remote/di/RetrofitModule.kt
+++ b/core/remote/src/main/java/com/emotionstorage/remote/di/RetrofitModule.kt
@@ -63,7 +63,11 @@ object RetrofitModule {
 
         val loggingInterceptor =
             HttpLoggingInterceptor().apply {
-                level = HttpLoggingInterceptor.Level.BODY
+                level = if (BuildConfig.DEBUG) {
+                    HttpLoggingInterceptor.Level.BODY
+                } else {
+                    HttpLoggingInterceptor.Level.NONE
+                }
             }
 
         return Retrofit

--- a/core/remote/src/main/java/com/emotionstorage/remote/di/RetrofitModule.kt
+++ b/core/remote/src/main/java/com/emotionstorage/remote/di/RetrofitModule.kt
@@ -33,36 +33,38 @@ object RetrofitModule {
 
     @Singleton
     @Provides
-    fun provideRetrofit(
-        requestHeaderInterceptor: RequestHeaderInterceptor,
-    ): Retrofit {
-        val cloneErrorBodyInterceptor = Interceptor { chain ->
-            val request = chain.request()
-            val response = chain.proceed(request)
+    fun provideRetrofit(requestHeaderInterceptor: RequestHeaderInterceptor): Retrofit {
+        val cloneErrorBodyInterceptor =
+            Interceptor { chain ->
+                val request = chain.request()
+                val response = chain.proceed(request)
 
-            if (response.isSuccessful) return@Interceptor response
+                if (response.isSuccessful) return@Interceptor response
 
-            // get error body
-            val sourceBody = response.body
-            if (sourceBody == null) {
-                return@Interceptor response
+                // get error body
+                val sourceBody = response.body
+                if (sourceBody == null) {
+                    return@Interceptor response
+                }
+
+                // clone error body stream to byte array input stream
+                val bytes = sourceBody.bytes()
+                val contentType = sourceBody.contentType()
+                val newResponseBody =
+                    bytes.inputStream().use {
+                        ResponseBody.create(contentType, bytes)
+                    }
+
+                response
+                    .newBuilder()
+                    .body(newResponseBody)
+                    .build()
             }
 
-            // clone error body stream to byte array input stream
-            val bytes = sourceBody.bytes()
-            val contentType = sourceBody.contentType()
-            val newResponseBody = bytes.inputStream().use {
-                ResponseBody.create(contentType, bytes)
+        val loggingInterceptor =
+            HttpLoggingInterceptor().apply {
+                level = HttpLoggingInterceptor.Level.BODY
             }
-
-            response.newBuilder()
-                .body(newResponseBody)
-                .build()
-        }
-
-        val loggingInterceptor = HttpLoggingInterceptor().apply {
-            level = HttpLoggingInterceptor.Level.BODY
-        }
 
         return Retrofit
             .Builder()

--- a/core/remote/src/main/java/com/emotionstorage/remote/di/RetrofitModule.kt
+++ b/core/remote/src/main/java/com/emotionstorage/remote/di/RetrofitModule.kt
@@ -63,11 +63,12 @@ object RetrofitModule {
 
         val loggingInterceptor =
             HttpLoggingInterceptor().apply {
-                level = if (BuildConfig.DEBUG) {
-                    HttpLoggingInterceptor.Level.BODY
-                } else {
-                    HttpLoggingInterceptor.Level.NONE
-                }
+                level =
+                    if (BuildConfig.DEBUG) {
+                        HttpLoggingInterceptor.Level.BODY
+                    } else {
+                        HttpLoggingInterceptor.Level.NONE
+                    }
             }
 
         return Retrofit

--- a/core/remote/src/main/java/com/emotionstorage/remote/response/timeCapsule/PatchTimeCapsuleFavoriteResponse.kt
+++ b/core/remote/src/main/java/com/emotionstorage/remote/response/timeCapsule/PatchTimeCapsuleFavoriteResponse.kt
@@ -8,6 +8,6 @@ import java.time.LocalDateTime
 data class PatchTimeCapsuleFavoriteResponse(
     val isFavorite: Boolean,
     @Serializable(with = LocalDateTimeSerializer::class)
-    val favoriteAt: LocalDateTime,
+    val favoriteAt: LocalDateTime? = null,
     val favoritesCnt: Int,
 )

--- a/core/ui/src/main/java/com/emotionstorage/ui/component/FavoriteToast.kt
+++ b/core/ui/src/main/java/com/emotionstorage/ui/component/FavoriteToast.kt
@@ -27,16 +27,13 @@ fun FavoriteToast(favoriteResultVal: String) {
     if (favoriteResult != null) {
         Toast(
             message =
-                when (favoriteResult) {
-                    FavoriteResult.ADDED ->
-                        LocalContext.current.getString(R.string.toast_favorite_added)
-
-                    FavoriteResult.REMOVED ->
-                        LocalContext.current.getString(R.string.toast_favorite_removed)
-
-                    FavoriteResult.FULL ->
-                        LocalContext.current.getString(R.string.toast_favorite_full)
-                },
+                LocalContext.current.getString(
+                    when (favoriteResult) {
+                        FavoriteResult.ADDED -> R.string.toast_favorite_added
+                        FavoriteResult.REMOVED -> R.string.toast_favorite_removed
+                        FavoriteResult.FULL -> R.string.toast_favorite_full
+                    },
+                ),
             iconId =
                 if (favoriteResult != FavoriteResult.FULL) {
                     R.drawable.success_filled

--- a/core/ui/src/main/java/com/emotionstorage/ui/component/FavoriteToast.kt
+++ b/core/ui/src/main/java/com/emotionstorage/ui/component/FavoriteToast.kt
@@ -1,0 +1,69 @@
+package com.emotionstorage.ui.component
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.padding
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import com.emotionstorage.domain.repo.FavoriteResult
+import com.emotionstorage.ui.R
+import com.emotionstorage.ui.theme.MooiTheme
+import com.orhanobut.logger.Logger
+
+@Composable
+fun FavoriteToast(favoriteResultVal: String) {
+    var favoriteResult: FavoriteResult? = null
+    try{
+        favoriteResult = FavoriteResult.valueOf(favoriteResultVal)
+    }catch (e: IllegalArgumentException){
+        Logger.e("Invalid favorite result: $favoriteResultVal")
+    }
+
+    if(favoriteResult != null) {
+        Toast(
+            message = when (favoriteResult) {
+                FavoriteResult.ADDED ->
+                    LocalContext.current.getString(R.string.toast_favorite_added)
+
+                FavoriteResult.REMOVED ->
+                    LocalContext.current.getString(R.string.toast_favorite_removed)
+
+                FavoriteResult.FULL ->
+                    LocalContext.current.getString(R.string.toast_favorite_full)
+
+            },
+            iconId =
+                if (favoriteResult != FavoriteResult.FULL) {
+                    R.drawable.success_filled
+                } else {
+                    null
+                },
+        )
+    }
+}
+
+@Preview
+@Composable
+private fun FavoriteToastPreview() {
+    MooiTheme {
+        Column(
+            modifier =
+                Modifier
+                    .background(MooiTheme.colorScheme.background)
+                    .padding(10.dp),
+            verticalArrangement = Arrangement.spacedBy(16.dp, Alignment.CenterVertically),
+            horizontalAlignment = Alignment.CenterHorizontally,
+        ) {
+            FavoriteToast(FavoriteResult.ADDED.name)
+            FavoriteToast(FavoriteResult.FULL.name)
+            FavoriteToast("INVALID_VALUE")
+        }
+    }
+}
+
+

--- a/core/ui/src/main/java/com/emotionstorage/ui/component/FavoriteToast.kt
+++ b/core/ui/src/main/java/com/emotionstorage/ui/component/FavoriteToast.kt
@@ -18,25 +18,25 @@ import com.orhanobut.logger.Logger
 @Composable
 fun FavoriteToast(favoriteResultVal: String) {
     var favoriteResult: FavoriteResult? = null
-    try{
+    try {
         favoriteResult = FavoriteResult.valueOf(favoriteResultVal)
-    }catch (e: IllegalArgumentException){
+    } catch (e: IllegalArgumentException) {
         Logger.e("Invalid favorite result: $favoriteResultVal")
     }
 
-    if(favoriteResult != null) {
+    if (favoriteResult != null) {
         Toast(
-            message = when (favoriteResult) {
-                FavoriteResult.ADDED ->
-                    LocalContext.current.getString(R.string.toast_favorite_added)
+            message =
+                when (favoriteResult) {
+                    FavoriteResult.ADDED ->
+                        LocalContext.current.getString(R.string.toast_favorite_added)
 
-                FavoriteResult.REMOVED ->
-                    LocalContext.current.getString(R.string.toast_favorite_removed)
+                    FavoriteResult.REMOVED ->
+                        LocalContext.current.getString(R.string.toast_favorite_removed)
 
-                FavoriteResult.FULL ->
-                    LocalContext.current.getString(R.string.toast_favorite_full)
-
-            },
+                    FavoriteResult.FULL ->
+                        LocalContext.current.getString(R.string.toast_favorite_full)
+                },
             iconId =
                 if (favoriteResult != FavoriteResult.FULL) {
                     R.drawable.success_filled
@@ -65,5 +65,3 @@ private fun FavoriteToastPreview() {
         }
     }
 }
-
-

--- a/core/ui/src/main/java/com/emotionstorage/ui/component/Modal.kt
+++ b/core/ui/src/main/java/com/emotionstorage/ui/component/Modal.kt
@@ -24,6 +24,8 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import androidx.compose.ui.window.Dialog
 import androidx.compose.ui.window.DialogWindowProvider
+import com.emotionstorage.ui.component.button.CtaButton
+import com.emotionstorage.ui.component.button.CtaButtonType
 import com.emotionstorage.ui.theme.MooiTheme
 
 @Composable

--- a/core/ui/src/main/java/com/emotionstorage/ui/component/Toast.kt
+++ b/core/ui/src/main/java/com/emotionstorage/ui/component/Toast.kt
@@ -16,15 +16,11 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
-import com.emotionstorage.domain.repo.FavoriteResult
-import com.emotionstorage.ui.R
 import com.emotionstorage.ui.theme.MooiTheme
-import com.orhanobut.logger.Logger
 
 @Composable
 fun Toast(
@@ -39,8 +35,7 @@ fun Toast(
                 .background(
                     Color(0xFF0E0C12).copy(alpha = 0.8f),
                     RoundedCornerShape(100),
-                )
-                .padding(paddingValues),
+                ).padding(paddingValues),
         verticalAlignment = Alignment.CenterVertically,
         horizontalArrangement = Arrangement.Center,
     ) {

--- a/core/ui/src/main/java/com/emotionstorage/ui/component/Toast.kt
+++ b/core/ui/src/main/java/com/emotionstorage/ui/component/Toast.kt
@@ -21,8 +21,10 @@ import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
+import com.emotionstorage.domain.repo.FavoriteResult
 import com.emotionstorage.ui.R
 import com.emotionstorage.ui.theme.MooiTheme
+import com.orhanobut.logger.Logger
 
 @Composable
 fun Toast(
@@ -37,7 +39,8 @@ fun Toast(
                 .background(
                     Color(0xFF0E0C12).copy(alpha = 0.8f),
                     RoundedCornerShape(100),
-                ).padding(paddingValues),
+                )
+                .padding(paddingValues),
         verticalAlignment = Alignment.CenterVertically,
         horizontalArrangement = Arrangement.Center,
     ) {
@@ -59,21 +62,6 @@ fun Toast(
     }
 }
 
-@Composable
-fun FavoriteToast(message: String) {
-    Toast(
-        message = message,
-        iconId =
-            if (message !=
-                LocalContext.current.getString(R.string.toast_favorite_full)
-            ) {
-                R.drawable.success_filled
-            } else {
-                null
-            },
-    )
-}
-
 @Preview
 @Composable
 private fun ToastPreview() {
@@ -89,12 +77,6 @@ private fun ToastPreview() {
             Toast(
                 "아직 보관을 확정하지 않은 감정이에요.\n오늘을 기준으로 타임캡슐\n회고 날짜를 지정해주세요.",
                 paddingValues = PaddingValues(horizontal = 25.dp, vertical = 13.dp),
-            )
-            FavoriteToast(
-                LocalContext.current.getString(R.string.toast_favorite_added),
-            )
-            FavoriteToast(
-                LocalContext.current.getString(R.string.toast_favorite_full),
             )
         }
     }

--- a/core/ui/src/main/java/com/emotionstorage/ui/component/TopAppBar.kt
+++ b/core/ui/src/main/java/com/emotionstorage/ui/component/TopAppBar.kt
@@ -21,6 +21,7 @@ import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import com.emotionstorage.ui.R
+import com.emotionstorage.ui.component.button.RoundedToggleButton
 import com.emotionstorage.ui.theme.MooiTheme
 
 @Composable

--- a/core/ui/src/main/java/com/emotionstorage/ui/component/bottomSheet/BottomSheet.kt
+++ b/core/ui/src/main/java/com/emotionstorage/ui/component/bottomSheet/BottomSheet.kt
@@ -1,4 +1,4 @@
-package com.emotionstorage.ui.component
+package com.emotionstorage.ui.component.bottomSheet
 
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
@@ -29,6 +29,8 @@ import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import androidx.compose.ui.window.DialogWindowProvider
+import com.emotionstorage.ui.component.button.CtaButton
+import com.emotionstorage.ui.component.button.CtaButtonType
 import com.emotionstorage.ui.theme.MooiTheme
 import kotlinx.coroutines.launch
 

--- a/core/ui/src/main/java/com/emotionstorage/ui/component/bottomSheet/DatePickerBottomSheet.kt
+++ b/core/ui/src/main/java/com/emotionstorage/ui/component/bottomSheet/DatePickerBottomSheet.kt
@@ -186,7 +186,8 @@ fun DatePickerBottomSheet(
                                         .clickable(
                                             enabled = date.isAfter(minDate) && date.isBefore(maxDate),
                                             onClick = {
-                                                scope.launch { sheetState.hide() }
+                                                scope
+                                                    .launch { sheetState.hide() }
                                                     .invokeOnCompletion {
                                                         if (!sheetState.isVisible) {
                                                             onDateSelect(date)

--- a/core/ui/src/main/java/com/emotionstorage/ui/component/bottomSheet/DatePickerBottomSheet.kt
+++ b/core/ui/src/main/java/com/emotionstorage/ui/component/bottomSheet/DatePickerBottomSheet.kt
@@ -1,4 +1,4 @@
-package com.emotionstorage.ui.component
+package com.emotionstorage.ui.component.bottomSheet
 
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
@@ -186,11 +186,12 @@ fun DatePickerBottomSheet(
                                         .clickable(
                                             enabled = date.isAfter(minDate) && date.isBefore(maxDate),
                                             onClick = {
-                                                scope.launch { sheetState.hide() }.invokeOnCompletion {
-                                                    if (!sheetState.isVisible) {
-                                                        onDateSelect(date)
+                                                scope.launch { sheetState.hide() }
+                                                    .invokeOnCompletion {
+                                                        if (!sheetState.isVisible) {
+                                                            onDateSelect(date)
+                                                        }
                                                     }
-                                                }
                                             },
                                         ),
                             )

--- a/core/ui/src/main/java/com/emotionstorage/ui/component/bottomSheet/TimePickerBottomSheet.kt
+++ b/core/ui/src/main/java/com/emotionstorage/ui/component/bottomSheet/TimePickerBottomSheet.kt
@@ -1,4 +1,4 @@
-package com.emotionstorage.ui.component
+package com.emotionstorage.ui.component.bottomSheet
 
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.heightIn
@@ -14,6 +14,7 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
+import com.emotionstorage.ui.component.picker.TimeWheelSpinner
 import com.emotionstorage.ui.theme.MooiTheme
 import java.time.LocalTime
 

--- a/core/ui/src/main/java/com/emotionstorage/ui/component/bottomSheet/YearMonthPickerBottomSheet.kt
+++ b/core/ui/src/main/java/com/emotionstorage/ui/component/bottomSheet/YearMonthPickerBottomSheet.kt
@@ -1,4 +1,4 @@
-package com.emotionstorage.ui.component
+package com.emotionstorage.ui.component.bottomSheet
 
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Box
@@ -15,6 +15,7 @@ import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
+import com.emotionstorage.ui.component.picker.YearMonthWheelSpinner
 import com.emotionstorage.ui.theme.MooiTheme
 import com.orhanobut.logger.Logger
 import java.time.YearMonth

--- a/core/ui/src/main/java/com/emotionstorage/ui/component/button/CtaButton.kt
+++ b/core/ui/src/main/java/com/emotionstorage/ui/component/button/CtaButton.kt
@@ -1,4 +1,4 @@
-package com.emotionstorage.ui.component
+package com.emotionstorage.ui.component.button
 
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.border

--- a/core/ui/src/main/java/com/emotionstorage/ui/component/button/RoundedToggleButton.kt
+++ b/core/ui/src/main/java/com/emotionstorage/ui/component/button/RoundedToggleButton.kt
@@ -1,4 +1,4 @@
-package com.emotionstorage.ui.component
+package com.emotionstorage.ui.component.button
 
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.clickable

--- a/core/ui/src/main/java/com/emotionstorage/ui/component/button/ToggleButton.kt
+++ b/core/ui/src/main/java/com/emotionstorage/ui/component/button/ToggleButton.kt
@@ -1,4 +1,4 @@
-package com.emotionstorage.ui.component
+package com.emotionstorage.ui.component.button
 
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.clickable

--- a/core/ui/src/main/java/com/emotionstorage/ui/component/picker/DropDownPicker.kt
+++ b/core/ui/src/main/java/com/emotionstorage/ui/component/picker/DropDownPicker.kt
@@ -1,4 +1,4 @@
-package com.emotionstorage.ui.component
+package com.emotionstorage.ui.component.picker
 
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.background

--- a/core/ui/src/main/java/com/emotionstorage/ui/component/picker/ScrollPicker.kt
+++ b/core/ui/src/main/java/com/emotionstorage/ui/component/picker/ScrollPicker.kt
@@ -1,4 +1,4 @@
-package com.emotionstorage.ui.component
+package com.emotionstorage.ui.component.picker
 
 import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.animation.expandVertically

--- a/core/ui/src/main/java/com/emotionstorage/ui/component/picker/TimeWheelSpinner.kt
+++ b/core/ui/src/main/java/com/emotionstorage/ui/component/picker/TimeWheelSpinner.kt
@@ -1,4 +1,4 @@
-package com.emotionstorage.ui.component
+package com.emotionstorage.ui.component.picker
 
 import androidx.compose.animation.animateColorAsState
 import androidx.compose.foundation.background

--- a/core/ui/src/main/java/com/emotionstorage/ui/component/picker/WheelSpinner.kt
+++ b/core/ui/src/main/java/com/emotionstorage/ui/component/picker/WheelSpinner.kt
@@ -1,4 +1,4 @@
-package com.emotionstorage.ui.component
+package com.emotionstorage.ui.component.picker
 
 import androidx.compose.animation.animateColorAsState
 import androidx.compose.foundation.background

--- a/core/ui/src/main/java/com/emotionstorage/ui/component/picker/YearMonthWheelSpinner.kt
+++ b/core/ui/src/main/java/com/emotionstorage/ui/component/picker/YearMonthWheelSpinner.kt
@@ -1,4 +1,4 @@
-package com.emotionstorage.ui.component
+package com.emotionstorage.ui.component.picker
 
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement

--- a/core/ui/src/main/java/com/emotionstorage/ui/component/text/BulletListItem.kt
+++ b/core/ui/src/main/java/com/emotionstorage/ui/component/text/BulletListItem.kt
@@ -1,4 +1,4 @@
-package com.emotionstorage.ui.component
+package com.emotionstorage.ui.component.text
 
 import androidx.compose.foundation.Canvas
 import androidx.compose.foundation.layout.size

--- a/core/ui/src/main/java/com/emotionstorage/ui/component/text/HangingListItem.kt
+++ b/core/ui/src/main/java/com/emotionstorage/ui/component/text/HangingListItem.kt
@@ -1,4 +1,4 @@
-package com.emotionstorage.ui.component
+package com.emotionstorage.ui.component.text
 
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Row

--- a/core/ui/src/main/java/com/emotionstorage/ui/component/text/NumberedListItem.kt
+++ b/core/ui/src/main/java/com/emotionstorage/ui/component/text/NumberedListItem.kt
@@ -1,4 +1,4 @@
-package com.emotionstorage.ui.component
+package com.emotionstorage.ui.component.text
 
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable

--- a/core/ui/src/main/java/com/emotionstorage/ui/component/text/RichTextList.kt
+++ b/core/ui/src/main/java/com/emotionstorage/ui/component/text/RichTextList.kt
@@ -1,4 +1,4 @@
-package com.emotionstorage.ui.component
+package com.emotionstorage.ui.component.text
 
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
@@ -7,6 +7,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
+import com.emotionstorage.ui.content.ListStyle
 import com.emotionstorage.ui.theme.MooiTheme
 
 private const val WS = "[\\s\\u00A0]"

--- a/core/ui/src/main/java/com/emotionstorage/ui/component/text/TextBoxInput.kt
+++ b/core/ui/src/main/java/com/emotionstorage/ui/component/text/TextBoxInput.kt
@@ -1,4 +1,4 @@
-package com.emotionstorage.ui.component
+package com.emotionstorage.ui.component.text
 
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement

--- a/core/ui/src/main/java/com/emotionstorage/ui/component/text/TextInput.kt
+++ b/core/ui/src/main/java/com/emotionstorage/ui/component/text/TextInput.kt
@@ -1,4 +1,4 @@
-package com.emotionstorage.ui.component
+package com.emotionstorage.ui.component.text
 
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.background

--- a/core/ui/src/main/java/com/emotionstorage/ui/component/toast/AppSnackbarHost.kt
+++ b/core/ui/src/main/java/com/emotionstorage/ui/component/toast/AppSnackbarHost.kt
@@ -1,4 +1,4 @@
-package com.emotionstorage.ui.component
+package com.emotionstorage.ui.component.toast
 
 import android.view.Gravity
 import android.view.WindowManager
@@ -6,7 +6,6 @@ import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.navigationBars
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.width
 import androidx.compose.material3.SnackbarData
 import androidx.compose.material3.SnackbarHost
 import androidx.compose.material3.SnackbarHostState

--- a/core/ui/src/main/java/com/emotionstorage/ui/component/toast/FavoriteToast.kt
+++ b/core/ui/src/main/java/com/emotionstorage/ui/component/toast/FavoriteToast.kt
@@ -1,4 +1,4 @@
-package com.emotionstorage.ui.component
+package com.emotionstorage.ui.component.toast
 
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement

--- a/core/ui/src/main/java/com/emotionstorage/ui/component/toast/Toast.kt
+++ b/core/ui/src/main/java/com/emotionstorage/ui/component/toast/Toast.kt
@@ -1,4 +1,4 @@
-package com.emotionstorage.ui.component
+package com.emotionstorage.ui.component.toast
 
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.background

--- a/core/ui/src/main/java/com/emotionstorage/ui/content/MarketingUsageContent.kt
+++ b/core/ui/src/main/java/com/emotionstorage/ui/content/MarketingUsageContent.kt
@@ -1,4 +1,4 @@
-package com.emotionstorage.ui.component
+package com.emotionstorage.ui.content
 
 import android.annotation.SuppressLint
 import androidx.compose.foundation.background
@@ -7,19 +7,15 @@ import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.BoxWithConstraints
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.IntrinsicSize
-import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxHeight
-import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.heightIn
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
-import androidx.compose.foundation.lazy.LazyColumn
-import androidx.compose.foundation.lazy.itemsIndexed
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Text
@@ -36,87 +32,54 @@ import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.em
 import androidx.compose.ui.unit.sp
-import com.emotionstorage.ui.R
 import com.emotionstorage.ui.theme.MooiTheme
+import com.emotionstorage.ui.R
 
 @Composable
-fun PrivacyPolicyContent() {
+fun MarketingUsageContent() {
     val context = LocalContext.current
-    val titles = context.resources.getStringArray(R.array.privacy_titles)
-    val contents = context.resources.getStringArray(R.array.privacy_contents)
-    val tableHeaders = context.resources.getStringArray(R.array.privacy_table_headers).toList()
-    val tableRow1 = context.resources.getStringArray(R.array.privacy_table_1th_row).toList()
-    val tableRow2 = context.resources.getStringArray(R.array.privacy_table_2th_row).toList()
-    val tableRow3 = context.resources.getStringArray(R.array.privacy_table_3th_row).toList()
-    val rows = listOf(tableRow1, tableRow2, tableRow3)
+    val tableHeaders = context.resources.getStringArray(R.array.marketing_table_headers).toList()
+    val row1 = context.resources.getStringArray(R.array.marketing_table_1th_row).toList()
+    val row2 = context.resources.getStringArray(R.array.marketing_table_2th_row).toList()
+    val rows = listOf(row1, row2)
 
-    LazyColumn(
-        modifier =
-            Modifier
-                .fillMaxSize()
-                .padding(start = 16.dp, end = 16.dp, top = 9.dp, bottom = 25.dp),
-        contentPadding = PaddingValues(vertical = 18.dp),
+    Column(
+        modifier = Modifier.padding(start = 16.dp, end = 16.dp, top = 22.dp),
     ) {
-        item {
-            Text(
-                text = "MOOI 개인정보처리방침",
-                style = MooiTheme.typography.head1,
-                color = Color.White,
-            )
-            Spacer(modifier = Modifier.size(22.dp))
-        }
+        Text(
+            text = "MOOI 마케팅 활용 및 수신동의",
+            style = MooiTheme.typography.head1,
+            color = Color.White,
+        )
 
-        item {
-            Text(
-                text = stringResource(id = R.string.privacy_main),
-                style = MooiTheme.typography.caption1.copy(lineHeight = 22.sp),
-                color = Color.White,
-            )
-        }
+        Spacer(modifier = Modifier.size(22.dp))
 
-        item {
-            Spacer(modifier = Modifier.size(32.dp))
-            PrivacyPolicySection(
-                title = stringResource(id = R.string.first_privacy_title),
-                content = stringResource(id = R.string.first_privacy_content),
-            )
-        }
+        Text(
+            text = stringResource(R.string.marketing_main),
+            style = MooiTheme.typography.caption3.copy(lineHeight = 22.sp),
+            color = Color.White,
+        )
 
-        item {
-            Spacer(modifier = Modifier.size(18.dp))
-            PrivacyTable(
-                header = tableHeaders,
-                rows = rows,
-            )
-            Spacer(modifier = Modifier.size(30.dp))
-        }
+        Spacer(modifier = Modifier.size(32.dp))
 
-        itemsIndexed(titles) { index, title ->
-            PrivacyPolicySection(
-                title = title,
-                content = contents[index],
-            )
-
-            if (index < titles.size - 1) Spacer(modifier = Modifier.size(32.dp))
-        }
+        MarketingTable(tableHeaders, rows)
     }
 }
 
 @SuppressLint("UnusedBoxWithConstraintsScope")
 @Composable
-fun PrivacyTable(
+fun MarketingTable(
     header: List<String>,
     rows: List<List<String>>,
 ) {
     val baseTableW = 328f
-    val baseColDp = listOf(76.5f, 108f, 67f, 76.6f)
-    val baseRowDp = listOf(56f, 84f, 68f, 68f)
+    val baseColDp = listOf(84.5f, 53f, 51f, 84.5f, 55f)
+    val baseRowDp = listOf(56f, 100f, 116f)
 
     val weights = baseColDp.map { it / baseTableW }
 
     BoxWithConstraints(Modifier.fillMaxWidth()) {
         val tableW = maxWidth
-        // 화면 별 비율 측정
         val scale = tableW / baseTableW.dp
 
         val border = 1.dp
@@ -142,8 +105,6 @@ fun PrivacyTable(
             TableRow(items = rows[0], weights = weights, height = rowHeights[1])
             HorizontalDivider(color = MooiTheme.colorScheme.gray700, thickness = divider)
             TableRow(items = rows[1], weights = weights, height = rowHeights[2])
-            HorizontalDivider(color = MooiTheme.colorScheme.gray700, thickness = divider)
-            TableRow(items = rows[2], weights = weights, height = rowHeights[3])
         }
     }
 }
@@ -203,31 +164,10 @@ private fun TableRow(
     }
 }
 
-@Composable
-fun PrivacyPolicySection(
-    title: String,
-    content: String,
-) {
-    Column {
-        Text(
-            text = title,
-            style = MooiTheme.typography.caption1.copy(lineHeight = 22.sp),
-            color = Color.White,
-        )
-
-        Spacer(modifier = Modifier.size(8.dp))
-
-        RichBody(
-            text = content,
-            color = Color.White,
-        )
-    }
-}
-
 @Preview
 @Composable
-fun PrivacyPolicyContentPreview() {
+private fun MarketingUsageContentPreview() {
     MooiTheme {
-        PrivacyPolicyContent()
+        MarketingUsageContent()
     }
 }

--- a/core/ui/src/main/java/com/emotionstorage/ui/content/PrivacyPolicyContent.kt
+++ b/core/ui/src/main/java/com/emotionstorage/ui/content/PrivacyPolicyContent.kt
@@ -1,4 +1,4 @@
-package com.emotionstorage.ui.component
+package com.emotionstorage.ui.content
 
 import android.annotation.SuppressLint
 import androidx.compose.foundation.background
@@ -7,15 +7,19 @@ import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.BoxWithConstraints
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.IntrinsicSize
+import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxHeight
+import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.heightIn
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.itemsIndexed
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Text
@@ -32,54 +36,88 @@ import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.em
 import androidx.compose.ui.unit.sp
-import com.emotionstorage.ui.theme.MooiTheme
 import com.emotionstorage.ui.R
+import com.emotionstorage.ui.component.text.RichBody
+import com.emotionstorage.ui.theme.MooiTheme
 
 @Composable
-fun MarketingUsageContent() {
+fun PrivacyPolicyContent() {
     val context = LocalContext.current
-    val tableHeaders = context.resources.getStringArray(R.array.marketing_table_headers).toList()
-    val row1 = context.resources.getStringArray(R.array.marketing_table_1th_row).toList()
-    val row2 = context.resources.getStringArray(R.array.marketing_table_2th_row).toList()
-    val rows = listOf(row1, row2)
+    val titles = context.resources.getStringArray(R.array.privacy_titles)
+    val contents = context.resources.getStringArray(R.array.privacy_contents)
+    val tableHeaders = context.resources.getStringArray(R.array.privacy_table_headers).toList()
+    val tableRow1 = context.resources.getStringArray(R.array.privacy_table_1th_row).toList()
+    val tableRow2 = context.resources.getStringArray(R.array.privacy_table_2th_row).toList()
+    val tableRow3 = context.resources.getStringArray(R.array.privacy_table_3th_row).toList()
+    val rows = listOf(tableRow1, tableRow2, tableRow3)
 
-    Column(
-        modifier = Modifier.padding(start = 16.dp, end = 16.dp, top = 22.dp),
+    LazyColumn(
+        modifier =
+            Modifier
+                .fillMaxSize()
+                .padding(start = 16.dp, end = 16.dp, top = 9.dp, bottom = 25.dp),
+        contentPadding = PaddingValues(vertical = 18.dp),
     ) {
-        Text(
-            text = "MOOI 마케팅 활용 및 수신동의",
-            style = MooiTheme.typography.head1,
-            color = Color.White,
-        )
+        item {
+            Text(
+                text = "MOOI 개인정보처리방침",
+                style = MooiTheme.typography.head1,
+                color = Color.White,
+            )
+            Spacer(modifier = Modifier.size(22.dp))
+        }
 
-        Spacer(modifier = Modifier.size(22.dp))
+        item {
+            Text(
+                text = stringResource(id = R.string.privacy_main),
+                style = MooiTheme.typography.caption1.copy(lineHeight = 22.sp),
+                color = Color.White,
+            )
+        }
 
-        Text(
-            text = stringResource(R.string.marketing_main),
-            style = MooiTheme.typography.caption3.copy(lineHeight = 22.sp),
-            color = Color.White,
-        )
+        item {
+            Spacer(modifier = Modifier.size(32.dp))
+            PrivacyPolicySection(
+                title = stringResource(id = R.string.first_privacy_title),
+                content = stringResource(id = R.string.first_privacy_content),
+            )
+        }
 
-        Spacer(modifier = Modifier.size(32.dp))
+        item {
+            Spacer(modifier = Modifier.size(18.dp))
+            PrivacyTable(
+                header = tableHeaders,
+                rows = rows,
+            )
+            Spacer(modifier = Modifier.size(30.dp))
+        }
 
-        MarketingTable(tableHeaders, rows)
+        itemsIndexed(titles) { index, title ->
+            PrivacyPolicySection(
+                title = title,
+                content = contents[index],
+            )
+
+            if (index < titles.size - 1) Spacer(modifier = Modifier.size(32.dp))
+        }
     }
 }
 
 @SuppressLint("UnusedBoxWithConstraintsScope")
 @Composable
-fun MarketingTable(
+fun PrivacyTable(
     header: List<String>,
     rows: List<List<String>>,
 ) {
     val baseTableW = 328f
-    val baseColDp = listOf(84.5f, 53f, 51f, 84.5f, 55f)
-    val baseRowDp = listOf(56f, 100f, 116f)
+    val baseColDp = listOf(76.5f, 108f, 67f, 76.6f)
+    val baseRowDp = listOf(56f, 84f, 68f, 68f)
 
     val weights = baseColDp.map { it / baseTableW }
 
     BoxWithConstraints(Modifier.fillMaxWidth()) {
         val tableW = maxWidth
+        // 화면 별 비율 측정
         val scale = tableW / baseTableW.dp
 
         val border = 1.dp
@@ -105,6 +143,8 @@ fun MarketingTable(
             TableRow(items = rows[0], weights = weights, height = rowHeights[1])
             HorizontalDivider(color = MooiTheme.colorScheme.gray700, thickness = divider)
             TableRow(items = rows[1], weights = weights, height = rowHeights[2])
+            HorizontalDivider(color = MooiTheme.colorScheme.gray700, thickness = divider)
+            TableRow(items = rows[2], weights = weights, height = rowHeights[3])
         }
     }
 }
@@ -164,10 +204,31 @@ private fun TableRow(
     }
 }
 
+@Composable
+fun PrivacyPolicySection(
+    title: String,
+    content: String,
+) {
+    Column {
+        Text(
+            text = title,
+            style = MooiTheme.typography.caption1.copy(lineHeight = 22.sp),
+            color = Color.White,
+        )
+
+        Spacer(modifier = Modifier.size(8.dp))
+
+        RichBody(
+            text = content,
+            color = Color.White,
+        )
+    }
+}
+
 @Preview
 @Composable
-private fun MarketingUsageContentPreview() {
+fun PrivacyPolicyContentPreview() {
     MooiTheme {
-        MarketingUsageContent()
+        PrivacyPolicyContent()
     }
 }

--- a/core/ui/src/main/java/com/emotionstorage/ui/content/TermsOfServiceContent.kt
+++ b/core/ui/src/main/java/com/emotionstorage/ui/content/TermsOfServiceContent.kt
@@ -1,4 +1,4 @@
-package com.emotionstorage.ui.component
+package com.emotionstorage.ui.content
 
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Spacer
@@ -19,6 +19,8 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import com.emotionstorage.ui.theme.MooiTheme
 import com.emotionstorage.ui.R
+import com.emotionstorage.ui.component.text.RichBody
+import com.emotionstorage.ui.component.text.RichList
 
 enum class ListStyle { Bulleted, Numbered }
 

--- a/data/src/main/java/com/emotionstorage/data/dataSource/TimeCapsuleRemoteDataSource.kt
+++ b/data/src/main/java/com/emotionstorage/data/dataSource/TimeCapsuleRemoteDataSource.kt
@@ -38,7 +38,7 @@ interface TimeCapsuleRemoteDataSource {
     suspend fun deleteTimeCapsule(id: Long): Boolean
 }
 
-enum class FavoriteResultEntity{
+enum class FavoriteResultEntity  {
     ADDED,
     REMOVED,
     FULL,

--- a/data/src/main/java/com/emotionstorage/data/dataSource/TimeCapsuleRemoteDataSource.kt
+++ b/data/src/main/java/com/emotionstorage/data/dataSource/TimeCapsuleRemoteDataSource.kt
@@ -38,7 +38,7 @@ interface TimeCapsuleRemoteDataSource {
     suspend fun deleteTimeCapsule(id: Long): Boolean
 }
 
-enum class FavoriteResultEntity  {
+enum class FavoriteResultEntity {
     ADDED,
     REMOVED,
     FULL,

--- a/data/src/main/java/com/emotionstorage/data/dataSource/TimeCapsuleRemoteDataSource.kt
+++ b/data/src/main/java/com/emotionstorage/data/dataSource/TimeCapsuleRemoteDataSource.kt
@@ -15,7 +15,7 @@ interface TimeCapsuleRemoteDataSource {
     suspend fun patchTimeCapsuleFavorite(
         id: Long,
         isFavorite: Boolean,
-    ): Boolean
+    ): FavoriteResultEntity
 
     suspend fun getFavoriteTimeCapsules(
         page: Int,
@@ -36,4 +36,10 @@ interface TimeCapsuleRemoteDataSource {
     suspend fun getTimeCapsuleDates(yearMonth: YearMonth): List<LocalDate>
 
     suspend fun deleteTimeCapsule(id: Long): Boolean
+}
+
+enum class FavoriteResultEntity{
+    ADDED,
+    REMOVED,
+    FULL,
 }

--- a/data/src/main/java/com/emotionstorage/data/repoImpl/TimeCapsuleRepositoryImpl.kt
+++ b/data/src/main/java/com/emotionstorage/data/repoImpl/TimeCapsuleRepositoryImpl.kt
@@ -61,7 +61,7 @@ class TimeCapsuleRepositoryImpl @Inject constructor(
                             FavoriteResultEntity.ADDED -> FavoriteResult.ADDED
                             FavoriteResultEntity.REMOVED -> FavoriteResult.REMOVED
                             FavoriteResultEntity.FULL -> FavoriteResult.FULL
-                        }
+                        },
                     ),
                 )
             } catch (e: Exception) {

--- a/data/src/main/java/com/emotionstorage/data/repoImpl/TimeCapsuleRepositoryImpl.kt
+++ b/data/src/main/java/com/emotionstorage/data/repoImpl/TimeCapsuleRepositoryImpl.kt
@@ -1,11 +1,12 @@
 package com.emotionstorage.data.repoImpl
 
+import com.emotionstorage.data.dataSource.FavoriteResultEntity
 import com.emotionstorage.data.dataSource.TimeCapsuleRemoteDataSource
 import com.emotionstorage.data.modelMapper.TimeCapsuleMapper
 import com.emotionstorage.domain.common.DataState
 import com.emotionstorage.domain.model.TimeCapsule
 import com.emotionstorage.domain.repo.FavoriteSortBy
-import com.emotionstorage.domain.repo.SetFavoriteResult
+import com.emotionstorage.domain.repo.FavoriteResult
 import com.emotionstorage.domain.repo.TimeCapsuleRepository
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.flow
@@ -49,16 +50,18 @@ class TimeCapsuleRepositoryImpl @Inject constructor(
     override suspend fun setFavoriteTimeCapsule(
         id: Long,
         isFavorite: Boolean,
-    ): Flow<DataState<SetFavoriteResult>> =
+    ): Flow<DataState<FavoriteResult>> =
         flow {
             emit(DataState.Loading(isLoading = true))
             try {
                 val result = remoteDataSource.patchTimeCapsuleFavorite(id, isFavorite)
-
-                // todo: handle time capsule favorite failure - list is full
                 emit(
                     DataState.Success(
-                        if (result) SetFavoriteResult.ADDED else SetFavoriteResult.REMOVED,
+                        when (result) {
+                            FavoriteResultEntity.ADDED -> FavoriteResult.ADDED
+                            FavoriteResultEntity.REMOVED -> FavoriteResult.REMOVED
+                            FavoriteResultEntity.FULL -> FavoriteResult.FULL
+                        }
                     ),
                 )
             } catch (e: Exception) {

--- a/domain/src/main/java/com/emotionstorage/domain/repo/TimeCapsuleRepository.kt
+++ b/domain/src/main/java/com/emotionstorage/domain/repo/TimeCapsuleRepository.kt
@@ -17,7 +17,7 @@ interface TimeCapsuleRepository {
     suspend fun setFavoriteTimeCapsule(
         id: Long,
         isFavorite: Boolean,
-    ): Flow<DataState<SetFavoriteResult>>
+    ): Flow<DataState<FavoriteResult>>
 
     suspend fun getFavoriteTimeCapsules(sortBy: FavoriteSortBy): Flow<DataState<List<TimeCapsule>>>
 
@@ -35,7 +35,7 @@ interface TimeCapsuleRepository {
     suspend fun deleteTimeCapsule(id: Long): Flow<DataState<Boolean>>
 }
 
-enum class SetFavoriteResult {
+enum class FavoriteResult {
     ADDED,
     REMOVED,
     FULL,

--- a/domain/src/main/java/com/emotionstorage/domain/useCase/timeCapsule/SetFavoriteTimeCapsuleUseCase.kt
+++ b/domain/src/main/java/com/emotionstorage/domain/useCase/timeCapsule/SetFavoriteTimeCapsuleUseCase.kt
@@ -2,7 +2,7 @@ package com.emotionstorage.domain.useCase.timeCapsule
 
 import com.emotionstorage.domain.common.DataState
 import com.emotionstorage.domain.repo.TimeCapsuleRepository
-import com.emotionstorage.domain.repo.SetFavoriteResult
+import com.emotionstorage.domain.repo.FavoriteResult
 import kotlinx.coroutines.flow.Flow
 import javax.inject.Inject
 
@@ -12,5 +12,5 @@ class SetFavoriteTimeCapsuleUseCase @Inject constructor(
     suspend operator fun invoke(
         id: Long,
         isFavorite: Boolean,
-    ): Flow<DataState<SetFavoriteResult>> = timeCapsuleRepository.setFavoriteTimeCapsule(id, isFavorite)
+    ): Flow<DataState<FavoriteResult>> = timeCapsuleRepository.setFavoriteTimeCapsule(id, isFavorite)
 }

--- a/feat/auth/src/main/java/com/emotionstorage/auth/ui/SignupCompleteScreen.kt
+++ b/feat/auth/src/main/java/com/emotionstorage/auth/ui/SignupCompleteScreen.kt
@@ -28,7 +28,7 @@ import com.emotionstorage.auth.presentation.SignupCompleteAction
 import com.emotionstorage.auth.presentation.SignupCompleteSideEffect
 import com.emotionstorage.auth.presentation.SignupCompleteViewModel
 import com.emotionstorage.domain.model.User.AuthProvider
-import com.emotionstorage.ui.component.CtaButton
+import com.emotionstorage.ui.component.button.CtaButton
 import com.emotionstorage.ui.component.TopAppBar
 import com.emotionstorage.ui.theme.MooiTheme
 

--- a/feat/home/src/main/java/com/emotionstorage/home/ui/HomeScreen.kt
+++ b/feat/home/src/main/java/com/emotionstorage/home/ui/HomeScreen.kt
@@ -38,7 +38,7 @@ import com.emotionstorage.home.presentation.HomeSideEffect
 import com.emotionstorage.home.presentation.HomeState
 import com.emotionstorage.home.presentation.HomeViewModel
 import com.emotionstorage.ui.R
-import com.emotionstorage.ui.component.CtaButton
+import com.emotionstorage.ui.component.button.CtaButton
 import com.emotionstorage.ui.component.IconWithCount
 import com.emotionstorage.ui.theme.MooiTheme
 import com.orhanobut.logger.Logger

--- a/feat/my/src/main/java/com/emotionstorage/my/ui/NicknameChangeScreen.kt
+++ b/feat/my/src/main/java/com/emotionstorage/my/ui/NicknameChangeScreen.kt
@@ -32,10 +32,10 @@ import androidx.hilt.navigation.compose.hiltViewModel
 import com.emotionstorage.my.presentation.InputNicknameEvent
 import com.emotionstorage.my.presentation.NicknameChangeViewModel
 import com.emotionstorage.my.presentation.NicknameChangeViewModel.State.InputState
-import com.emotionstorage.ui.component.CtaButton
+import com.emotionstorage.ui.component.button.CtaButton
 import com.emotionstorage.ui.component.HideKeyboard
-import com.emotionstorage.ui.component.TextInput
-import com.emotionstorage.ui.component.TextInputState
+import com.emotionstorage.ui.component.text.TextInput
+import com.emotionstorage.ui.component.text.TextInputState
 import com.emotionstorage.ui.component.TopAppBar
 import com.emotionstorage.ui.theme.MooiTheme
 

--- a/feat/my/src/main/java/com/emotionstorage/my/ui/NotificationSettingScreen.kt
+++ b/feat/my/src/main/java/com/emotionstorage/my/ui/NotificationSettingScreen.kt
@@ -32,7 +32,7 @@ import com.emotionstorage.my.presentation.NotificationSettingViewModel
 import com.emotionstorage.my.ui.component.DayOfWeekSelector
 import com.emotionstorage.my.ui.component.ReminderTimeComponent
 import com.emotionstorage.my.ui.component.ToggleRow
-import com.emotionstorage.ui.component.TimePickerBottomSheet
+import com.emotionstorage.ui.component.bottomSheet.TimePickerBottomSheet
 import com.emotionstorage.ui.component.TopAppBar
 import com.emotionstorage.ui.theme.MooiTheme
 import java.time.DayOfWeek

--- a/feat/my/src/main/java/com/emotionstorage/my/ui/TermsAndPrivacyScreen.kt
+++ b/feat/my/src/main/java/com/emotionstorage/my/ui/TermsAndPrivacyScreen.kt
@@ -22,8 +22,8 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
-import com.emotionstorage.ui.component.PrivacyPolicyContent
-import com.emotionstorage.ui.component.TermsOfServiceContent
+import com.emotionstorage.ui.content.PrivacyPolicyContent
+import com.emotionstorage.ui.content.TermsOfServiceContent
 import com.emotionstorage.ui.component.TopAppBar
 import com.emotionstorage.ui.theme.MooiTheme
 

--- a/feat/my/src/main/java/com/emotionstorage/my/ui/component/WithDrawNoticeContent.kt
+++ b/feat/my/src/main/java/com/emotionstorage/my/ui/component/WithDrawNoticeContent.kt
@@ -29,8 +29,8 @@ import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
-import com.emotionstorage.ui.component.CtaButton
-import com.emotionstorage.ui.component.CtaButtonType
+import com.emotionstorage.ui.component.button.CtaButton
+import com.emotionstorage.ui.component.button.CtaButtonType
 import com.emotionstorage.ui.component.Modal
 import com.emotionstorage.ui.component.TopAppBar
 import com.emotionstorage.ui.theme.MooiTheme

--- a/feat/time-capsule-detail/src/main/java/com/emotionstorage/time_capsule_detail/presentation/TimeCapsuleDetailViewModel.kt
+++ b/feat/time-capsule-detail/src/main/java/com/emotionstorage/time_capsule_detail/presentation/TimeCapsuleDetailViewModel.kt
@@ -1,6 +1,5 @@
 package com.emotionstorage.time_capsule_detail.presentation
 
-import androidx.annotation.StringRes
 import androidx.lifecycle.ViewModel
 import com.emotionstorage.domain.common.collectDataState
 import com.emotionstorage.domain.model.TimeCapsule
@@ -30,7 +29,6 @@ import com.emotionstorage.time_capsule_detail.presentation.TimeCapsuleDetailSide
 import com.emotionstorage.time_capsule_detail.presentation.TimeCapsuleDetailSideEffect.ShowFavoriteToast
 import com.emotionstorage.time_capsule_detail.presentation.TimeCapsuleDetailSideEffect.ShowUnlockModal
 import com.emotionstorage.time_capsule_detail.presentation.TimeCapsuleDetailSideEffect.ShowUnlockModal.UnlockModalState
-import com.emotionstorage.ui.R
 import com.orhanobut.logger.Logger
 import dagger.hilt.android.lifecycle.HiltViewModel
 import org.orbitmvi.orbit.Container

--- a/feat/time-capsule-detail/src/main/java/com/emotionstorage/time_capsule_detail/presentation/TimeCapsuleDetailViewModel.kt
+++ b/feat/time-capsule-detail/src/main/java/com/emotionstorage/time_capsule_detail/presentation/TimeCapsuleDetailViewModel.kt
@@ -4,7 +4,7 @@ import androidx.annotation.StringRes
 import androidx.lifecycle.ViewModel
 import com.emotionstorage.domain.common.collectDataState
 import com.emotionstorage.domain.model.TimeCapsule
-import com.emotionstorage.domain.repo.SetFavoriteResult
+import com.emotionstorage.domain.repo.FavoriteResult
 import com.emotionstorage.domain.useCase.key.GetKeyCountUseCase
 import com.emotionstorage.domain.useCase.timeCapsule.GetTimeCapsuleByIdUseCase
 import com.emotionstorage.domain.useCase.timeCapsule.SetFavoriteTimeCapsuleUseCase
@@ -272,12 +272,12 @@ class TimeCapsuleDetailViewModel @Inject constructor(
             collectDataState(
                 flow = setFavorite(id, !state.timeCapsule!!.isFavorite),
                 onSuccess = {
-                    if (it == SetFavoriteResult.ADDED) {
+                    if (it == FavoriteResult.ADDED) {
                         postSideEffect(ShowToast(R.string.toast_favorite_added))
                         reduce {
                             state.copy(timeCapsule = state.timeCapsule?.copy(isFavorite = true))
                         }
-                    } else if (it == SetFavoriteResult.REMOVED) {
+                    } else if (it == FavoriteResult.REMOVED) {
                         postSideEffect(ShowToast(R.string.toast_favorite_removed))
                         reduce {
                             state.copy(timeCapsule = state.timeCapsule?.copy(isFavorite = false))
@@ -285,7 +285,7 @@ class TimeCapsuleDetailViewModel @Inject constructor(
                     }
                 },
                 onError = { throwable, data ->
-                    if (data == SetFavoriteResult.FULL) {
+                    if (data == FavoriteResult.FULL) {
                         postSideEffect(ShowToast(R.string.toast_favorite_full))
                     }
                 },

--- a/feat/time-capsule-detail/src/main/java/com/emotionstorage/time_capsule_detail/presentation/TimeCapsuleDetailViewModel.kt
+++ b/feat/time-capsule-detail/src/main/java/com/emotionstorage/time_capsule_detail/presentation/TimeCapsuleDetailViewModel.kt
@@ -27,7 +27,7 @@ import com.emotionstorage.time_capsule_detail.presentation.TimeCapsuleDetailSide
 import com.emotionstorage.time_capsule_detail.presentation.TimeCapsuleDetailSideEffect.ShowExitModal
 import com.emotionstorage.time_capsule_detail.presentation.TimeCapsuleDetailSideEffect.ShowExpiredModal
 import com.emotionstorage.time_capsule_detail.presentation.TimeCapsuleDetailSideEffect.ShowSaveChangesModal
-import com.emotionstorage.time_capsule_detail.presentation.TimeCapsuleDetailSideEffect.ShowToast
+import com.emotionstorage.time_capsule_detail.presentation.TimeCapsuleDetailSideEffect.ShowFavoriteToast
 import com.emotionstorage.time_capsule_detail.presentation.TimeCapsuleDetailSideEffect.ShowUnlockModal
 import com.emotionstorage.time_capsule_detail.presentation.TimeCapsuleDetailSideEffect.ShowUnlockModal.UnlockModalState
 import com.emotionstorage.ui.R
@@ -105,8 +105,8 @@ sealed class TimeCapsuleDetailSideEffect {
 
     object ShowSaveChangesModal : TimeCapsuleDetailSideEffect()
 
-    data class ShowToast(
-        @StringRes val stringResId: Int,
+    data class ShowFavoriteToast(
+        val favoriteResult: FavoriteResult,
     ) : TimeCapsuleDetailSideEffect()
 }
 
@@ -272,22 +272,27 @@ class TimeCapsuleDetailViewModel @Inject constructor(
             collectDataState(
                 flow = setFavorite(id, !state.timeCapsule!!.isFavorite),
                 onSuccess = {
-                    if (it == FavoriteResult.ADDED) {
-                        postSideEffect(ShowToast(R.string.toast_favorite_added))
-                        reduce {
-                            state.copy(timeCapsule = state.timeCapsule?.copy(isFavorite = true))
+                    when (it) {
+                        FavoriteResult.ADDED -> {
+                            reduce {
+                                state.copy(timeCapsule = state.timeCapsule?.copy(isFavorite = true))
+                            }
                         }
-                    } else if (it == FavoriteResult.REMOVED) {
-                        postSideEffect(ShowToast(R.string.toast_favorite_removed))
-                        reduce {
-                            state.copy(timeCapsule = state.timeCapsule?.copy(isFavorite = false))
+
+                        FavoriteResult.REMOVED -> {
+                            reduce {
+                                state.copy(timeCapsule = state.timeCapsule?.copy(isFavorite = false))
+                            }
+                        }
+
+                        FavoriteResult.FULL -> {
+                            // do nothing
                         }
                     }
+                    postSideEffect(ShowFavoriteToast(it))
                 },
                 onError = { throwable, data ->
-                    if (data == FavoriteResult.FULL) {
-                        postSideEffect(ShowToast(R.string.toast_favorite_full))
-                    }
+                    Logger.e("setFavorite error: $throwable")
                 },
             )
         }

--- a/feat/time-capsule-detail/src/main/java/com/emotionstorage/time_capsule_detail/ui/SaveTimeCapsuleScreen.kt
+++ b/feat/time-capsule-detail/src/main/java/com/emotionstorage/time_capsule_detail/ui/SaveTimeCapsuleScreen.kt
@@ -24,10 +24,8 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
-import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
-import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
@@ -52,12 +50,12 @@ import com.emotionstorage.time_capsule_detail.ui.modal.CheckArriveDateModal
 import com.emotionstorage.time_capsule_detail.ui.modal.TimeCapsuleExpiredModal
 import com.emotionstorage.time_capsule_detail.ui.modal.TimeCapsuleSavedModal
 import com.emotionstorage.ui.R
-import com.emotionstorage.ui.component.AppSnackbarHost
-import com.emotionstorage.ui.component.DatePickerBottomSheet
+import com.emotionstorage.ui.component.toast.AppSnackbarHost
+import com.emotionstorage.ui.component.bottomSheet.DatePickerBottomSheet
 import com.emotionstorage.ui.component.FullLoadingScreen
-import com.emotionstorage.ui.component.Toast
+import com.emotionstorage.ui.component.toast.Toast
 import com.emotionstorage.ui.component.TopAppBar
-import com.emotionstorage.ui.component.YearMonthPickerBottomSheet
+import com.emotionstorage.ui.component.bottomSheet.YearMonthPickerBottomSheet
 import com.emotionstorage.ui.theme.MooiTheme
 import com.emotionstorage.ui.util.subBackground
 import java.time.LocalDate

--- a/feat/time-capsule-detail/src/main/java/com/emotionstorage/time_capsule_detail/ui/TimeCapsuleDetailScreen.kt
+++ b/feat/time-capsule-detail/src/main/java/com/emotionstorage/time_capsule_detail/ui/TimeCapsuleDetailScreen.kt
@@ -55,10 +55,10 @@ import com.emotionstorage.time_capsule_detail.ui.modal.DeleteTimeCapsuleModal
 import com.emotionstorage.time_capsule_detail.ui.modal.ExitTimeCapsuleModal
 import com.emotionstorage.time_capsule_detail.ui.modal.TimeCapsuleExpiredModal
 import com.emotionstorage.time_capsule_detail.ui.modal.TimeCapsuleUnlockModal
-import com.emotionstorage.ui.component.AppSnackbarHost
-import com.emotionstorage.ui.component.FavoriteToast
+import com.emotionstorage.ui.component.toast.AppSnackbarHost
+import com.emotionstorage.ui.component.toast.FavoriteToast
 import com.emotionstorage.ui.component.FullLoadingScreen
-import com.emotionstorage.ui.component.RoundedToggleButton
+import com.emotionstorage.ui.component.button.RoundedToggleButton
 import com.emotionstorage.ui.component.TopAppBar
 import com.emotionstorage.ui.theme.MooiTheme
 import java.time.LocalDateTime

--- a/feat/time-capsule-detail/src/main/java/com/emotionstorage/time_capsule_detail/ui/TimeCapsuleDetailScreen.kt
+++ b/feat/time-capsule-detail/src/main/java/com/emotionstorage/time_capsule_detail/ui/TimeCapsuleDetailScreen.kt
@@ -21,7 +21,6 @@ import androidx.compose.ui.draw.blur
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
-import androidx.core.content.ContextCompat.getString
 import androidx.hilt.navigation.compose.hiltViewModel
 import com.emotionstorage.domain.model.TimeCapsule
 import com.emotionstorage.time_capsule_detail.presentation.TimeCapsuleDetailState
@@ -42,7 +41,7 @@ import com.emotionstorage.time_capsule_detail.presentation.TimeCapsuleDetailSide
 import com.emotionstorage.time_capsule_detail.presentation.TimeCapsuleDetailSideEffect.ShowExitModal
 import com.emotionstorage.time_capsule_detail.presentation.TimeCapsuleDetailSideEffect.ShowExpiredModal
 import com.emotionstorage.time_capsule_detail.presentation.TimeCapsuleDetailSideEffect.ShowSaveChangesModal
-import com.emotionstorage.time_capsule_detail.presentation.TimeCapsuleDetailSideEffect.ShowToast
+import com.emotionstorage.time_capsule_detail.presentation.TimeCapsuleDetailSideEffect.ShowFavoriteToast
 import com.emotionstorage.time_capsule_detail.presentation.TimeCapsuleDetailSideEffect.ShowUnlockModal
 import com.emotionstorage.time_capsule_detail.presentation.TimeCapsuleDetailSideEffect.ShowUnlockModal.UnlockModalState
 import com.emotionstorage.time_capsule_detail.presentation.TimeCapsuleDetailViewModel
@@ -132,12 +131,10 @@ fun TimeCapsuleDetailScreen(
                     setSaveChangesModalOpen(true)
                 }
 
-                is ShowToast -> {
+                is ShowFavoriteToast -> {
                     // dismiss current snackbar if exists
                     snackState.currentSnackbarData?.dismiss()
-                    snackState.showSnackbar(
-                        context.getString(sideEffect.stringResId),
-                    )
+                    snackState.showSnackbar(sideEffect.favoriteResult.name)
                 }
             }
         }

--- a/feat/time-capsule-detail/src/main/java/com/emotionstorage/time_capsule_detail/ui/component/SaveTimeCapsuleButton.kt
+++ b/feat/time-capsule-detail/src/main/java/com/emotionstorage/time_capsule_detail/ui/component/SaveTimeCapsuleButton.kt
@@ -18,7 +18,7 @@ import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import com.emotionstorage.ui.component.CountDownTimer
-import com.emotionstorage.ui.component.CtaButton
+import com.emotionstorage.ui.component.button.CtaButton
 import com.emotionstorage.ui.theme.MooiTheme
 import java.time.LocalDateTime
 

--- a/feat/time-capsule-detail/src/main/java/com/emotionstorage/time_capsule_detail/ui/component/TimeCapsuleDetailActionButtons.kt
+++ b/feat/time-capsule-detail/src/main/java/com/emotionstorage/time_capsule_detail/ui/component/TimeCapsuleDetailActionButtons.kt
@@ -23,7 +23,7 @@ import androidx.compose.ui.unit.dp
 import com.emotionstorage.domain.model.TimeCapsule
 import com.emotionstorage.ui.R
 import com.emotionstorage.ui.component.CountDownTimer
-import com.emotionstorage.ui.component.CtaButton
+import com.emotionstorage.ui.component.button.CtaButton
 import com.emotionstorage.ui.theme.MooiTheme
 import java.time.LocalDateTime
 

--- a/feat/time-capsule-detail/src/main/java/com/emotionstorage/time_capsule_detail/ui/component/TimeCapsuleNote.kt
+++ b/feat/time-capsule-detail/src/main/java/com/emotionstorage/time_capsule_detail/ui/component/TimeCapsuleNote.kt
@@ -16,7 +16,7 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
-import com.emotionstorage.ui.component.TextBoxInput
+import com.emotionstorage.ui.component.text.TextBoxInput
 import com.emotionstorage.ui.theme.MooiTheme
 import com.orhanobut.logger.Logger
 import kotlinx.coroutines.Job

--- a/feat/time-capsule-detail/src/main/java/com/emotionstorage/time_capsule_detail/ui/modal/TimeCapsuleUnlockModal.kt
+++ b/feat/time-capsule-detail/src/main/java/com/emotionstorage/time_capsule_detail/ui/modal/TimeCapsuleUnlockModal.kt
@@ -25,7 +25,7 @@ import androidx.compose.ui.unit.dp
 import com.emotionstorage.common.getDaysBetween
 import com.emotionstorage.ui.R
 import com.emotionstorage.ui.component.CountDownTimer
-import com.emotionstorage.ui.component.CtaButton
+import com.emotionstorage.ui.component.button.CtaButton
 import com.emotionstorage.ui.component.Modal
 import com.emotionstorage.ui.theme.MooiTheme
 import java.time.LocalDate

--- a/feat/time-capsule/src/main/java/com/emotionstorage/time_capsule/presentation/ArrivedTimeCapsulesViewModel.kt
+++ b/feat/time-capsule/src/main/java/com/emotionstorage/time_capsule/presentation/ArrivedTimeCapsulesViewModel.kt
@@ -6,7 +6,7 @@ import com.emotionstorage.domain.common.collectDataState
 import com.emotionstorage.domain.repo.FavoriteResult
 import com.emotionstorage.domain.useCase.timeCapsule.GetArrivedTimeCapsulesUseCase
 import com.emotionstorage.domain.useCase.timeCapsule.SetFavoriteTimeCapsuleUseCase
-import com.emotionstorage.time_capsule.presentation.ArrivedTimeCapsulesSideEffect.ShowToast
+import com.emotionstorage.time_capsule.presentation.ArrivedTimeCapsulesSideEffect.ShowFavoriteToast
 import com.emotionstorage.time_capsule.ui.model.TimeCapsuleItemState
 import com.emotionstorage.time_capsule.ui.modelMapper.TimeCapsuleMapper
 import com.emotionstorage.ui.R
@@ -34,8 +34,8 @@ sealed class ArrivedTimeCapsulesAction {
 }
 
 sealed class ArrivedTimeCapsulesSideEffect {
-    data class ShowToast(
-        @StringRes val stringResId: Int,
+    data class ShowFavoriteToast(
+        val favoriteResult: FavoriteResult
     ) : ArrivedTimeCapsulesSideEffect()
 }
 
@@ -128,18 +128,21 @@ class ArrivedTimeCapsulesViewModel @Inject constructor(
                 collectDataState(
                     flow = setFavorite(id, newIsFavorite),
                     onSuccess = {
-                        if (it == FavoriteResult.ADDED) {
-                            postSideEffect(ShowToast(stringResId = R.string.toast_favorite_added))
-                            updateFavorite(id, true)
-                        } else if (it == FavoriteResult.REMOVED) {
-                            postSideEffect(ShowToast(stringResId = R.string.toast_favorite_removed))
-                            updateFavorite(id, false)
+                        when(it){
+                            FavoriteResult.ADDED -> {
+                                updateFavorite(id, true)
+                            }
+                            FavoriteResult.REMOVED -> {
+                                updateFavorite(id, false)
+                            }
+                            FavoriteResult.FULL -> {
+                                // do nothing
+                            }
                         }
+                        postSideEffect(ShowFavoriteToast(it))
                     },
                     onError = { throwable, data ->
-                        if (data == FavoriteResult.FULL) {
-                            postSideEffect(ShowToast(stringResId = R.string.toast_favorite_full))
-                        }
+                        Logger.e("Failed to toggle favorite, $throwable")
                     },
                 )
             }

--- a/feat/time-capsule/src/main/java/com/emotionstorage/time_capsule/presentation/ArrivedTimeCapsulesViewModel.kt
+++ b/feat/time-capsule/src/main/java/com/emotionstorage/time_capsule/presentation/ArrivedTimeCapsulesViewModel.kt
@@ -3,7 +3,7 @@ package com.emotionstorage.time_capsule.presentation
 import androidx.annotation.StringRes
 import androidx.lifecycle.ViewModel
 import com.emotionstorage.domain.common.collectDataState
-import com.emotionstorage.domain.repo.SetFavoriteResult
+import com.emotionstorage.domain.repo.FavoriteResult
 import com.emotionstorage.domain.useCase.timeCapsule.GetArrivedTimeCapsulesUseCase
 import com.emotionstorage.domain.useCase.timeCapsule.SetFavoriteTimeCapsuleUseCase
 import com.emotionstorage.time_capsule.presentation.ArrivedTimeCapsulesSideEffect.ShowToast
@@ -128,16 +128,16 @@ class ArrivedTimeCapsulesViewModel @Inject constructor(
                 collectDataState(
                     flow = setFavorite(id, newIsFavorite),
                     onSuccess = {
-                        if (it == SetFavoriteResult.ADDED) {
+                        if (it == FavoriteResult.ADDED) {
                             postSideEffect(ShowToast(stringResId = R.string.toast_favorite_added))
                             updateFavorite(id, true)
-                        } else if (it == SetFavoriteResult.REMOVED) {
+                        } else if (it == FavoriteResult.REMOVED) {
                             postSideEffect(ShowToast(stringResId = R.string.toast_favorite_removed))
                             updateFavorite(id, false)
                         }
                     },
                     onError = { throwable, data ->
-                        if (data == SetFavoriteResult.FULL) {
+                        if (data == FavoriteResult.FULL) {
                             postSideEffect(ShowToast(stringResId = R.string.toast_favorite_full))
                         }
                     },

--- a/feat/time-capsule/src/main/java/com/emotionstorage/time_capsule/presentation/ArrivedTimeCapsulesViewModel.kt
+++ b/feat/time-capsule/src/main/java/com/emotionstorage/time_capsule/presentation/ArrivedTimeCapsulesViewModel.kt
@@ -1,6 +1,5 @@
 package com.emotionstorage.time_capsule.presentation
 
-import androidx.annotation.StringRes
 import androidx.lifecycle.ViewModel
 import com.emotionstorage.domain.common.collectDataState
 import com.emotionstorage.domain.repo.FavoriteResult
@@ -9,7 +8,6 @@ import com.emotionstorage.domain.useCase.timeCapsule.SetFavoriteTimeCapsuleUseCa
 import com.emotionstorage.time_capsule.presentation.ArrivedTimeCapsulesSideEffect.ShowFavoriteToast
 import com.emotionstorage.time_capsule.ui.model.TimeCapsuleItemState
 import com.emotionstorage.time_capsule.ui.modelMapper.TimeCapsuleMapper
-import com.emotionstorage.ui.R
 import com.orhanobut.logger.Logger
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.coroutineScope
@@ -35,7 +33,7 @@ sealed class ArrivedTimeCapsulesAction {
 
 sealed class ArrivedTimeCapsulesSideEffect {
     data class ShowFavoriteToast(
-        val favoriteResult: FavoriteResult
+        val favoriteResult: FavoriteResult,
     ) : ArrivedTimeCapsulesSideEffect()
 }
 
@@ -128,7 +126,7 @@ class ArrivedTimeCapsulesViewModel @Inject constructor(
                 collectDataState(
                     flow = setFavorite(id, newIsFavorite),
                     onSuccess = {
-                        when(it){
+                        when (it) {
                             FavoriteResult.ADDED -> {
                                 updateFavorite(id, true)
                             }

--- a/feat/time-capsule/src/main/java/com/emotionstorage/time_capsule/presentation/ArrivedTimeCapsulesViewModel.kt
+++ b/feat/time-capsule/src/main/java/com/emotionstorage/time_capsule/presentation/ArrivedTimeCapsulesViewModel.kt
@@ -130,9 +130,11 @@ class ArrivedTimeCapsulesViewModel @Inject constructor(
                             FavoriteResult.ADDED -> {
                                 updateFavorite(id, true)
                             }
+
                             FavoriteResult.REMOVED -> {
                                 updateFavorite(id, false)
                             }
+
                             FavoriteResult.FULL -> {
                                 // do nothing
                             }

--- a/feat/time-capsule/src/main/java/com/emotionstorage/time_capsule/presentation/CalendarViewModel.kt
+++ b/feat/time-capsule/src/main/java/com/emotionstorage/time_capsule/presentation/CalendarViewModel.kt
@@ -4,7 +4,7 @@ import androidx.annotation.StringRes
 import androidx.lifecycle.ViewModel
 import com.emotionstorage.domain.useCase.chat.GetChatRoomIdUseCase
 import com.emotionstorage.domain.common.collectDataState
-import com.emotionstorage.domain.repo.SetFavoriteResult
+import com.emotionstorage.domain.repo.FavoriteResult
 import com.emotionstorage.domain.useCase.dailyReport.GetDailyReportOfDateUseCase
 import com.emotionstorage.domain.useCase.key.GetKeyCountUseCase
 import com.emotionstorage.domain.useCase.timeCapsule.GetTimeCapsuleDatesUseCase
@@ -290,16 +290,16 @@ class CalendarViewModel @Inject constructor(
                 collectDataState(
                     flow = setFavorite(id, newIsFavorite),
                     onSuccess = {
-                        if (it == SetFavoriteResult.ADDED) {
+                        if (it == FavoriteResult.ADDED) {
                             postSideEffect(ShowToast(R.string.toast_favorite_added))
                             updateFavorite(id, true)
-                        } else if (it == SetFavoriteResult.REMOVED) {
+                        } else if (it == FavoriteResult.REMOVED) {
                             postSideEffect(ShowToast(R.string.toast_favorite_removed))
                             updateFavorite(id, false)
                         }
                     },
                     onError = { throwable, data ->
-                        if (data == SetFavoriteResult.FULL) {
+                        if (data == FavoriteResult.FULL) {
                             postSideEffect(ShowToast(R.string.toast_favorite_full))
                         }
                     },

--- a/feat/time-capsule/src/main/java/com/emotionstorage/time_capsule/presentation/CalendarViewModel.kt
+++ b/feat/time-capsule/src/main/java/com/emotionstorage/time_capsule/presentation/CalendarViewModel.kt
@@ -10,7 +10,7 @@ import com.emotionstorage.domain.useCase.key.GetKeyCountUseCase
 import com.emotionstorage.domain.useCase.timeCapsule.GetTimeCapsuleDatesUseCase
 import com.emotionstorage.domain.useCase.timeCapsule.GetTimeCapsulesOfDateUseCase
 import com.emotionstorage.domain.useCase.timeCapsule.SetFavoriteTimeCapsuleUseCase
-import com.emotionstorage.time_capsule.presentation.CalendarSideEffect.ShowToast
+import com.emotionstorage.time_capsule.presentation.CalendarSideEffect.ShowFavoriteToast
 import com.emotionstorage.time_capsule.ui.model.TimeCapsuleItemState
 import com.emotionstorage.time_capsule.ui.modelMapper.TimeCapsuleMapper
 import com.emotionstorage.ui.R
@@ -66,8 +66,8 @@ sealed class CalendarAction {
 sealed class CalendarSideEffect {
     object ShowTimeCapsuleBottomSheet : CalendarSideEffect()
 
-    data class ShowToast(
-        @StringRes val stringResId: Int,
+    data class ShowFavoriteToast(
+        val favoriteResult: FavoriteResult
     ) : CalendarSideEffect()
 
     data class EnterCharRoomSuccess(
@@ -290,18 +290,23 @@ class CalendarViewModel @Inject constructor(
                 collectDataState(
                     flow = setFavorite(id, newIsFavorite),
                     onSuccess = {
-                        if (it == FavoriteResult.ADDED) {
-                            postSideEffect(ShowToast(R.string.toast_favorite_added))
-                            updateFavorite(id, true)
-                        } else if (it == FavoriteResult.REMOVED) {
-                            postSideEffect(ShowToast(R.string.toast_favorite_removed))
-                            updateFavorite(id, false)
+                        when (it) {
+                            FavoriteResult.ADDED -> {
+                                updateFavorite(id, true)
+                            }
+
+                            FavoriteResult.REMOVED -> {
+                                updateFavorite(id, false)
+                            }
+
+                            FavoriteResult.FULL -> {
+                                // do nothing
+                            }
                         }
+                        postSideEffect(ShowFavoriteToast(it))
                     },
                     onError = { throwable, data ->
-                        if (data == FavoriteResult.FULL) {
-                            postSideEffect(ShowToast(R.string.toast_favorite_full))
-                        }
+                        Logger.e("Failed to toggle favorite, $throwable")
                     },
                 )
             }

--- a/feat/time-capsule/src/main/java/com/emotionstorage/time_capsule/presentation/CalendarViewModel.kt
+++ b/feat/time-capsule/src/main/java/com/emotionstorage/time_capsule/presentation/CalendarViewModel.kt
@@ -1,6 +1,5 @@
 package com.emotionstorage.time_capsule.presentation
 
-import androidx.annotation.StringRes
 import androidx.lifecycle.ViewModel
 import com.emotionstorage.domain.useCase.chat.GetChatRoomIdUseCase
 import com.emotionstorage.domain.common.collectDataState
@@ -13,7 +12,6 @@ import com.emotionstorage.domain.useCase.timeCapsule.SetFavoriteTimeCapsuleUseCa
 import com.emotionstorage.time_capsule.presentation.CalendarSideEffect.ShowFavoriteToast
 import com.emotionstorage.time_capsule.ui.model.TimeCapsuleItemState
 import com.emotionstorage.time_capsule.ui.modelMapper.TimeCapsuleMapper
-import com.emotionstorage.ui.R
 import com.orhanobut.logger.Logger
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.coroutineScope
@@ -67,7 +65,7 @@ sealed class CalendarSideEffect {
     object ShowTimeCapsuleBottomSheet : CalendarSideEffect()
 
     data class ShowFavoriteToast(
-        val favoriteResult: FavoriteResult
+        val favoriteResult: FavoriteResult,
     ) : CalendarSideEffect()
 
     data class EnterCharRoomSuccess(

--- a/feat/time-capsule/src/main/java/com/emotionstorage/time_capsule/presentation/FavoriteTimeCapsulesViewModel.kt
+++ b/feat/time-capsule/src/main/java/com/emotionstorage/time_capsule/presentation/FavoriteTimeCapsulesViewModel.kt
@@ -1,6 +1,5 @@
 package com.emotionstorage.time_capsule.presentation
 
-import androidx.annotation.StringRes
 import androidx.lifecycle.ViewModel
 import com.emotionstorage.domain.common.collectDataState
 import com.emotionstorage.domain.repo.FavoriteSortBy
@@ -10,7 +9,6 @@ import com.emotionstorage.domain.useCase.timeCapsule.SetFavoriteTimeCapsuleUseCa
 import com.emotionstorage.time_capsule.presentation.FavoriteTimeCapsulesSideEffect.ShowFavoriteToast
 import com.emotionstorage.time_capsule.ui.model.TimeCapsuleItemState
 import com.emotionstorage.time_capsule.ui.modelMapper.TimeCapsuleMapper
-import com.emotionstorage.ui.R
 import com.orhanobut.logger.Logger
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.coroutineScope
@@ -37,9 +35,8 @@ sealed class FavoriteTimeCapsulesAction {
 
 sealed class FavoriteTimeCapsulesSideEffect {
     data class ShowFavoriteToast(
-        val favoriteResult: FavoriteResult
+        val favoriteResult: FavoriteResult,
     ) : FavoriteTimeCapsulesSideEffect()
-
 }
 
 @HiltViewModel

--- a/feat/time-capsule/src/main/java/com/emotionstorage/time_capsule/presentation/FavoriteTimeCapsulesViewModel.kt
+++ b/feat/time-capsule/src/main/java/com/emotionstorage/time_capsule/presentation/FavoriteTimeCapsulesViewModel.kt
@@ -4,7 +4,7 @@ import androidx.annotation.StringRes
 import androidx.lifecycle.ViewModel
 import com.emotionstorage.domain.common.collectDataState
 import com.emotionstorage.domain.repo.FavoriteSortBy
-import com.emotionstorage.domain.repo.SetFavoriteResult
+import com.emotionstorage.domain.repo.FavoriteResult
 import com.emotionstorage.domain.useCase.timeCapsule.GetFavoriteTimeCapsulesUseCase
 import com.emotionstorage.domain.useCase.timeCapsule.SetFavoriteTimeCapsuleUseCase
 import com.emotionstorage.time_capsule.presentation.FavoriteTimeCapsulesSideEffect.ShowToast
@@ -134,16 +134,18 @@ class FavoriteTimeCapsulesViewModel @Inject constructor(
                 collectDataState(
                     flow = setFavorite(id, newIsFavorite),
                     onSuccess = {
-                        if (it == SetFavoriteResult.ADDED) {
+                        if (it == FavoriteResult.ADDED) {
+                            Logger.v("Favorite added, id: $id")
                             postSideEffect(ShowToast(R.string.toast_favorite_added))
                             updateFavorite(id, true)
-                        } else if (it == SetFavoriteResult.REMOVED) {
+                        } else if (it == FavoriteResult.REMOVED) {
+                            Logger.v("Favorite removed, id: $id")
                             postSideEffect(ShowToast(R.string.toast_favorite_removed))
                             updateFavorite(id, false)
                         }
                     },
                     onError = { throwable, data ->
-                        if (data == SetFavoriteResult.FULL) {
+                        if (data == FavoriteResult.FULL) {
                             postSideEffect(ShowToast(R.string.toast_favorite_full))
                         }
                     },

--- a/feat/time-capsule/src/main/java/com/emotionstorage/time_capsule/presentation/FavoriteTimeCapsulesViewModel.kt
+++ b/feat/time-capsule/src/main/java/com/emotionstorage/time_capsule/presentation/FavoriteTimeCapsulesViewModel.kt
@@ -7,7 +7,7 @@ import com.emotionstorage.domain.repo.FavoriteSortBy
 import com.emotionstorage.domain.repo.FavoriteResult
 import com.emotionstorage.domain.useCase.timeCapsule.GetFavoriteTimeCapsulesUseCase
 import com.emotionstorage.domain.useCase.timeCapsule.SetFavoriteTimeCapsuleUseCase
-import com.emotionstorage.time_capsule.presentation.FavoriteTimeCapsulesSideEffect.ShowToast
+import com.emotionstorage.time_capsule.presentation.FavoriteTimeCapsulesSideEffect.ShowFavoriteToast
 import com.emotionstorage.time_capsule.ui.model.TimeCapsuleItemState
 import com.emotionstorage.time_capsule.ui.modelMapper.TimeCapsuleMapper
 import com.emotionstorage.ui.R
@@ -36,9 +36,10 @@ sealed class FavoriteTimeCapsulesAction {
 }
 
 sealed class FavoriteTimeCapsulesSideEffect {
-    data class ShowToast(
-        @StringRes val stringResId: Int,
+    data class ShowFavoriteToast(
+        val favoriteResult: FavoriteResult
     ) : FavoriteTimeCapsulesSideEffect()
+
 }
 
 @HiltViewModel
@@ -134,20 +135,23 @@ class FavoriteTimeCapsulesViewModel @Inject constructor(
                 collectDataState(
                     flow = setFavorite(id, newIsFavorite),
                     onSuccess = {
-                        if (it == FavoriteResult.ADDED) {
-                            Logger.v("Favorite added, id: $id")
-                            postSideEffect(ShowToast(R.string.toast_favorite_added))
-                            updateFavorite(id, true)
-                        } else if (it == FavoriteResult.REMOVED) {
-                            Logger.v("Favorite removed, id: $id")
-                            postSideEffect(ShowToast(R.string.toast_favorite_removed))
-                            updateFavorite(id, false)
+                        when (it) {
+                            FavoriteResult.ADDED -> {
+                                updateFavorite(id, true)
+                            }
+
+                            FavoriteResult.REMOVED -> {
+                                updateFavorite(id, false)
+                            }
+
+                            FavoriteResult.FULL -> {
+                                // do nothing
+                            }
                         }
+                        postSideEffect(ShowFavoriteToast(it))
                     },
                     onError = { throwable, data ->
-                        if (data == FavoriteResult.FULL) {
-                            postSideEffect(ShowToast(R.string.toast_favorite_full))
-                        }
+                        Logger.e("Failed to toggle favorite, $throwable")
                     },
                 )
             }

--- a/feat/time-capsule/src/main/java/com/emotionstorage/time_capsule/ui/ArrivedTimeCapsulesScreen.kt
+++ b/feat/time-capsule/src/main/java/com/emotionstorage/time_capsule/ui/ArrivedTimeCapsulesScreen.kt
@@ -36,8 +36,8 @@ import com.emotionstorage.time_capsule.presentation.ArrivedTimeCapsulesViewModel
 import com.emotionstorage.time_capsule.ui.component.TimeCapsuleItem
 import com.emotionstorage.time_capsule.ui.model.TimeCapsuleItemState
 import com.emotionstorage.ui.R
-import com.emotionstorage.ui.component.AppSnackbarHost
-import com.emotionstorage.ui.component.FavoriteToast
+import com.emotionstorage.ui.component.toast.AppSnackbarHost
+import com.emotionstorage.ui.component.toast.FavoriteToast
 import com.emotionstorage.ui.component.TopAppBar
 import com.emotionstorage.ui.theme.MooiTheme
 import java.time.LocalDateTime

--- a/feat/time-capsule/src/main/java/com/emotionstorage/time_capsule/ui/ArrivedTimeCapsulesScreen.kt
+++ b/feat/time-capsule/src/main/java/com/emotionstorage/time_capsule/ui/ArrivedTimeCapsulesScreen.kt
@@ -28,7 +28,6 @@ import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
-import androidx.core.content.ContextCompat.getString
 import androidx.hilt.navigation.compose.hiltViewModel
 import com.emotionstorage.domain.model.TimeCapsule
 import com.emotionstorage.time_capsule.presentation.ArrivedTimeCapsulesAction
@@ -59,9 +58,9 @@ fun ArrivedTimeCapsulesScreen(
 
         viewModel.container.sideEffectFlow.collect {
             when (it) {
-                is ArrivedTimeCapsulesSideEffect.ShowToast -> {
+                is ArrivedTimeCapsulesSideEffect.ShowFavoriteToast -> {
                     snackState.currentSnackbarData?.dismiss()
-                    snackState.showSnackbar(context.getString(it.stringResId))
+                    snackState.showSnackbar(it.favoriteResult.name)
                 }
             }
         }

--- a/feat/time-capsule/src/main/java/com/emotionstorage/time_capsule/ui/CalendarScreen.kt
+++ b/feat/time-capsule/src/main/java/com/emotionstorage/time_capsule/ui/CalendarScreen.kt
@@ -85,12 +85,12 @@ fun CalendarScreen(
                     setShowTimeCapsuleBottomSheet(true)
                 }
 
-                is CalendarSideEffect.ShowToast -> {
+                is CalendarSideEffect.ShowFavoriteToast -> {
                     // dismiss current snackbar if exists
                     snackState.currentSnackbarData?.dismiss()
                     // show new snackbar
                     snackState.showSnackbar(
-                        context.getString(sideEffect.stringResId),
+                        sideEffect.favoriteResult.name
                     )
                 }
 

--- a/feat/time-capsule/src/main/java/com/emotionstorage/time_capsule/ui/CalendarScreen.kt
+++ b/feat/time-capsule/src/main/java/com/emotionstorage/time_capsule/ui/CalendarScreen.kt
@@ -90,7 +90,7 @@ fun CalendarScreen(
                     snackState.currentSnackbarData?.dismiss()
                     // show new snackbar
                     snackState.showSnackbar(
-                        sideEffect.favoriteResult.name
+                        sideEffect.favoriteResult.name,
                     )
                 }
 

--- a/feat/time-capsule/src/main/java/com/emotionstorage/time_capsule/ui/CalendarScreen.kt
+++ b/feat/time-capsule/src/main/java/com/emotionstorage/time_capsule/ui/CalendarScreen.kt
@@ -43,12 +43,12 @@ import com.emotionstorage.time_capsule.presentation.CalendarAction
 import com.emotionstorage.time_capsule.presentation.CalendarSideEffect
 import com.emotionstorage.time_capsule.presentation.CalendarState
 import com.emotionstorage.time_capsule.presentation.CalendarViewModel
-import com.emotionstorage.ui.component.YearMonthPickerBottomSheet
+import com.emotionstorage.ui.component.bottomSheet.YearMonthPickerBottomSheet
 import com.emotionstorage.time_capsule.ui.component.TimeCapsuleCalendar
 import com.emotionstorage.time_capsule.ui.component.TimeCapsuleCalendarBottomSheet
 import com.emotionstorage.ui.R
-import com.emotionstorage.ui.component.AppSnackbarHost
-import com.emotionstorage.ui.component.FavoriteToast
+import com.emotionstorage.ui.component.toast.AppSnackbarHost
+import com.emotionstorage.ui.component.toast.FavoriteToast
 import com.emotionstorage.ui.component.IconWithCount
 import com.emotionstorage.ui.theme.MooiTheme
 import com.emotionstorage.ui.util.mainBackground

--- a/feat/time-capsule/src/main/java/com/emotionstorage/time_capsule/ui/FavoriteTimeCapsulesScreen.kt
+++ b/feat/time-capsule/src/main/java/com/emotionstorage/time_capsule/ui/FavoriteTimeCapsulesScreen.kt
@@ -33,9 +33,10 @@ import androidx.core.content.ContextCompat.getString
 import androidx.hilt.navigation.compose.hiltViewModel
 import com.emotionstorage.domain.model.TimeCapsule
 import com.emotionstorage.domain.model.TimeCapsule.Emotion
+import com.emotionstorage.domain.repo.FavoriteResult
 import com.emotionstorage.domain.repo.FavoriteSortBy
 import com.emotionstorage.time_capsule.presentation.FavoriteTimeCapsulesAction
-import com.emotionstorage.time_capsule.presentation.FavoriteTimeCapsulesSideEffect.ShowToast
+import com.emotionstorage.time_capsule.presentation.FavoriteTimeCapsulesSideEffect.ShowFavoriteToast
 import com.emotionstorage.time_capsule.presentation.FavoriteTimeCapsulesState
 import com.emotionstorage.time_capsule.presentation.FavoriteTimeCapsulesViewModel
 import com.emotionstorage.time_capsule.ui.component.TimeCapsuleItem
@@ -66,12 +67,12 @@ fun FavoriteTimeCapsulesScreen(
     LaunchedEffect(Unit) {
         viewModel.container.sideEffectFlow.collect { sideEffect ->
             when (sideEffect) {
-                is ShowToast -> {
+                is ShowFavoriteToast -> {
                     // dismiss current snackbar if exists
                     snackState.currentSnackbarData?.dismiss()
                     // show new snackbar
                     snackState.showSnackbar(
-                        context.getString(sideEffect.stringResId),
+                        sideEffect.favoriteResult.name
                     )
                 }
             }

--- a/feat/time-capsule/src/main/java/com/emotionstorage/time_capsule/ui/FavoriteTimeCapsulesScreen.kt
+++ b/feat/time-capsule/src/main/java/com/emotionstorage/time_capsule/ui/FavoriteTimeCapsulesScreen.kt
@@ -42,9 +42,9 @@ import com.emotionstorage.time_capsule.ui.model.TimeCapsuleItemState
 import com.emotionstorage.ui.component.TopAppBar
 import com.emotionstorage.ui.theme.MooiTheme
 import com.emotionstorage.ui.R
-import com.emotionstorage.ui.component.AppSnackbarHost
-import com.emotionstorage.ui.component.DropDownPicker
-import com.emotionstorage.ui.component.FavoriteToast
+import com.emotionstorage.ui.component.toast.AppSnackbarHost
+import com.emotionstorage.ui.component.picker.DropDownPicker
+import com.emotionstorage.ui.component.toast.FavoriteToast
 import java.time.LocalDateTime
 
 @Composable

--- a/feat/time-capsule/src/main/java/com/emotionstorage/time_capsule/ui/FavoriteTimeCapsulesScreen.kt
+++ b/feat/time-capsule/src/main/java/com/emotionstorage/time_capsule/ui/FavoriteTimeCapsulesScreen.kt
@@ -29,11 +29,9 @@ import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
-import androidx.core.content.ContextCompat.getString
 import androidx.hilt.navigation.compose.hiltViewModel
 import com.emotionstorage.domain.model.TimeCapsule
 import com.emotionstorage.domain.model.TimeCapsule.Emotion
-import com.emotionstorage.domain.repo.FavoriteResult
 import com.emotionstorage.domain.repo.FavoriteSortBy
 import com.emotionstorage.time_capsule.presentation.FavoriteTimeCapsulesAction
 import com.emotionstorage.time_capsule.presentation.FavoriteTimeCapsulesSideEffect.ShowFavoriteToast
@@ -72,7 +70,7 @@ fun FavoriteTimeCapsulesScreen(
                     snackState.currentSnackbarData?.dismiss()
                     // show new snackbar
                     snackState.showSnackbar(
-                        sideEffect.favoriteResult.name
+                        sideEffect.favoriteResult.name,
                     )
                 }
             }

--- a/feat/time-capsule/src/main/java/com/emotionstorage/time_capsule/ui/component/TimeCapsuleCalendarBottomSheet.kt
+++ b/feat/time-capsule/src/main/java/com/emotionstorage/time_capsule/ui/component/TimeCapsuleCalendarBottomSheet.kt
@@ -37,8 +37,8 @@ import com.emotionstorage.common.toKorDate
 import com.emotionstorage.domain.model.TimeCapsule
 import com.emotionstorage.domain.model.TimeCapsule.Status
 import com.emotionstorage.time_capsule.ui.model.TimeCapsuleItemState
-import com.emotionstorage.ui.component.BottomSheet
-import com.emotionstorage.ui.component.CtaButton
+import com.emotionstorage.ui.component.bottomSheet.BottomSheet
+import com.emotionstorage.ui.component.button.CtaButton
 import com.emotionstorage.ui.theme.MooiTheme
 import com.emotionstorage.ui.theme.pretendard
 import java.time.LocalDate

--- a/feat/time-capsule/src/main/java/com/emotionstorage/time_capsule/ui/component/TimeCapsuleItem.kt
+++ b/feat/time-capsule/src/main/java/com/emotionstorage/time_capsule/ui/component/TimeCapsuleItem.kt
@@ -40,7 +40,7 @@ import com.emotionstorage.domain.model.TimeCapsule.Emotion
 import com.emotionstorage.time_capsule.ui.model.TimeCapsuleItemState
 import com.emotionstorage.ui.R
 import com.emotionstorage.ui.component.CountDownTimer
-import com.emotionstorage.ui.component.RoundedToggleButton
+import com.emotionstorage.ui.component.button.RoundedToggleButton
 import com.emotionstorage.ui.theme.MooiTheme
 import com.emotionstorage.ui.util.LinearGradient
 import com.emotionstorage.ui.util.dropShadow

--- a/feat/tutorial/src/main/java/com/emotionstorage/tutorial/ui/onBoarding/AgreeTermsScreen.kt
+++ b/feat/tutorial/src/main/java/com/emotionstorage/tutorial/ui/onBoarding/AgreeTermsScreen.kt
@@ -33,8 +33,8 @@ import com.emotionstorage.tutorial.R
 import com.emotionstorage.tutorial.presentation.onBoarding.AgreeTermsEvent
 import com.emotionstorage.tutorial.presentation.onBoarding.AgreeTermsViewModel
 import com.emotionstorage.tutorial.presentation.onBoarding.AgreeTermsViewModel.State
-import com.emotionstorage.ui.component.CtaButton
-import com.emotionstorage.ui.component.ToggleButton
+import com.emotionstorage.ui.component.button.CtaButton
+import com.emotionstorage.ui.component.button.ToggleButton
 import com.emotionstorage.ui.component.TopAppBar
 import com.emotionstorage.ui.theme.MooiTheme
 import kotlinx.coroutines.launch

--- a/feat/tutorial/src/main/java/com/emotionstorage/tutorial/ui/onBoarding/ExpectationsScreen.kt
+++ b/feat/tutorial/src/main/java/com/emotionstorage/tutorial/ui/onBoarding/ExpectationsScreen.kt
@@ -33,7 +33,7 @@ import com.emotionstorage.tutorial.R
 import com.emotionstorage.tutorial.presentation.onBoarding.ExpectationsEvent
 import com.emotionstorage.tutorial.presentation.onBoarding.ExpectationsViewModel
 import com.emotionstorage.tutorial.presentation.onBoarding.ExpectationsViewModel.State
-import com.emotionstorage.ui.component.CtaButton
+import com.emotionstorage.ui.component.button.CtaButton
 import com.emotionstorage.ui.component.TopAppBar
 import com.emotionstorage.ui.theme.MooiTheme
 import com.emotionstorage.ui.util.subBackground

--- a/feat/tutorial/src/main/java/com/emotionstorage/tutorial/ui/onBoarding/GenderBirthScreen.kt
+++ b/feat/tutorial/src/main/java/com/emotionstorage/tutorial/ui/onBoarding/GenderBirthScreen.kt
@@ -29,8 +29,8 @@ import com.emotionstorage.tutorial.R
 import com.emotionstorage.tutorial.presentation.onBoarding.GenderBirthEvent
 import com.emotionstorage.tutorial.presentation.onBoarding.GenderBirthViewModel
 import com.emotionstorage.tutorial.presentation.onBoarding.GenderBirthViewModel.State
-import com.emotionstorage.ui.component.CtaButton
-import com.emotionstorage.ui.component.ScrollPicker
+import com.emotionstorage.ui.component.button.CtaButton
+import com.emotionstorage.ui.component.picker.ScrollPicker
 import com.emotionstorage.ui.component.TopAppBar
 import com.emotionstorage.ui.theme.MooiTheme
 import com.emotionstorage.ui.util.subBackground

--- a/feat/tutorial/src/main/java/com/emotionstorage/tutorial/ui/onBoarding/MarketingUsageDetailScreen.kt
+++ b/feat/tutorial/src/main/java/com/emotionstorage/tutorial/ui/onBoarding/MarketingUsageDetailScreen.kt
@@ -11,7 +11,7 @@ import androidx.compose.material3.Scaffold
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.tooling.preview.Preview
-import com.emotionstorage.ui.component.MarketingUsageContent
+import com.emotionstorage.ui.content.MarketingUsageContent
 import com.emotionstorage.ui.component.TopAppBar
 import com.emotionstorage.ui.theme.MooiTheme
 

--- a/feat/tutorial/src/main/java/com/emotionstorage/tutorial/ui/onBoarding/NicknameScreen.kt
+++ b/feat/tutorial/src/main/java/com/emotionstorage/tutorial/ui/onBoarding/NicknameScreen.kt
@@ -31,11 +31,11 @@ import com.emotionstorage.tutorial.R
 import com.emotionstorage.tutorial.presentation.onBoarding.InputNicknameEvent
 import com.emotionstorage.tutorial.presentation.onBoarding.NicknameViewModel
 import com.emotionstorage.tutorial.presentation.onBoarding.NicknameViewModel.State.InputState
-import com.emotionstorage.ui.component.CtaButton
+import com.emotionstorage.ui.component.button.CtaButton
 import com.emotionstorage.ui.component.HideKeyboard
 import com.emotionstorage.ui.component.Modal
-import com.emotionstorage.ui.component.TextInput
-import com.emotionstorage.ui.component.TextInputState
+import com.emotionstorage.ui.component.text.TextInput
+import com.emotionstorage.ui.component.text.TextInputState
 import com.emotionstorage.ui.component.TopAppBar
 import com.emotionstorage.ui.theme.MooiTheme
 

--- a/feat/tutorial/src/main/java/com/emotionstorage/tutorial/ui/onBoarding/PrivacyPolicyDetailScreen.kt
+++ b/feat/tutorial/src/main/java/com/emotionstorage/tutorial/ui/onBoarding/PrivacyPolicyDetailScreen.kt
@@ -11,7 +11,7 @@ import androidx.compose.material3.Scaffold
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.tooling.preview.Preview
-import com.emotionstorage.ui.component.PrivacyPolicyContent
+import com.emotionstorage.ui.content.PrivacyPolicyContent
 import com.emotionstorage.ui.component.TopAppBar
 import com.emotionstorage.ui.theme.MooiTheme
 

--- a/feat/tutorial/src/main/java/com/emotionstorage/tutorial/ui/onBoarding/TermDetailScreen.kt
+++ b/feat/tutorial/src/main/java/com/emotionstorage/tutorial/ui/onBoarding/TermDetailScreen.kt
@@ -11,7 +11,7 @@ import androidx.compose.material3.Scaffold
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.tooling.preview.Preview
-import com.emotionstorage.ui.component.TermsOfServiceContent
+import com.emotionstorage.ui.content.TermsOfServiceContent
 import com.emotionstorage.ui.component.TopAppBar
 import com.emotionstorage.ui.theme.MooiTheme
 

--- a/feat/tutorial/src/main/java/com/emotionstorage/tutorial/ui/tutorial/TutorialScreen.kt
+++ b/feat/tutorial/src/main/java/com/emotionstorage/tutorial/ui/tutorial/TutorialScreen.kt
@@ -24,7 +24,7 @@ import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.PreviewScreenSizes
 import androidx.compose.ui.unit.dp
 import com.emotionstorage.tutorial.R
-import com.emotionstorage.ui.component.CtaButton
+import com.emotionstorage.ui.component.button.CtaButton
 import com.emotionstorage.ui.theme.MooiTheme
 import com.emotionstorage.ui.util.buildHighlightAnnotatedString
 


### PR DESCRIPTION
## Related Issue
- Issue #107
- Issue #77

## 작업 상세 내용
- 즐겨찾기 해제 버그 고침
  - 즐겨찾기 토글 Remote data source 반환 값 Boolean -> enum 클래스로 변경
- 즐겨찾기 토스트 표시 로직 리팩토링
  - String 리소스 -> enum 클래스로 관리하도록 변경 
  - 관련 PR #104
- 즐겨찾기 목록 다 찬 경우 처리 로직 추가
  - Remote data source 에서 Http Exception 캐치 -> error body status & code 확인
- Remote data source에서 eror body 처리를 위한 `cloneErrorBodyInterceptor` 추가
  - OkHttp의 ResponseBody는 한 번만 읽을 수 있는 stream 기반 구조
    - 기존: 로깅 인터셉터에서 에러 ResponseBody 소비 
    -> 상위 계층에서 ` e.response()?.errorBody()?.string()` 접근 시 null
    - 개선: ResponseBody를 로깅 인터셉터가 읽기 전, byte array로 복제, 여러 번 읽을 수 있게 함
    -> 상위계층에서 에러 response body 접근 가능!

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **New Features**
  * 타임 캡슐 즐겨찾기 한계 도달 시 명확한 피드백 제공
  * 즐겨찾기 추가/제거 상태를 세분화하여 표시

* **Bug Fixes**
  * 즐겨찾기 기능 오류 처리 개선

* **Chores**
  * 내부 에러 처리 강화
  * UI 컴포넌트 구조 최적화
<!-- end of auto-generated comment: release notes by coderabbit.ai -->