### PR TITLE
feat: update user nickname on local when remote user nickname changed

### DIFF
--- a/core/local/src/main/java/com/emotionstorage/local/dataSourceImpl/UserLocalDataSourceImpl.kt
+++ b/core/local/src/main/java/com/emotionstorage/local/dataSourceImpl/UserLocalDataSourceImpl.kt
@@ -41,11 +41,13 @@ class UserLocalDataSourceImpl @Inject constructor(
         }
     }
 
-    override suspend fun updateUserNickname(nickname: String) {
+    override suspend fun updateUserNickname(nickname: String): Boolean {
         try {
             userDao.updateUserNickname(nickname)
+            return true
         } catch (e: Exception) {
             Logger.e("updateUserNickname error: $e")
+            return false
         }
     }
 }

--- a/core/local/src/main/java/com/emotionstorage/local/dataSourceImpl/UserLocalDataSourceImpl.kt
+++ b/core/local/src/main/java/com/emotionstorage/local/dataSourceImpl/UserLocalDataSourceImpl.kt
@@ -40,4 +40,12 @@ class UserLocalDataSourceImpl @Inject constructor(
             return false
         }
     }
+
+    override suspend fun updateUserNickname(nickname: String) {
+        try {
+            userDao.updateUserNickname(nickname)
+        } catch (e: Exception) {
+            Logger.e("updateUserNickname error: $e")
+        }
+    }
 }

--- a/core/local/src/main/java/com/emotionstorage/local/room/dao/UserDao.kt
+++ b/core/local/src/main/java/com/emotionstorage/local/room/dao/UserDao.kt
@@ -17,4 +17,7 @@ interface UserDao {
 
     @Query("DELETE FROM user WHERE pk = $USER_PRIMARY_KEY")
     suspend fun deleteUser()
+
+    @Query("UPDATE user SET name = :nickname WHERE pk = $USER_PRIMARY_KEY")
+    suspend fun updateUserNickname(nickname: String)
 }

--- a/data/src/main/java/com/emotionstorage/data/dataSource/local/UserLocalDataSource.kt
+++ b/data/src/main/java/com/emotionstorage/data/dataSource/local/UserLocalDataSource.kt
@@ -8,4 +8,6 @@ interface UserLocalDataSource {
     suspend fun getUser(): UserEntity?
 
     suspend fun deleteUser(): Boolean
+
+    suspend fun updateUserNickname(nickname: String)
 }

--- a/data/src/main/java/com/emotionstorage/data/dataSource/local/UserLocalDataSource.kt
+++ b/data/src/main/java/com/emotionstorage/data/dataSource/local/UserLocalDataSource.kt
@@ -9,5 +9,5 @@ interface UserLocalDataSource {
 
     suspend fun deleteUser(): Boolean
 
-    suspend fun updateUserNickname(nickname: String)
+    suspend fun updateUserNickname(nickname: String): Boolean
 }

--- a/data/src/main/java/com/emotionstorage/data/repoImpl/UserRepositoryImpl.kt
+++ b/data/src/main/java/com/emotionstorage/data/repoImpl/UserRepositoryImpl.kt
@@ -28,7 +28,7 @@ class UserRepositoryImpl
                     // ?: userRemoteDataSource.getUser()
 
                     if (user != null) {
-                        emit(DataState.Success(UserMapper.toDomain(user!!)))
+                        emit(DataState.Success(UserMapper.toDomain(user)))
                     } else {
                         emit(DataState.Error(Exception("User not found")))
                     }
@@ -41,7 +41,14 @@ class UserRepositoryImpl
 
         override suspend fun deleteUser(): Boolean = userLocalDataSource.deleteUser()
 
-        override suspend fun updateUserNickname(nickname: String) = userRemoteDataSource.updateUserNickname(nickname)
+        override suspend fun updateUserNickname(nickname: String) =
+            userRemoteDataSource
+                .updateUserNickname(nickname)
+                .also { state ->
+                    if (state is DataState.Success) {
+                        userLocalDataSource.updateUserNickname(nickname)
+                    }
+                }
 
         override suspend fun getKeyCount(): DataState<Int> = userRemoteDataSource.getKeyCount()
 

--- a/data/src/main/java/com/emotionstorage/data/repoImpl/UserRepositoryImpl.kt
+++ b/data/src/main/java/com/emotionstorage/data/repoImpl/UserRepositoryImpl.kt
@@ -46,7 +46,11 @@ class UserRepositoryImpl
                 .updateUserNickname(nickname)
                 .also { state ->
                     if (state is DataState.Success) {
-                        userLocalDataSource.updateUserNickname(nickname)
+                        val localUpdateSuccess = userLocalDataSource.updateUserNickname(nickname)
+                        if (!localUpdateSuccess) {
+                            // 로컬 업데이트 실패 상황 및 실패 했을 때의 대처 고려 필요
+                            throw Exception("Local update failed")
+                        }
                     }
                 }
 


### PR DESCRIPTION
## Related Issue
- Issue #144

## 작업 상세 내용
- 사용자 닉네임 Server 변경 성공 시 Local에도 닉네임 변경 로직 추가

⚠️ 이슈의 2번째 Task는 저는 오류가 나오지 않아서 구체적으로 어느 상황에 발생하는지 말씀해주시면 감사하겠습니다 😢 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 사용자 닉네임을 변경할 수 있는 기능 추가
  * 로컬 저장소에서 닉네임을 갱신하는 동작 추가

* **개선 사항**
  * 닉네임 변경 시 원격 및 로컬 데이터 동기화가 이루어지도록 개선
  * 사용자 조회 흐름의 안정성 및 에러 처리 강화

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->