### PR TITLE
Refactor/auth usecase 유저 로그인/로그아웃 처리 로직 유즈 케이스로 캡슐화

### DIFF
--- a/core/common/src/main/java/com/emotionstorage/common/util/LocalDateTimeUtil.kt
+++ b/core/common/src/main/java/com/emotionstorage/common/util/LocalDateTimeUtil.kt
@@ -1,4 +1,4 @@
-package com.emotionstorage.common
+package com.emotionstorage.common.util
 
 import java.time.LocalDateTime
 import java.time.ZoneId

--- a/core/common/src/main/java/com/emotionstorage/common/util/LocalDateUtil.kt
+++ b/core/common/src/main/java/com/emotionstorage/common/util/LocalDateUtil.kt
@@ -1,4 +1,4 @@
-package com.emotionstorage.common
+package com.emotionstorage.common.util
 
 import java.time.DayOfWeek
 import java.time.LocalDate

--- a/core/common/src/main/java/com/emotionstorage/common/util/SerializerUtil.kt
+++ b/core/common/src/main/java/com/emotionstorage/common/util/SerializerUtil.kt
@@ -1,4 +1,4 @@
-package com.emotionstorage.common
+package com.emotionstorage.common.util
 import kotlinx.serialization.KSerializer
 import kotlinx.serialization.descriptors.PrimitiveKind
 import kotlinx.serialization.descriptors.PrimitiveSerialDescriptor

--- a/core/common/src/main/java/com/emotionstorage/common/util/YearMonthUtil.kt
+++ b/core/common/src/main/java/com/emotionstorage/common/util/YearMonthUtil.kt
@@ -1,4 +1,4 @@
-package com.emotionstorage.common
+package com.emotionstorage.common.util
 
 import java.time.LocalDate
 import java.time.YearMonth

--- a/core/local/src/main/java/com/emotionstorage/local/model/TimeCapsuleLocal.kt
+++ b/core/local/src/main/java/com/emotionstorage/local/model/TimeCapsuleLocal.kt
@@ -3,7 +3,7 @@ package com.emotionstorage.local.model
 import androidx.room.Entity
 import androidx.room.Index
 import androidx.room.PrimaryKey
-import com.emotionstorage.common.LocalDateTimeSerializer
+import com.emotionstorage.common.util.LocalDateTimeSerializer
 import com.emotionstorage.local.room.database.AppDatabaseConstant
 import kotlinx.serialization.Serializable
 import java.time.LocalDateTime

--- a/core/remote/src/main/java/com/emotionstorage/remote/response/ResponseDto.kt
+++ b/core/remote/src/main/java/com/emotionstorage/remote/response/ResponseDto.kt
@@ -1,6 +1,6 @@
 package com.emotionstorage.remote.response
 
-import com.emotionstorage.common.LocalDateTimeSerializer
+import com.emotionstorage.common.util.LocalDateTimeSerializer
 import com.emotionstorage.domain.common.DataState
 import kotlinx.serialization.Serializable
 import java.time.LocalDateTime

--- a/core/remote/src/main/java/com/emotionstorage/remote/response/dailyReport/GetDailyReportResponse.kt
+++ b/core/remote/src/main/java/com/emotionstorage/remote/response/dailyReport/GetDailyReportResponse.kt
@@ -1,6 +1,6 @@
 package com.emotionstorage.remote.response.dailyReport
 
-import com.emotionstorage.common.LocalDateTimeSerializer
+import com.emotionstorage.common.util.LocalDateTimeSerializer
 import kotlinx.serialization.Serializable
 import java.time.LocalDateTime
 

--- a/core/remote/src/main/java/com/emotionstorage/remote/response/timeCapsule/GetTimeCapsuleDetailResponse.kt
+++ b/core/remote/src/main/java/com/emotionstorage/remote/response/timeCapsule/GetTimeCapsuleDetailResponse.kt
@@ -1,5 +1,5 @@
 package com.emotionstorage.remote.response.timeCapsule
-import com.emotionstorage.common.LocalDateTimeSerializer
+import com.emotionstorage.common.util.LocalDateTimeSerializer
 import kotlinx.serialization.Serializable
 import java.time.LocalDateTime
 

--- a/core/remote/src/main/java/com/emotionstorage/remote/response/timeCapsule/GetTimeCapsulesResponse.kt
+++ b/core/remote/src/main/java/com/emotionstorage/remote/response/timeCapsule/GetTimeCapsulesResponse.kt
@@ -1,6 +1,6 @@
 package com.emotionstorage.remote.response.timeCapsule
 
-import com.emotionstorage.common.LocalDateTimeSerializer
+import com.emotionstorage.common.util.LocalDateTimeSerializer
 import kotlinx.serialization.Serializable
 import java.time.LocalDateTime
 

--- a/core/remote/src/main/java/com/emotionstorage/remote/response/timeCapsule/PatchTimeCapsuleFavoriteResponse.kt
+++ b/core/remote/src/main/java/com/emotionstorage/remote/response/timeCapsule/PatchTimeCapsuleFavoriteResponse.kt
@@ -1,6 +1,6 @@
 package com.emotionstorage.remote.response.timeCapsule
 
-import com.emotionstorage.common.LocalDateTimeSerializer
+import com.emotionstorage.common.util.LocalDateTimeSerializer
 import kotlinx.serialization.Serializable
 import java.time.LocalDateTime
 

--- a/core/ui/src/main/java/com/emotionstorage/ui/component/CountDownTimer.kt
+++ b/core/ui/src/main/java/com/emotionstorage/ui/component/CountDownTimer.kt
@@ -8,7 +8,7 @@ import androidx.compose.runtime.mutableLongStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
-import com.emotionstorage.common.toEpochMillis
+import com.emotionstorage.common.util.toEpochMillis
 import kotlinx.coroutines.delay
 import java.time.LocalDateTime
 

--- a/core/ui/src/main/java/com/emotionstorage/ui/component/calendar/CalendarDates.kt
+++ b/core/ui/src/main/java/com/emotionstorage/ui/component/calendar/CalendarDates.kt
@@ -13,7 +13,7 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
-import com.emotionstorage.common.getWeekDatesOfTargetMonth
+import com.emotionstorage.common.util.getWeekDatesOfTargetMonth
 import com.emotionstorage.ui.theme.MooiTheme
 import java.time.LocalDate
 import java.time.YearMonth

--- a/domain/src/main/java/com/emotionstorage/domain/di/AppModule.kt
+++ b/domain/src/main/java/com/emotionstorage/domain/di/AppModule.kt
@@ -1,0 +1,26 @@
+package com.emotionstorage.domain.di
+
+import dagger.Provides
+import dagger.hilt.InstallIn
+import dagger.hilt.components.SingletonComponent
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import dagger.Module
+import kotlinx.coroutines.SupervisorJob
+import javax.inject.Qualifier
+import javax.inject.Singleton
+
+@Module
+@InstallIn(SingletonComponent::class)
+object AppModule {
+
+    @Provides
+    @Singleton
+    @ApplicationScope
+    fun provideApplicationScope(): CoroutineScope =
+        CoroutineScope(SupervisorJob() + Dispatchers.IO)
+}
+
+@Retention(AnnotationRetention.RUNTIME)
+@Qualifier
+annotation class ApplicationScope

--- a/domain/src/main/java/com/emotionstorage/domain/di/AppModule.kt
+++ b/domain/src/main/java/com/emotionstorage/domain/di/AppModule.kt
@@ -13,12 +13,10 @@ import javax.inject.Singleton
 @Module
 @InstallIn(SingletonComponent::class)
 object AppModule {
-
     @Provides
     @Singleton
     @ApplicationScope
-    fun provideApplicationScope(): CoroutineScope =
-        CoroutineScope(SupervisorJob() + Dispatchers.IO)
+    fun provideApplicationScope(): CoroutineScope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
 }
 
 @Retention(AnnotationRetention.RUNTIME)

--- a/domain/src/main/java/com/emotionstorage/domain/useCase/auth/AutomaticLoginUseCase.kt
+++ b/domain/src/main/java/com/emotionstorage/domain/useCase/auth/AutomaticLoginUseCase.kt
@@ -10,14 +10,9 @@ class AutomaticLoginUseCase
 @Inject
 constructor(
     private val authRepository: AuthRepository,
+    private val handleLogin: HandleLoginUseCase,
+    private val handleLogout: HandleLogoutUseCase,
 ) {
-    @Inject
-    private lateinit var handleLogin: HandleLoginUseCase
-
-    @Inject
-    private lateinit var handleLogout: HandleLogoutUseCase
-
-
     suspend operator fun invoke(): Flow<DataState<Boolean>> =
         authRepository.checkSession().onEach { it ->
             if (it is DataState.Success) {

--- a/domain/src/main/java/com/emotionstorage/domain/useCase/auth/AutomaticLoginUseCase.kt
+++ b/domain/src/main/java/com/emotionstorage/domain/useCase/auth/AutomaticLoginUseCase.kt
@@ -7,19 +7,19 @@ import kotlinx.coroutines.flow.onEach
 import javax.inject.Inject
 
 class AutomaticLoginUseCase
-@Inject
-constructor(
-    private val authRepository: AuthRepository,
-    private val handleLogin: HandleLoginUseCase,
-    private val handleLogout: HandleLogoutUseCase,
-) {
-    suspend operator fun invoke(): Flow<DataState<Boolean>> =
-        authRepository.checkSession().onEach { it ->
-            if (it is DataState.Success) {
-                handleLogin()
+    @Inject
+    constructor(
+        private val authRepository: AuthRepository,
+        private val handleLogin: HandleLoginUseCase,
+        private val handleLogout: HandleLogoutUseCase,
+    ) {
+        suspend operator fun invoke(): Flow<DataState<Boolean>> =
+            authRepository.checkSession().onEach { it ->
+                if (it is DataState.Success) {
+                    handleLogin()
+                }
+                if (it is DataState.Error) {
+                    handleLogout()
+                }
             }
-            if (it is DataState.Error) {
-                handleLogout()
-            }
-        }
-}
+    }

--- a/domain/src/main/java/com/emotionstorage/domain/useCase/auth/AutomaticLoginUseCase.kt
+++ b/domain/src/main/java/com/emotionstorage/domain/useCase/auth/AutomaticLoginUseCase.kt
@@ -2,33 +2,29 @@ package com.emotionstorage.domain.useCase.auth
 
 import com.emotionstorage.domain.common.DataState
 import com.emotionstorage.domain.repo.AuthRepository
-import com.emotionstorage.domain.repo.FcmRepository
-import com.emotionstorage.domain.repo.SessionRepository
-import com.emotionstorage.domain.repo.UserRepository
 import kotlinx.coroutines.flow.Flow
-import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.onEach
 import javax.inject.Inject
 
 class AutomaticLoginUseCase
+@Inject
+constructor(
+    private val authRepository: AuthRepository,
+) {
     @Inject
-    constructor(
-        private val authRepository: AuthRepository,
-        private val sessionRepository: SessionRepository,
-        private val userRepository: UserRepository,
-        private val fcmRepository: FcmRepository,
-    ) {
-        suspend operator fun invoke(): Flow<DataState<Boolean>> =
-            authRepository.checkSession().map { it ->
-                if (it is DataState.Success) {
-                    fcmRepository.getToken()?.let {
-                        fcmRepository.registerToken(it)
-                    }
-                }
-                if (it is DataState.Error) {
-                    sessionRepository.deleteSession()
-                    userRepository.deleteUser()
-                    fcmRepository.deleteToken()
-                }
-                it
+    private lateinit var handleLogin: HandleLoginUseCase
+
+    @Inject
+    private lateinit var handleLogout: HandleLogoutUseCase
+
+
+    suspend operator fun invoke(): Flow<DataState<Boolean>> =
+        authRepository.checkSession().onEach { it ->
+            if (it is DataState.Success) {
+                handleLogin()
             }
-    }
+            if (it is DataState.Error) {
+                handleLogout()
+            }
+        }
+}

--- a/domain/src/main/java/com/emotionstorage/domain/useCase/auth/AutomaticLoginUseCase.kt
+++ b/domain/src/main/java/com/emotionstorage/domain/useCase/auth/AutomaticLoginUseCase.kt
@@ -28,7 +28,6 @@ class AutomaticLoginUseCase
                     sessionRepository.deleteSession()
                     userRepository.deleteUser()
                     fcmRepository.deleteToken()
-                    return@map it
                 }
                 it
             }

--- a/domain/src/main/java/com/emotionstorage/domain/useCase/auth/DeleteAccountUseCase.kt
+++ b/domain/src/main/java/com/emotionstorage/domain/useCase/auth/DeleteAccountUseCase.kt
@@ -1,25 +1,19 @@
 package com.emotionstorage.domain.useCase.auth
 
-import com.emotionstorage.domain.di.ApplicationScope
 import com.emotionstorage.domain.repo.AuthRepository
-import com.emotionstorage.domain.repo.FcmRepository
-import com.emotionstorage.domain.repo.SessionRepository
-import com.emotionstorage.domain.repo.UserRepository
-import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.launch
 import javax.inject.Inject
 
 class DeleteAccountUseCase
-@Inject
-constructor(
-    private val authRepository: AuthRepository,
-    private val handleLogout: HandleLogoutUseCase,
-) {
-    suspend operator fun invoke(): Boolean {
-        val result = authRepository.deleteAccount()
-        if (result) {
-            handleLogout()
+    @Inject
+    constructor(
+        private val authRepository: AuthRepository,
+        private val handleLogout: HandleLogoutUseCase,
+    ) {
+        suspend operator fun invoke(): Boolean {
+            val result = authRepository.deleteAccount()
+            if (result) {
+                handleLogout()
+            }
+            return result
         }
-        return result
     }
-}

--- a/domain/src/main/java/com/emotionstorage/domain/useCase/auth/DeleteAccountUseCase.kt
+++ b/domain/src/main/java/com/emotionstorage/domain/useCase/auth/DeleteAccountUseCase.kt
@@ -1,9 +1,12 @@
 package com.emotionstorage.domain.useCase.auth
 
+import com.emotionstorage.domain.di.ApplicationScope
 import com.emotionstorage.domain.repo.AuthRepository
 import com.emotionstorage.domain.repo.FcmRepository
 import com.emotionstorage.domain.repo.SessionRepository
 import com.emotionstorage.domain.repo.UserRepository
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.launch
 import javax.inject.Inject
 
 /**
@@ -12,20 +15,18 @@ import javax.inject.Inject
  * - delete account fail: return false
  */
 class DeleteAccountUseCase
+@Inject
+constructor(
+    private val authRepository: AuthRepository,
+) {
     @Inject
-    constructor(
-        private val authRepository: AuthRepository,
-        private val userRepository: UserRepository,
-        private val sessionRepository: SessionRepository,
-        private val fcmRepository: FcmRepository,
-    ) {
-        suspend operator fun invoke(): Boolean {
-            val result = authRepository.deleteAccount()
-            if (result) {
-                sessionRepository.deleteSession()
-                userRepository.deleteUser()
-                fcmRepository.deleteToken()
-            }
-            return result
+    private lateinit var handleLogout: HandleLogoutUseCase
+
+    suspend operator fun invoke(): Boolean {
+        val result = authRepository.deleteAccount()
+        if (result) {
+            handleLogout()
         }
+        return result
     }
+}

--- a/domain/src/main/java/com/emotionstorage/domain/useCase/auth/DeleteAccountUseCase.kt
+++ b/domain/src/main/java/com/emotionstorage/domain/useCase/auth/DeleteAccountUseCase.kt
@@ -9,19 +9,12 @@ import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.launch
 import javax.inject.Inject
 
-/**
- * Delete account use case
- * - delete account success: delete session info, delete user info, return true
- * - delete account fail: return false
- */
 class DeleteAccountUseCase
 @Inject
 constructor(
     private val authRepository: AuthRepository,
+    private val handleLogout: HandleLogoutUseCase,
 ) {
-    @Inject
-    private lateinit var handleLogout: HandleLogoutUseCase
-
     suspend operator fun invoke(): Boolean {
         val result = authRepository.deleteAccount()
         if (result) {

--- a/domain/src/main/java/com/emotionstorage/domain/useCase/auth/HandleLoginUseCase.kt
+++ b/domain/src/main/java/com/emotionstorage/domain/useCase/auth/HandleLoginUseCase.kt
@@ -8,12 +8,13 @@ import com.emotionstorage.domain.repo.UserRepository
 import io.github.aakira.napier.Napier
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.launch
+import javax.inject.Inject
 
 /**
  * - Login success logic use case
  * - Should only be **called in Auth Use cases**
  */
-class HandleLoginUseCase(
+class HandleLoginUseCase @Inject constructor(
     private val sessionRepository: SessionRepository,
     private val userRepository: UserRepository,
     private val fcmRepository: FcmRepository,

--- a/domain/src/main/java/com/emotionstorage/domain/useCase/auth/HandleLoginUseCase.kt
+++ b/domain/src/main/java/com/emotionstorage/domain/useCase/auth/HandleLoginUseCase.kt
@@ -8,12 +8,17 @@ import com.emotionstorage.domain.repo.UserRepository
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.launch
 
-internal class HandleLoginUseCase(
+/**
+ * - Login success logic use case
+ * - Should only be **called in Auth Use cases**
+ */
+class HandleLoginUseCase(
     private val sessionRepository: SessionRepository,
     private val userRepository: UserRepository,
     private val fcmRepository: FcmRepository,
     @ApplicationScope private val applicationScope: CoroutineScope,
 ) {
+    // access token can be null when called on automatic login success
     operator fun invoke(accessToken: String? = null) {
         applicationScope.launch {
             // save session

--- a/domain/src/main/java/com/emotionstorage/domain/useCase/auth/HandleLoginUseCase.kt
+++ b/domain/src/main/java/com/emotionstorage/domain/useCase/auth/HandleLoginUseCase.kt
@@ -1,0 +1,35 @@
+package com.emotionstorage.domain.useCase.auth
+
+import com.emotionstorage.domain.di.ApplicationScope
+import com.emotionstorage.domain.model.Session
+import com.emotionstorage.domain.repo.FcmRepository
+import com.emotionstorage.domain.repo.SessionRepository
+import com.emotionstorage.domain.repo.UserRepository
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.launch
+
+internal class HandleLoginUseCase(
+    private val sessionRepository: SessionRepository,
+    private val userRepository: UserRepository,
+    private val fcmRepository: FcmRepository,
+    @ApplicationScope private val applicationScope: CoroutineScope,
+) {
+    operator fun invoke(accessToken: String? = null) {
+        applicationScope.launch {
+            // save session
+            runCatching {
+                accessToken?.let{
+                    sessionRepository.saveSession(Session(it))
+                }
+            }
+            // todo: fetch & save user
+
+            // save fcm token
+            runCatching {
+                fcmRepository.getToken()?.let {
+                    fcmRepository.registerToken(it)
+                }
+            }
+        }
+    }
+}

--- a/domain/src/main/java/com/emotionstorage/domain/useCase/auth/HandleLoginUseCase.kt
+++ b/domain/src/main/java/com/emotionstorage/domain/useCase/auth/HandleLoginUseCase.kt
@@ -5,6 +5,7 @@ import com.emotionstorage.domain.model.Session
 import com.emotionstorage.domain.repo.FcmRepository
 import com.emotionstorage.domain.repo.SessionRepository
 import com.emotionstorage.domain.repo.UserRepository
+import io.github.aakira.napier.Napier
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.launch
 
@@ -25,6 +26,7 @@ class HandleLoginUseCase(
             runCatching {
                 accessToken?.let {
                     sessionRepository.saveSession(Session(it))
+                    Napier.d("session saved")
                 }
             }
             // todo: fetch & save user
@@ -33,6 +35,7 @@ class HandleLoginUseCase(
             runCatching {
                 fcmRepository.getToken()?.let {
                     fcmRepository.registerToken(it)
+                    Napier.d("fcm token saved")
                 }
             }
         }

--- a/domain/src/main/java/com/emotionstorage/domain/useCase/auth/HandleLoginUseCase.kt
+++ b/domain/src/main/java/com/emotionstorage/domain/useCase/auth/HandleLoginUseCase.kt
@@ -23,7 +23,7 @@ class HandleLoginUseCase(
         applicationScope.launch {
             // save session
             runCatching {
-                accessToken?.let{
+                accessToken?.let {
                     sessionRepository.saveSession(Session(it))
                 }
             }

--- a/domain/src/main/java/com/emotionstorage/domain/useCase/auth/HandleLogoutUseCase.kt
+++ b/domain/src/main/java/com/emotionstorage/domain/useCase/auth/HandleLogoutUseCase.kt
@@ -1,0 +1,30 @@
+package com.emotionstorage.domain.useCase.auth
+
+import com.emotionstorage.domain.di.ApplicationScope
+import com.emotionstorage.domain.repo.FcmRepository
+import com.emotionstorage.domain.repo.SessionRepository
+import com.emotionstorage.domain.repo.UserRepository
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.launch
+import javax.inject.Inject
+
+internal class HandleLogoutUseCase @Inject constructor(
+    private val sessionRepository: SessionRepository,
+    private val userRepository: UserRepository,
+    private val fcmRepository: FcmRepository,
+    @ApplicationScope private val applicationScope: CoroutineScope,
+) {
+    operator fun invoke() {
+        applicationScope.launch {
+            runCatching {
+                sessionRepository.deleteSession()
+            }
+            runCatching {
+                userRepository.deleteUser()
+            }
+            runCatching {
+                fcmRepository.deleteToken()
+            }
+        }
+    }
+}

--- a/domain/src/main/java/com/emotionstorage/domain/useCase/auth/HandleLogoutUseCase.kt
+++ b/domain/src/main/java/com/emotionstorage/domain/useCase/auth/HandleLogoutUseCase.kt
@@ -4,6 +4,7 @@ import com.emotionstorage.domain.di.ApplicationScope
 import com.emotionstorage.domain.repo.FcmRepository
 import com.emotionstorage.domain.repo.SessionRepository
 import com.emotionstorage.domain.repo.UserRepository
+import io.github.aakira.napier.Napier
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.launch
 import javax.inject.Inject
@@ -22,12 +23,15 @@ class HandleLogoutUseCase @Inject constructor(
         applicationScope.launch {
             runCatching {
                 sessionRepository.deleteSession()
+                Napier.d("session deleted")
             }
             runCatching {
                 userRepository.deleteUser()
+                Napier.d("user deleted")
             }
             runCatching {
                 fcmRepository.deleteToken()
+                Napier.d("fcm token deleted")
             }
         }
     }

--- a/domain/src/main/java/com/emotionstorage/domain/useCase/auth/HandleLogoutUseCase.kt
+++ b/domain/src/main/java/com/emotionstorage/domain/useCase/auth/HandleLogoutUseCase.kt
@@ -8,7 +8,11 @@ import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.launch
 import javax.inject.Inject
 
-internal class HandleLogoutUseCase @Inject constructor(
+/**
+ * - Logout success logic use case
+ * - Should only be **called in Auth Use cases**
+ */
+class HandleLogoutUseCase @Inject constructor(
     private val sessionRepository: SessionRepository,
     private val userRepository: UserRepository,
     private val fcmRepository: FcmRepository,

--- a/domain/src/main/java/com/emotionstorage/domain/useCase/auth/LoginUseCase.kt
+++ b/domain/src/main/java/com/emotionstorage/domain/useCase/auth/LoginUseCase.kt
@@ -2,33 +2,25 @@ package com.emotionstorage.domain.useCase.auth
 
 import com.emotionstorage.domain.repo.AuthRepository
 import com.emotionstorage.domain.common.DataState
-import com.emotionstorage.domain.di.ApplicationScope
-import com.emotionstorage.domain.model.Session
 import com.emotionstorage.domain.model.User
-import com.emotionstorage.domain.repo.FcmRepository
-import com.emotionstorage.domain.repo.SessionRepository
-import com.emotionstorage.domain.repo.UserRepository
-import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.onEach
-import kotlinx.coroutines.launch
 import javax.inject.Inject
 
 class LoginUseCase
-@Inject
-constructor(
-    private val authRepository: AuthRepository,
-    private val handleLogin: HandleLoginUseCase,
-    private val handleLogout: HandleLogoutUseCase,
-) {
-
-    suspend operator fun invoke(provider: User.AuthProvider): Flow<DataState<String>> =
-        authRepository.login(provider).onEach {
-            if (it is DataState.Success) {
-                handleLogin(it.data)
+    @Inject
+    constructor(
+        private val authRepository: AuthRepository,
+        private val handleLogin: HandleLoginUseCase,
+        private val handleLogout: HandleLogoutUseCase,
+    ) {
+        suspend operator fun invoke(provider: User.AuthProvider): Flow<DataState<String>> =
+            authRepository.login(provider).onEach {
+                if (it is DataState.Success) {
+                    handleLogin(it.data)
+                }
+                if (it is DataState.Error) {
+                    handleLogout()
+                }
             }
-            if (it is DataState.Error) {
-                handleLogout()
-            }
-        }
-}
+    }

--- a/domain/src/main/java/com/emotionstorage/domain/useCase/auth/LoginUseCase.kt
+++ b/domain/src/main/java/com/emotionstorage/domain/useCase/auth/LoginUseCase.kt
@@ -18,12 +18,9 @@ class LoginUseCase
 @Inject
 constructor(
     private val authRepository: AuthRepository,
+    private val handleLogin: HandleLoginUseCase,
+    private val handleLogout: HandleLogoutUseCase,
 ) {
-    @Inject
-    private lateinit var handleLogin: HandleLoginUseCase
-
-    @Inject
-    private lateinit var handleLogout: HandleLogoutUseCase
 
     suspend operator fun invoke(provider: User.AuthProvider): Flow<DataState<String>> =
         authRepository.login(provider).onEach {

--- a/domain/src/main/java/com/emotionstorage/domain/useCase/auth/LoginUseCase.kt
+++ b/domain/src/main/java/com/emotionstorage/domain/useCase/auth/LoginUseCase.kt
@@ -2,36 +2,36 @@ package com.emotionstorage.domain.useCase.auth
 
 import com.emotionstorage.domain.repo.AuthRepository
 import com.emotionstorage.domain.common.DataState
+import com.emotionstorage.domain.di.ApplicationScope
 import com.emotionstorage.domain.model.Session
 import com.emotionstorage.domain.model.User
 import com.emotionstorage.domain.repo.FcmRepository
 import com.emotionstorage.domain.repo.SessionRepository
 import com.emotionstorage.domain.repo.UserRepository
+import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.flow.Flow
-import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.onEach
+import kotlinx.coroutines.launch
 import javax.inject.Inject
 
 class LoginUseCase
+@Inject
+constructor(
+    private val authRepository: AuthRepository,
+) {
     @Inject
-    constructor(
-        private val authRepository: AuthRepository,
-        private val sessionRepository: SessionRepository,
-        private val userRepository: UserRepository,
-        private val fcmRepository: FcmRepository,
-    ) {
-        suspend operator fun invoke(provider: User.AuthProvider): Flow<DataState<String>> =
-            authRepository.login(provider).map {
-                if (it is DataState.Success) {
-                    sessionRepository.saveSession(Session(it.data))
-                    fcmRepository.getToken()?.let {
-                        fcmRepository.registerToken(it)
-                    }
-                }
-                if (it is DataState.Error) {
-                    sessionRepository.deleteSession()
-                    userRepository.deleteUser()
-                    fcmRepository.deleteToken()
-                }
-                it
+    private lateinit var handleLogin: HandleLoginUseCase
+
+    @Inject
+    private lateinit var handleLogout: HandleLogoutUseCase
+
+    suspend operator fun invoke(provider: User.AuthProvider): Flow<DataState<String>> =
+        authRepository.login(provider).onEach {
+            if (it is DataState.Success) {
+                handleLogin(it.data)
             }
-    }
+            if (it is DataState.Error) {
+                handleLogout()
+            }
+        }
+}

--- a/domain/src/main/java/com/emotionstorage/domain/useCase/auth/LoginWithIdTokenUseCase.kt
+++ b/domain/src/main/java/com/emotionstorage/domain/useCase/auth/LoginWithIdTokenUseCase.kt
@@ -18,13 +18,9 @@ class LoginWithIdTokenUseCase
 @Inject
 constructor(
     private val authRepository: AuthRepository,
+    private val handleLogin: HandleLoginUseCase,
+    private val handleLogout: HandleLogoutUseCase,
 ) {
-    @Inject
-    private lateinit var handleLogin: HandleLoginUseCase
-
-    @Inject
-    private lateinit var handleLogout: HandleLogoutUseCase
-
     suspend operator fun invoke(
         provider: User.AuthProvider,
         idToken: String,

--- a/domain/src/main/java/com/emotionstorage/domain/useCase/auth/LoginWithIdTokenUseCase.kt
+++ b/domain/src/main/java/com/emotionstorage/domain/useCase/auth/LoginWithIdTokenUseCase.kt
@@ -2,39 +2,39 @@ package com.emotionstorage.domain.useCase.auth
 
 import com.emotionstorage.domain.repo.AuthRepository
 import com.emotionstorage.domain.common.DataState
+import com.emotionstorage.domain.di.ApplicationScope
 import com.emotionstorage.domain.model.Session
 import com.emotionstorage.domain.model.User
 import com.emotionstorage.domain.repo.FcmRepository
 import com.emotionstorage.domain.repo.SessionRepository
 import com.emotionstorage.domain.repo.UserRepository
+import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.flow.Flow
-import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.onEach
+import kotlinx.coroutines.launch
 import javax.inject.Inject
 
 class LoginWithIdTokenUseCase
+@Inject
+constructor(
+    private val authRepository: AuthRepository,
+) {
     @Inject
-    constructor(
-        private val authRepository: AuthRepository,
-        private val sessionRepository: SessionRepository,
-        private val userRepository: UserRepository,
-        private val fcmRepository: FcmRepository,
-    ) {
-        suspend operator fun invoke(
-            provider: User.AuthProvider,
-            idToken: String,
-        ): Flow<DataState<String>> =
-            authRepository.loginWithIdToken(provider, idToken).map {
-                if (it is DataState.Success) {
-                    sessionRepository.saveSession(Session(it.data))
-                    fcmRepository.getToken()?.let {
-                        fcmRepository.registerToken(it)
-                    }
-                }
-                if (it is DataState.Error) {
-                    sessionRepository.deleteSession()
-                    userRepository.deleteUser()
-                    fcmRepository.deleteToken()
-                }
-                it
+    private lateinit var handleLogin: HandleLoginUseCase
+
+    @Inject
+    private lateinit var handleLogout: HandleLogoutUseCase
+
+    suspend operator fun invoke(
+        provider: User.AuthProvider,
+        idToken: String,
+    ): Flow<DataState<String>> =
+        authRepository.loginWithIdToken(provider, idToken).onEach {
+            if (it is DataState.Success) {
+                handleLogin(it.data)
             }
-    }
+            if (it is DataState.Error) {
+                handleLogout()
+            }
+        }
+}

--- a/domain/src/main/java/com/emotionstorage/domain/useCase/auth/LoginWithIdTokenUseCase.kt
+++ b/domain/src/main/java/com/emotionstorage/domain/useCase/auth/LoginWithIdTokenUseCase.kt
@@ -2,35 +2,28 @@ package com.emotionstorage.domain.useCase.auth
 
 import com.emotionstorage.domain.repo.AuthRepository
 import com.emotionstorage.domain.common.DataState
-import com.emotionstorage.domain.di.ApplicationScope
-import com.emotionstorage.domain.model.Session
 import com.emotionstorage.domain.model.User
-import com.emotionstorage.domain.repo.FcmRepository
-import com.emotionstorage.domain.repo.SessionRepository
-import com.emotionstorage.domain.repo.UserRepository
-import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.onEach
-import kotlinx.coroutines.launch
 import javax.inject.Inject
 
 class LoginWithIdTokenUseCase
-@Inject
-constructor(
-    private val authRepository: AuthRepository,
-    private val handleLogin: HandleLoginUseCase,
-    private val handleLogout: HandleLogoutUseCase,
-) {
-    suspend operator fun invoke(
-        provider: User.AuthProvider,
-        idToken: String,
-    ): Flow<DataState<String>> =
-        authRepository.loginWithIdToken(provider, idToken).onEach {
-            if (it is DataState.Success) {
-                handleLogin(it.data)
+    @Inject
+    constructor(
+        private val authRepository: AuthRepository,
+        private val handleLogin: HandleLoginUseCase,
+        private val handleLogout: HandleLogoutUseCase,
+    ) {
+        suspend operator fun invoke(
+            provider: User.AuthProvider,
+            idToken: String,
+        ): Flow<DataState<String>> =
+            authRepository.loginWithIdToken(provider, idToken).onEach {
+                if (it is DataState.Success) {
+                    handleLogin(it.data)
+                }
+                if (it is DataState.Error) {
+                    handleLogout()
+                }
             }
-            if (it is DataState.Error) {
-                handleLogout()
-            }
-        }
-}
+    }

--- a/domain/src/main/java/com/emotionstorage/domain/useCase/auth/LogoutUseCase.kt
+++ b/domain/src/main/java/com/emotionstorage/domain/useCase/auth/LogoutUseCase.kt
@@ -1,26 +1,19 @@
 package com.emotionstorage.domain.useCase.auth
 
-import com.emotionstorage.domain.di.ApplicationScope
 import com.emotionstorage.domain.repo.AuthRepository
-import com.emotionstorage.domain.repo.FcmRepository
-import com.emotionstorage.domain.repo.SessionRepository
-import com.emotionstorage.domain.repo.UserRepository
-import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.launch
 import javax.inject.Inject
 
-
 class LogoutUseCase
-@Inject
-constructor(
-    private val authRepository: AuthRepository,
-    private val handleLogout: HandleLogoutUseCase,
-) {
-    suspend operator fun invoke(): Boolean {
-        val result = authRepository.logout()
-        if (result) {
-            handleLogout()
+    @Inject
+    constructor(
+        private val authRepository: AuthRepository,
+        private val handleLogout: HandleLogoutUseCase,
+    ) {
+        suspend operator fun invoke(): Boolean {
+            val result = authRepository.logout()
+            if (result) {
+                handleLogout()
+            }
+            return result
         }
-        return result
     }
-}

--- a/domain/src/main/java/com/emotionstorage/domain/useCase/auth/LogoutUseCase.kt
+++ b/domain/src/main/java/com/emotionstorage/domain/useCase/auth/LogoutUseCase.kt
@@ -9,30 +9,17 @@ import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.launch
 import javax.inject.Inject
 
-/**
- *  Logout use case
- *  - logout success: delete session info, delete user info, return true
- *  - logout fail: return false
- */
+
 class LogoutUseCase
 @Inject
 constructor(
     private val authRepository: AuthRepository,
-    private val userRepository: UserRepository,
-    private val sessionRepository: SessionRepository,
-    private val fcmRepository: FcmRepository,
-    @ApplicationScope private val applicationScope: CoroutineScope,
+    private val handleLogout: HandleLogoutUseCase,
 ) {
     suspend operator fun invoke(): Boolean {
         val result = authRepository.logout()
         if (result) {
-            applicationScope.launch {
-                runCatching {
-                    sessionRepository.deleteSession()
-                    userRepository.deleteUser()
-                    fcmRepository.deleteToken()
-                }
-            }
+            handleLogout()
         }
         return result
     }

--- a/domain/src/main/java/com/emotionstorage/domain/useCase/auth/LogoutUseCase.kt
+++ b/domain/src/main/java/com/emotionstorage/domain/useCase/auth/LogoutUseCase.kt
@@ -1,9 +1,12 @@
 package com.emotionstorage.domain.useCase.auth
 
+import com.emotionstorage.domain.di.ApplicationScope
 import com.emotionstorage.domain.repo.AuthRepository
 import com.emotionstorage.domain.repo.FcmRepository
 import com.emotionstorage.domain.repo.SessionRepository
 import com.emotionstorage.domain.repo.UserRepository
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.launch
 import javax.inject.Inject
 
 /**
@@ -12,20 +15,25 @@ import javax.inject.Inject
  *  - logout fail: return false
  */
 class LogoutUseCase
-    @Inject
-    constructor(
-        private val authRepository: AuthRepository,
-        private val userRepository: UserRepository,
-        private val sessionRepository: SessionRepository,
-        private val fcmRepository: FcmRepository,
-    ) {
-        suspend operator fun invoke(): Boolean {
-            val result = authRepository.logout()
-            if (result) {
-                sessionRepository.deleteSession()
-                userRepository.deleteUser()
-                fcmRepository.deleteToken()
+@Inject
+constructor(
+    private val authRepository: AuthRepository,
+    private val userRepository: UserRepository,
+    private val sessionRepository: SessionRepository,
+    private val fcmRepository: FcmRepository,
+    @ApplicationScope private val applicationScope: CoroutineScope,
+) {
+    suspend operator fun invoke(): Boolean {
+        val result = authRepository.logout()
+        if (result) {
+            applicationScope.launch {
+                runCatching {
+                    sessionRepository.deleteSession()
+                    userRepository.deleteUser()
+                    fcmRepository.deleteToken()
+                }
             }
-            return result
         }
+        return result
     }
+}

--- a/domain/src/main/java/com/emotionstorage/domain/useCase/key/GetRequiredKeyCountUseCase.kt
+++ b/domain/src/main/java/com/emotionstorage/domain/useCase/key/GetRequiredKeyCountUseCase.kt
@@ -1,6 +1,6 @@
 package com.emotionstorage.domain.useCase.key
 
-import com.emotionstorage.common.getDaysBetween
+import com.emotionstorage.common.util.getDaysBetween
 import com.emotionstorage.domain.common.DataState
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.flow

--- a/feat/ai-chat/src/main/java/com/emotionstorage/ai_chat/ui/component/ChatMessageList.kt
+++ b/feat/ai-chat/src/main/java/com/emotionstorage/ai_chat/ui/component/ChatMessageList.kt
@@ -30,7 +30,7 @@ import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import com.emotionstorage.domain.model.ChatMessage
 import com.emotionstorage.domain.model.ChatMessage.MessageSource
-import com.emotionstorage.common.toKorDateWithWeekDay
+import com.emotionstorage.common.util.toKorDateWithWeekDay
 import com.emotionstorage.ui.theme.MooiTheme
 import java.time.LocalDate
 import java.time.LocalDateTime

--- a/feat/daily-report/src/main/java/com/emotionstorage/daily_report/ui/DailyReportDetailScreen.kt
+++ b/feat/daily-report/src/main/java/com/emotionstorage/daily_report/ui/DailyReportDetailScreen.kt
@@ -25,7 +25,7 @@ import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import androidx.hilt.navigation.compose.hiltViewModel
-import com.emotionstorage.common.toKorDateWithWeekDay
+import com.emotionstorage.common.util.toKorDateWithWeekDay
 import com.emotionstorage.daily_report.presentation.DailyReportDetailAction
 import com.emotionstorage.daily_report.presentation.DailyReportDetailViewModel
 import com.emotionstorage.daily_report.ui.component.DailyReportEmotionLog

--- a/feat/daily-report/src/main/java/com/emotionstorage/daily_report/ui/component/DailyReportEmotionLog.kt
+++ b/feat/daily-report/src/main/java/com/emotionstorage/daily_report/ui/component/DailyReportEmotionLog.kt
@@ -20,7 +20,6 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.draw.blur
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.RectangleShape
 import androidx.compose.ui.layout.onGloballyPositioned
@@ -29,7 +28,7 @@ import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
-import com.emotionstorage.common.formatToKorTime
+import com.emotionstorage.common.util.formatToKorTime
 import com.emotionstorage.domain.model.DailyReport.EmotionLog
 import com.emotionstorage.ui.theme.MooiTheme
 import com.emotionstorage.ui.util.LinearGradient

--- a/feat/time-capsule-detail/src/main/java/com/emotionstorage/time_capsule_detail/ui/SaveTimeCapsuleScreen.kt
+++ b/feat/time-capsule-detail/src/main/java/com/emotionstorage/time_capsule_detail/ui/SaveTimeCapsuleScreen.kt
@@ -36,7 +36,7 @@ import androidx.compose.ui.tooling.preview.PreviewScreenSizes
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.zIndex
 import androidx.hilt.navigation.compose.hiltViewModel
-import com.emotionstorage.common.toKorDate
+import com.emotionstorage.common.util.toKorDate
 import com.emotionstorage.time_capsule_detail.presentation.SaveTimeCapsuleAction
 import com.emotionstorage.time_capsule_detail.presentation.SaveTimeCapsuleSideEffect.SaveTimeCapsuleSuccess
 import com.emotionstorage.time_capsule_detail.presentation.SaveTimeCapsuleSideEffect.ShowToast

--- a/feat/time-capsule-detail/src/main/java/com/emotionstorage/time_capsule_detail/ui/modal/TimeCapsuleUnlockModal.kt
+++ b/feat/time-capsule-detail/src/main/java/com/emotionstorage/time_capsule_detail/ui/modal/TimeCapsuleUnlockModal.kt
@@ -22,7 +22,7 @@ import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.text.withStyle
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
-import com.emotionstorage.common.getDaysBetween
+import com.emotionstorage.common.util.getDaysBetween
 import com.emotionstorage.ui.R
 import com.emotionstorage.ui.component.CountDownTimer
 import com.emotionstorage.ui.component.button.CtaButton

--- a/feat/time-capsule/src/main/java/com/emotionstorage/time_capsule/ui/component/TimeCapsuleBottomSheet.kt
+++ b/feat/time-capsule/src/main/java/com/emotionstorage/time_capsule/ui/component/TimeCapsuleBottomSheet.kt
@@ -34,7 +34,7 @@ import androidx.compose.ui.unit.sp
 import androidx.paging.LoadState
 import androidx.paging.PagingData
 import androidx.paging.compose.collectAsLazyPagingItems
-import com.emotionstorage.common.toKorDateWithWeekDay
+import com.emotionstorage.common.util.toKorDateWithWeekDay
 import com.emotionstorage.time_capsule.ui.component.timeCapsuleItem.TimeCapsuleItem
 import com.emotionstorage.time_capsule.ui.model.TimeCapsuleItemState
 import com.emotionstorage.ui.component.bottomSheet.BottomSheet

--- a/feat/time-capsule/src/main/java/com/emotionstorage/time_capsule/ui/component/timeCapsuleItem/InfoHeader.kt
+++ b/feat/time-capsule/src/main/java/com/emotionstorage/time_capsule/ui/component/timeCapsuleItem/InfoHeader.kt
@@ -15,8 +15,8 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.ColorFilter
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.unit.dp
-import com.emotionstorage.common.formatToKorDateTime
-import com.emotionstorage.common.formatToKorTime
+import com.emotionstorage.common.util.formatToKorDateTime
+import com.emotionstorage.common.util.formatToKorTime
 import com.emotionstorage.domain.model.TimeCapsule
 import com.emotionstorage.ui.R
 import com.emotionstorage.ui.component.CountDownTimer

--- a/feat/time-capsule/src/main/java/com/emotionstorage/time_capsule/ui/modelMapper/TimeCapsuleMapper.kt
+++ b/feat/time-capsule/src/main/java/com/emotionstorage/time_capsule/ui/modelMapper/TimeCapsuleMapper.kt
@@ -1,6 +1,6 @@
 package com.emotionstorage.time_capsule.ui.modelMapper
 
-import com.emotionstorage.common.getDaysBetween
+import com.emotionstorage.common.util.getDaysBetween
 import com.emotionstorage.domain.model.TimeCapsule
 import com.emotionstorage.time_capsule.ui.model.TimeCapsuleItemState
 import java.time.LocalDate


### PR DESCRIPTION
## 작업 상세 내용
- 유저 로그인/로그아웃 처리 로직 유즈 케이스로 캡슐화
   - `HandleLoginUseCase` - 세션 정보 저장, Fcm 토큰 저장 
   (@harry7408 *LoginViewModel 내부에 위치한 유저 정보 조회 & 저장 로직 여기로 이동 필요*)
  - `HandleLogoutUseCase` - 세션 정보 삭제, 유저 정보 삭제, Fcm 토큰 삭제
  - 처리 로직 AppCoroutineScope에서 비동기적으로 실행 -> 로그인/로그아웃 결과는 즉시 반환 & 처리 로직은 별도의 코루틴에서 비동기 실행
  - runCatching 블록으로 감싸 호출 -> 처리 로직 실패해도 로그인 결과에 영향 없음 (*실패 시 처리 추후 고민 필요*)



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **Chores**
  * 내부 코드 구조를 개선하고 유틸리티 함수를 정리했습니다.
  * 인증 흐름의 내부 구조를 재정렬하여 유지보수성을 향상시켰습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->