### PR TITLE
feat: local system notification status save logic

### DIFF
--- a/.idea/deploymentTargetSelector.xml
+++ b/.idea/deploymentTargetSelector.xml
@@ -13,9 +13,6 @@
         </DropdownSelection>
         <DialogSelection />
       </SelectionState>
-      <SelectionState runConfigName="BaseViewModelTest">
-        <option name="selectionMode" value="DROPDOWN" />
-      </SelectionState>
     </selectionStates>
   </component>
 </project>

--- a/core/local/src/main/java/com/emotionstorage/local/dataSourceImpl/NotificationPermissionDataSourceImpl.kt
+++ b/core/local/src/main/java/com/emotionstorage/local/dataSourceImpl/NotificationPermissionDataSourceImpl.kt
@@ -3,14 +3,18 @@ package com.emotionstorage.local.dataSourceImpl
 import android.content.Context
 import androidx.datastore.preferences.core.booleanPreferencesKey
 import androidx.datastore.preferences.core.edit
-import androidx.datastore.preferences.core.intPreferencesKey
+import androidx.datastore.preferences.core.emptyPreferences
+import androidx.datastore.preferences.core.stringPreferencesKey
 import androidx.datastore.preferences.preferencesDataStore
 import com.emotionstorage.data.dataSource.local.NotificationPermissionDataSource
 import com.emotionstorage.domain.model.NotificationPermissionInfo
 import com.emotionstorage.domain.model.NotificationPermissionStatus
+import com.orhanobut.logger.Logger
 import dagger.hilt.android.qualifiers.ApplicationContext
 import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.catch
 import kotlinx.coroutines.flow.map
+import okio.IOException
 import javax.inject.Inject
 
 class NotificationPermissionDataSourceImpl @Inject constructor(
@@ -19,24 +23,34 @@ class NotificationPermissionDataSourceImpl @Inject constructor(
     private val Context.dataStore by preferencesDataStore("permission_prefs")
 
     private object Keys {
-        val STATUS = intPreferencesKey("notif_status")
+        val STATUS = stringPreferencesKey("notif_status")
         val PROMPTED = booleanPreferencesKey("notif_prompted")
     }
 
     override fun observeInfo(): Flow<NotificationPermissionInfo> =
-        context.dataStore.data.map { pref ->
-            val statusOrdinal = pref[Keys.STATUS] ?: NotificationPermissionStatus.Unknown.ordinal
-            val status =
-                NotificationPermissionStatus.entries.getOrElse(statusOrdinal) { NotificationPermissionStatus.Unknown }
-            val prompted = pref[Keys.PROMPTED] ?: false
-            NotificationPermissionInfo(status = status, hasPrompted = prompted)
-        }
+        context.dataStore.data
+            .catch { emit(emptyPreferences()) }
+            .map { pref ->
+                val statusName = pref[Keys.STATUS] ?: NotificationPermissionStatus.Unknown.name
+                val status = NotificationPermissionStatus.entries.firstOrNull { it.name == statusName }
+                    ?: NotificationPermissionStatus.Unknown
+                val prompted = pref[Keys.PROMPTED] ?: false
+                NotificationPermissionInfo(status = status, hasPrompted = prompted)
+            }
 
     override suspend fun updateStatus(status: NotificationPermissionStatus) {
-        context.dataStore.edit { it[Keys.STATUS] = status.ordinal }
+        try {
+            context.dataStore.edit { it[Keys.STATUS] = status.name }
+        } catch (e: IOException) {
+            Logger.e("Update Notification Setting value Error ${e.message.toString()}")
+        }
     }
 
     override suspend fun setPrompted(value: Boolean) {
-        context.dataStore.edit { it[Keys.PROMPTED] = value }
+        try {
+            context.dataStore.edit { it[Keys.PROMPTED] = value }
+        } catch (e: IOException) {
+            Logger.e("Update Notification Setting value Error ${e.message.toString()}")
+        }
     }
 }

--- a/core/local/src/main/java/com/emotionstorage/local/dataSourceImpl/NotificationPermissionDataSourceImpl.kt
+++ b/core/local/src/main/java/com/emotionstorage/local/dataSourceImpl/NotificationPermissionDataSourceImpl.kt
@@ -1,0 +1,42 @@
+package com.emotionstorage.local.dataSourceImpl
+
+import android.content.Context
+import androidx.datastore.preferences.core.booleanPreferencesKey
+import androidx.datastore.preferences.core.edit
+import androidx.datastore.preferences.core.intPreferencesKey
+import androidx.datastore.preferences.preferencesDataStore
+import com.emotionstorage.data.dataSource.local.NotificationPermissionDataSource
+import com.emotionstorage.domain.model.NotificationPermissionInfo
+import com.emotionstorage.domain.model.NotificationPermissionStatus
+import dagger.hilt.android.qualifiers.ApplicationContext
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.map
+import javax.inject.Inject
+
+class NotificationPermissionDataSourceImpl @Inject constructor(
+    @ApplicationContext private val context: Context,
+) : NotificationPermissionDataSource {
+    private val Context.dataStore by preferencesDataStore("permission_prefs")
+
+    private object Keys {
+        val STATUS = intPreferencesKey("notif_status")
+        val PROMPTED = booleanPreferencesKey("notif_prompted")
+    }
+
+    override fun observeInfo(): Flow<NotificationPermissionInfo> =
+        context.dataStore.data.map { pref ->
+            val statusOrdinal = pref[Keys.STATUS] ?: NotificationPermissionStatus.Unknown.ordinal
+            val status =
+                NotificationPermissionStatus.entries.getOrElse(statusOrdinal) { NotificationPermissionStatus.Unknown }
+            val prompted = pref[Keys.PROMPTED] ?: false
+            NotificationPermissionInfo(status = status, hasPrompted = prompted)
+        }
+
+    override suspend fun updateStatus(status: NotificationPermissionStatus) {
+        context.dataStore.edit { it[Keys.STATUS] = status.ordinal }
+    }
+
+    override suspend fun setPrompted(value: Boolean) {
+        context.dataStore.edit { it[Keys.PROMPTED] = value }
+    }
+}

--- a/core/local/src/main/java/com/emotionstorage/local/dataSourceImpl/NotificationPermissionDataSourceImpl.kt
+++ b/core/local/src/main/java/com/emotionstorage/local/dataSourceImpl/NotificationPermissionDataSourceImpl.kt
@@ -28,12 +28,15 @@ class NotificationPermissionDataSourceImpl @Inject constructor(
     }
 
     override fun observeInfo(): Flow<NotificationPermissionInfo> =
-        context.dataStore.data
+        context
+            .dataStore
+            .data
             .catch { emit(emptyPreferences()) }
             .map { pref ->
                 val statusName = pref[Keys.STATUS] ?: NotificationPermissionStatus.Unknown.name
-                val status = NotificationPermissionStatus.entries.firstOrNull { it.name == statusName }
-                    ?: NotificationPermissionStatus.Unknown
+                val status =
+                    NotificationPermissionStatus.entries.firstOrNull { it.name == statusName }
+                        ?: NotificationPermissionStatus.Unknown
                 val prompted = pref[Keys.PROMPTED] ?: false
                 NotificationPermissionInfo(status = status, hasPrompted = prompted)
             }
@@ -42,7 +45,7 @@ class NotificationPermissionDataSourceImpl @Inject constructor(
         try {
             context.dataStore.edit { it[Keys.STATUS] = status.name }
         } catch (e: IOException) {
-            Logger.e("Update Notification Setting value Error ${e.message.toString()}")
+            Logger.e("Update Notification Setting value Error ${e.message}")
         }
     }
 
@@ -50,7 +53,7 @@ class NotificationPermissionDataSourceImpl @Inject constructor(
         try {
             context.dataStore.edit { it[Keys.PROMPTED] = value }
         } catch (e: IOException) {
-            Logger.e("Update Notification Setting value Error ${e.message.toString()}")
+            Logger.e("Update Notification Setting value Error ${e.message}")
         }
     }
 }

--- a/core/local/src/main/java/com/emotionstorage/local/di/LocalDataSourceModule.kt
+++ b/core/local/src/main/java/com/emotionstorage/local/di/LocalDataSourceModule.kt
@@ -2,11 +2,13 @@ package com.emotionstorage.local.di
 
 import com.emotionstorage.data.dataSource.local.AttendanceLocalDataSource
 import com.emotionstorage.data.dataSource.local.FcmLocalDataSource
+import com.emotionstorage.data.dataSource.local.NotificationPermissionDataSource
 import com.emotionstorage.data.dataSource.local.SessionLocalDataSource
 import com.emotionstorage.data.dataSource.local.TimeCapsuleLocalDataSource
 import com.emotionstorage.data.dataSource.local.UserLocalDataSource
 import com.emotionstorage.local.dataSourceImpl.AttendanceLocalDataSourceImpl
 import com.emotionstorage.local.dataSourceImpl.FcmLocalDataSourceImpl
+import com.emotionstorage.local.dataSourceImpl.NotificationPermissionDataSourceImpl
 import com.emotionstorage.local.dataSourceImpl.SessionLocalDataSourceImpl
 import com.emotionstorage.local.dataSourceImpl.TimeCapsuleLocalDataSourceImpl
 import com.emotionstorage.local.dataSourceImpl.UserLocalDataSourceImpl
@@ -38,4 +40,10 @@ abstract class LocalDataSourceModule {
     @Binds
     @Singleton
     abstract fun bindTimeCapsuleLocalDataSource(impl: TimeCapsuleLocalDataSourceImpl): TimeCapsuleLocalDataSource
+
+    @Binds
+    @Singleton
+    abstract fun bindNotificationPermissionDataSource(
+        impl: NotificationPermissionDataSourceImpl,
+    ): NotificationPermissionDataSource
 }

--- a/core/presentation/src/main/java/com/emotionstorage/presentation/notification/NotificationPermissionGateViewModel.kt
+++ b/core/presentation/src/main/java/com/emotionstorage/presentation/notification/NotificationPermissionGateViewModel.kt
@@ -31,13 +31,15 @@ class NotificationPermissionGateViewModel @Inject constructor(
 
     fun syncFromSystem(canPostNotifications: Boolean) {
         viewModelScope.launch {
-            updateStatus(
-                if (canPostNotifications) {
-                    NotificationPermissionStatus.Granted
-                } else {
-                    NotificationPermissionStatus.Denied
-                },
-            )
+            val nextStatus = if (canPostNotifications) {
+                NotificationPermissionStatus.Granted
+            } else {
+                when (info.value.status) {
+                    NotificationPermissionStatus.DeniedAlways -> NotificationPermissionStatus.DeniedAlways
+                    else -> NotificationPermissionStatus.Denied
+                }
+            }
+            updateStatus(nextStatus)
         }
     }
 

--- a/core/presentation/src/main/java/com/emotionstorage/presentation/notification/NotificationPermissionGateViewModel.kt
+++ b/core/presentation/src/main/java/com/emotionstorage/presentation/notification/NotificationPermissionGateViewModel.kt
@@ -1,0 +1,63 @@
+package com.emotionstorage.presentation.notification
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.emotionstorage.domain.model.NotificationPermissionInfo
+import com.emotionstorage.domain.model.NotificationPermissionStatus
+import com.emotionstorage.domain.useCase.notification.ObserveNotificationPermissionInfoUseCase
+import com.emotionstorage.domain.useCase.notification.SetNotificationPermissionPromptedUseCase
+import com.emotionstorage.domain.useCase.notification.UpdateNotificationPermissionInfoUseCase
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.flow.SharingStarted
+import kotlinx.coroutines.flow.stateIn
+import kotlinx.coroutines.launch
+import javax.inject.Inject
+
+@HiltViewModel
+class NotificationPermissionGateViewModel @Inject constructor(
+    observeInfo: ObserveNotificationPermissionInfoUseCase,
+    private val updateStatus: UpdateNotificationPermissionInfoUseCase,
+    private val setPrompted: SetNotificationPermissionPromptedUseCase,
+) : ViewModel() {
+    val info =
+        observeInfo().stateIn(
+            viewModelScope,
+            SharingStarted.WhileSubscribed(5_000),
+            NotificationPermissionInfo(
+                status = NotificationPermissionStatus.Unknown,
+                hasPrompted = false,
+            ),
+        )
+
+    fun syncFromSystem(canPostNotifications: Boolean) {
+        viewModelScope.launch {
+            updateStatus(
+                if (canPostNotifications) {
+                    NotificationPermissionStatus.Granted
+                } else {
+                    NotificationPermissionStatus.Denied
+                },
+            )
+        }
+    }
+
+    fun markPrompted() {
+        viewModelScope.launch { setPrompted(true) }
+    }
+
+    fun onPermissionResult(
+        granted: Boolean,
+        showRationale: Boolean,
+    ) {
+        val status =
+            when {
+                granted -> NotificationPermissionStatus.Granted
+                !showRationale -> NotificationPermissionStatus.DeniedAlways
+                else -> NotificationPermissionStatus.Denied
+            }
+        viewModelScope.launch {
+            updateStatus(status)
+            setPrompted(true)
+        }
+    }
+}

--- a/core/presentation/src/main/java/com/emotionstorage/presentation/notification/NotificationPermissionGateViewModel.kt
+++ b/core/presentation/src/main/java/com/emotionstorage/presentation/notification/NotificationPermissionGateViewModel.kt
@@ -31,14 +31,15 @@ class NotificationPermissionGateViewModel @Inject constructor(
 
     fun syncFromSystem(canPostNotifications: Boolean) {
         viewModelScope.launch {
-            val nextStatus = if (canPostNotifications) {
-                NotificationPermissionStatus.Granted
-            } else {
-                when (info.value.status) {
-                    NotificationPermissionStatus.DeniedAlways -> NotificationPermissionStatus.DeniedAlways
-                    else -> NotificationPermissionStatus.Denied
+            val nextStatus =
+                if (canPostNotifications) {
+                    NotificationPermissionStatus.Granted
+                } else {
+                    when (info.value.status) {
+                        NotificationPermissionStatus.DeniedAlways -> NotificationPermissionStatus.DeniedAlways
+                        else -> NotificationPermissionStatus.Denied
+                    }
                 }
-            }
             updateStatus(nextStatus)
         }
     }

--- a/data/src/main/java/com/emotionstorage/data/dataSource/local/NotificationPermissionDataSource.kt
+++ b/data/src/main/java/com/emotionstorage/data/dataSource/local/NotificationPermissionDataSource.kt
@@ -1,0 +1,12 @@
+package com.emotionstorage.data.dataSource.local
+
+import com.emotionstorage.domain.model.NotificationPermissionInfo
+import com.emotionstorage.domain.model.NotificationPermissionStatus
+
+interface NotificationPermissionDataSource {
+    fun observeInfo(): kotlinx.coroutines.flow.Flow<NotificationPermissionInfo>
+
+    suspend fun updateStatus(status: NotificationPermissionStatus)
+
+    suspend fun setPrompted(value: Boolean)
+}

--- a/data/src/main/java/com/emotionstorage/data/di/RepositoryModule.kt
+++ b/data/src/main/java/com/emotionstorage/data/di/RepositoryModule.kt
@@ -6,6 +6,7 @@ import com.emotionstorage.data.repoImpl.HomeRepositoryImpl
 import com.emotionstorage.data.repoImpl.DailyReportRepositoryImpl
 import com.emotionstorage.data.repoImpl.FcmRepositoryImpl
 import com.emotionstorage.data.repoImpl.MyPageRepositoryImpl
+import com.emotionstorage.data.repoImpl.NotificationPermissionRepositoryImpl
 import com.emotionstorage.data.repoImpl.NotificationSettingsRepositoryImpl
 import com.emotionstorage.data.repoImpl.SessionRepositoryImpl
 import com.emotionstorage.data.repoImpl.TimeCapsuleRepositoryImpl
@@ -16,6 +17,7 @@ import com.emotionstorage.domain.repo.DailyReportRepository
 import com.emotionstorage.domain.repo.FcmRepository
 import com.emotionstorage.domain.repo.HomeRepository
 import com.emotionstorage.domain.repo.MyPageRepository
+import com.emotionstorage.domain.repo.NotificationPermissionRepository
 import com.emotionstorage.domain.repo.NotificationSettingRepository
 import com.emotionstorage.domain.repo.SessionRepository
 import com.emotionstorage.domain.repo.TimeCapsuleRepository
@@ -70,4 +72,10 @@ abstract class RepositoryModule {
     abstract fun bindNotificationSettingRepository(
         impl: NotificationSettingsRepositoryImpl,
     ): NotificationSettingRepository
+
+    @Binds
+    @Singleton
+    abstract fun bindNotificationPermissionRepository(
+        impl: NotificationPermissionRepositoryImpl,
+    ): NotificationPermissionRepository
 }

--- a/data/src/main/java/com/emotionstorage/data/repoImpl/NotificationPermissionRepositoryImpl.kt
+++ b/data/src/main/java/com/emotionstorage/data/repoImpl/NotificationPermissionRepositoryImpl.kt
@@ -1,0 +1,16 @@
+package com.emotionstorage.data.repoImpl
+
+import com.emotionstorage.data.dataSource.local.NotificationPermissionDataSource
+import com.emotionstorage.domain.model.NotificationPermissionStatus
+import com.emotionstorage.domain.repo.NotificationPermissionRepository
+import javax.inject.Inject
+
+class NotificationPermissionRepositoryImpl @Inject constructor(
+    private val datsSource: NotificationPermissionDataSource,
+) : NotificationPermissionRepository {
+    override fun observeInfo() = datsSource.observeInfo()
+
+    override suspend fun updateStatus(status: NotificationPermissionStatus) = datsSource.updateStatus(status)
+
+    override suspend fun setPrompted(value: Boolean) = datsSource.setPrompted(value)
+}

--- a/domain/src/main/java/com/emotionstorage/domain/model/NotificationPermissionInfo.kt
+++ b/domain/src/main/java/com/emotionstorage/domain/model/NotificationPermissionInfo.kt
@@ -1,0 +1,13 @@
+package com.emotionstorage.domain.model
+
+enum class NotificationPermissionStatus {
+    Unknown,
+    Granted,
+    Denied,
+    DeniedAlways,
+}
+
+data class NotificationPermissionInfo(
+    val status: NotificationPermissionStatus,
+    val hasPrompted: Boolean,
+)

--- a/domain/src/main/java/com/emotionstorage/domain/repo/NotificationPermissionRepository.kt
+++ b/domain/src/main/java/com/emotionstorage/domain/repo/NotificationPermissionRepository.kt
@@ -1,0 +1,13 @@
+package com.emotionstorage.domain.repo
+
+import com.emotionstorage.domain.model.NotificationPermissionInfo
+import com.emotionstorage.domain.model.NotificationPermissionStatus
+import kotlinx.coroutines.flow.Flow
+
+interface NotificationPermissionRepository {
+    fun observeInfo(): Flow<NotificationPermissionInfo>
+
+    suspend fun updateStatus(status: NotificationPermissionStatus)
+
+    suspend fun setPrompted(value: Boolean)
+}

--- a/domain/src/main/java/com/emotionstorage/domain/useCase/notification/ObserveNotificationPermissionInfoUseCase.kt
+++ b/domain/src/main/java/com/emotionstorage/domain/useCase/notification/ObserveNotificationPermissionInfoUseCase.kt
@@ -1,0 +1,10 @@
+package com.emotionstorage.domain.useCase.notification
+
+import com.emotionstorage.domain.repo.NotificationPermissionRepository
+import javax.inject.Inject
+
+class ObserveNotificationPermissionInfoUseCase @Inject constructor(
+    private val repository: NotificationPermissionRepository,
+) {
+    operator fun invoke() = repository.observeInfo()
+}

--- a/domain/src/main/java/com/emotionstorage/domain/useCase/notification/SetNotificationPermissionPromptedUseCase.kt
+++ b/domain/src/main/java/com/emotionstorage/domain/useCase/notification/SetNotificationPermissionPromptedUseCase.kt
@@ -1,0 +1,10 @@
+package com.emotionstorage.domain.useCase.notification
+
+import com.emotionstorage.domain.repo.NotificationPermissionRepository
+import javax.inject.Inject
+
+class SetNotificationPermissionPromptedUseCase @Inject constructor(
+    private val repository: NotificationPermissionRepository,
+) {
+    suspend operator fun invoke(value: Boolean) = repository.setPrompted(value)
+}

--- a/domain/src/main/java/com/emotionstorage/domain/useCase/notification/UpdateNotificationPermissionInfoUseCase.kt
+++ b/domain/src/main/java/com/emotionstorage/domain/useCase/notification/UpdateNotificationPermissionInfoUseCase.kt
@@ -1,0 +1,11 @@
+package com.emotionstorage.domain.useCase.notification
+
+import com.emotionstorage.domain.model.NotificationPermissionStatus
+import com.emotionstorage.domain.repo.NotificationPermissionRepository
+import javax.inject.Inject
+
+class UpdateNotificationPermissionInfoUseCase @Inject constructor(
+    private val repository: NotificationPermissionRepository,
+) {
+    suspend operator fun invoke(status: NotificationPermissionStatus) = repository.updateStatus(status)
+}

--- a/feat/home/src/main/java/com/emotionstorage/home/ui/HomeScreen.kt
+++ b/feat/home/src/main/java/com/emotionstorage/home/ui/HomeScreen.kt
@@ -1,7 +1,5 @@
 package com.emotionstorage.home.ui
 
-import android.Manifest
-import android.os.Build
 import android.view.Gravity
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
@@ -48,13 +46,13 @@ import com.emotionstorage.home.presentation.HomeSideEffect
 import com.emotionstorage.home.presentation.HomeState
 import com.emotionstorage.home.presentation.HomeViewModel
 import com.emotionstorage.home.ui.component.AttendanceRewardDialog
+import com.emotionstorage.home.ui.component.NotificationPermissionAutoRequest
 import com.emotionstorage.ui.R
 import com.emotionstorage.ui.component.IconWithCount
 import com.emotionstorage.ui.component.button.CtaButton
 import com.emotionstorage.ui.component.loading.LoadingOverlay
 import com.emotionstorage.ui.component.toast.AppSnackbarHost
 import com.emotionstorage.ui.theme.MooiTheme
-import com.emotionstorage.ui.util.RequestPermission
 import com.emotionstorage.presentation.BaseSideEffect
 
 @Composable
@@ -74,6 +72,8 @@ fun HomeScreen(
     val state = viewModel.container.stateFlow.collectAsState()
     val attendanceState = attendanceViewModel.uiState
     val snackbarState = remember { SnackbarHostState() }
+
+    NotificationPermissionAutoRequest()
 
     LaunchedEffect("init") {
         // load attendance state
@@ -113,12 +113,6 @@ fun HomeScreen(
         // init screen state on resume
         viewModel.onAction(HomeAction.Initiate)
         onPauseOrDispose {}
-    }
-
-    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
-        RequestPermission(
-            permission = Manifest.permission.POST_NOTIFICATIONS,
-        )
     }
 
     StatelessHomeScreen(

--- a/feat/home/src/main/java/com/emotionstorage/home/ui/component/NotificationPermissionAutoRequest.kt
+++ b/feat/home/src/main/java/com/emotionstorage/home/ui/component/NotificationPermissionAutoRequest.kt
@@ -1,0 +1,36 @@
+package com.emotionstorage.home.ui.component
+
+import android.Manifest
+import android.os.Build
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.hilt.navigation.compose.hiltViewModel
+import com.emotionstorage.domain.model.NotificationPermissionStatus
+import com.emotionstorage.presentation.notification.NotificationPermissionGateViewModel
+import com.emotionstorage.ui.util.RequestPermission
+import com.emotionstorage.ui.util.RequestPermissionEvent
+
+@Composable
+fun NotificationPermissionAutoRequest(
+    onEvent: RequestPermissionEvent = RequestPermissionEvent.ON_START,
+    viewModel: NotificationPermissionGateViewModel = hiltViewModel(),
+) {
+    if (Build.VERSION.SDK_INT < Build.VERSION_CODES.TIRAMISU) return
+
+    val info by viewModel.info.collectAsState()
+
+    if (info.status != NotificationPermissionStatus.Granted && info.hasPrompted.not()) {
+        LaunchedEffect(Unit) { viewModel.markPrompted() }
+
+        RequestPermission(
+            permission = Manifest.permission.POST_NOTIFICATIONS,
+            onEvent = onEvent,
+            onPermissionGranted = { viewModel.onPermissionResult(true, showRationale = true) },
+            onPermissionDenied = { showRationale ->
+                viewModel.onPermissionResult(false, showRationale)
+            },
+        )
+    }
+}

--- a/feat/my/src/main/java/com/emotionstorage/my/ui/notificationSettings/NotificationSettingScreen.kt
+++ b/feat/my/src/main/java/com/emotionstorage/my/ui/notificationSettings/NotificationSettingScreen.kt
@@ -1,6 +1,8 @@
 package com.emotionstorage.my.ui.notificationSettings
 
 import android.Manifest
+import android.content.Context
+import android.content.pm.PackageManager
 import android.os.Build
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Box
@@ -17,6 +19,7 @@ import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
 import androidx.compose.material3.rememberModalBottomSheetState
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
@@ -28,20 +31,21 @@ import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.core.app.NotificationManagerCompat
+import androidx.core.content.ContextCompat
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.LifecycleResumeEffect
+import com.emotionstorage.domain.model.NotificationPermissionStatus
 import com.emotionstorage.my.presentation.NotificationSettingState
 import com.emotionstorage.my.presentation.NotificationSettingViewModel
 import com.emotionstorage.my.ui.notificationSettings.component.DayOfWeekSelector
 import com.emotionstorage.my.ui.notificationSettings.component.ReminderTimeComponent
 import com.emotionstorage.my.ui.notificationSettings.component.ToggleRow
 import com.emotionstorage.my.ui.notificationSettings.component.RequestPermissionBottomSheet
+import com.emotionstorage.presentation.notification.NotificationPermissionGateViewModel
 import com.emotionstorage.ui.component.appBar.TopAppBar
 import com.emotionstorage.ui.component.bottomSheet.TimePickerBottomSheet
 import com.emotionstorage.ui.component.loading.LoadingOverlay
 import com.emotionstorage.ui.theme.MooiTheme
-import com.emotionstorage.ui.util.RequestPermission
-import com.emotionstorage.ui.util.RequestPermissionEvent
 import com.orhanobut.logger.Logger
 import java.time.DayOfWeek
 
@@ -51,56 +55,36 @@ enum class Sheet { None, Permission, TimePicker }
 @Composable
 fun NotificationSettingScreen(
     viewModel: NotificationSettingViewModel = hiltViewModel(),
+    permissionGateViewModel: NotificationPermissionGateViewModel = hiltViewModel(),
     navToBack: () -> Unit,
 ) {
     val context = LocalContext.current
     val state = viewModel.state.collectAsState()
-    var activeSheet by remember {
-        mutableStateOf(Sheet.None)
-    }
+    val permissionInfo by permissionGateViewModel.info.collectAsState()
 
-    var systemEnabled by remember {
-        mutableStateOf(
-            NotificationManagerCompat.from(context).areNotificationsEnabled(),
-        )
-    }
-    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
-        // request run time permission, if build version >= 33
-        RequestPermission(
-            permission = Manifest.permission.POST_NOTIFICATIONS,
-            onEvent = RequestPermissionEvent.ON_START,
-            onPermissionGranted = {
-                Logger.d("Notification permission granted, init settings")
-            },
-            onPermissionDenied = { showRationale ->
-                if (!showRationale) {
-                    Logger.d("Notification permission denied permanently, open permission bottom sheet")
-                    activeSheet = Sheet.Permission
-                }
-            },
-        )
-    } else {
-        if (!systemEnabled) {
-            Logger.d("Notification system permission denied, open permission bottom sheet")
-            activeSheet = Sheet.Permission
-        }
-    }
+    var activeSheet by remember { mutableStateOf(Sheet.None) }
 
-    LifecycleResumeEffect("onResume") {
-        systemEnabled = NotificationManagerCompat.from(context).areNotificationsEnabled()
-        Logger.d("onResume - systemEnabled: $systemEnabled")
-        if (!systemEnabled) {
+    val locallyAllowed = permissionInfo.status == NotificationPermissionStatus.Granted
+
+    LifecycleResumeEffect(Unit) {
+        val canPost = computeCanPostNotifications(context)
+        permissionGateViewModel.syncFromSystem(canPost)
+
+        if (!canPost) {
             viewModel.setAppPush(isOn = false)
-            activeSheet = Sheet.Permission
         }
 
         onPauseOrDispose { }
     }
 
+    LaunchedEffect(locallyAllowed) {
+        activeSheet = if (locallyAllowed) Sheet.None else Sheet.Permission
+    }
+
     StatelessNotificationSettingScreen(
         state = state.value,
         onToggleAppPush = { isOn ->
-            if (systemEnabled) {
+            if (locallyAllowed) {
                 viewModel.setAppPush(isOn)
             } else {
                 activeSheet = Sheet.Permission
@@ -291,6 +275,21 @@ private fun StatelessNotificationSettingScreen(
             }
         }
     }
+}
+
+private fun computeCanPostNotifications(context: Context): Boolean {
+    val systemEnabled = NotificationManagerCompat.from(context).areNotificationsEnabled()
+    val runtimeGranted =
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+            ContextCompat.checkSelfPermission(
+                context,
+                Manifest.permission.POST_NOTIFICATIONS,
+            ) == PackageManager.PERMISSION_GRANTED
+        } else {
+            true
+        }
+
+    return systemEnabled && runtimeGranted
 }
 
 @Preview

--- a/feat/tutorial/src/main/java/com/emotionstorage/tutorial/ui/TutorialScreen.kt
+++ b/feat/tutorial/src/main/java/com/emotionstorage/tutorial/ui/TutorialScreen.kt
@@ -1,7 +1,5 @@
 package com.emotionstorage.tutorial.ui
 
-import android.Manifest
-import android.os.Build
 import androidx.annotation.DrawableRes
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
@@ -31,12 +29,12 @@ import androidx.compose.ui.text.SpanStyle
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.PreviewScreenSizes
 import androidx.compose.ui.unit.dp
+import com.emotionstorage.tutorial.ui.component.NotificationPermissionAutoRequest
 import com.emotionstorage.tutorial.R as tutorialR
 import com.emotionstorage.tutorial.ui.component.PagerWithIndicator
 import com.emotionstorage.ui.R
 import com.emotionstorage.ui.component.button.CtaButton
 import com.emotionstorage.ui.theme.MooiTheme
-import com.emotionstorage.ui.util.RequestPermission
 import com.emotionstorage.ui.util.buildHighlightAnnotatedString
 
 private const val TUTORIAL_PAGE_COUNT = 4
@@ -46,11 +44,7 @@ fun TutorialScreen(
     modifier: Modifier = Modifier,
     navToLogin: () -> Unit = {},
 ) {
-    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
-        RequestPermission(
-            permission = Manifest.permission.POST_NOTIFICATIONS,
-        )
-    }
+    NotificationPermissionAutoRequest()
 
     Scaffold(
         modifier =

--- a/feat/tutorial/src/main/java/com/emotionstorage/tutorial/ui/component/NotificationPermissionAutoRequest.kt
+++ b/feat/tutorial/src/main/java/com/emotionstorage/tutorial/ui/component/NotificationPermissionAutoRequest.kt
@@ -3,7 +3,6 @@ package com.emotionstorage.tutorial.ui.component
 import android.Manifest
 import android.os.Build
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.hilt.navigation.compose.hiltViewModel

--- a/feat/tutorial/src/main/java/com/emotionstorage/tutorial/ui/component/NotificationPermissionAutoRequest.kt
+++ b/feat/tutorial/src/main/java/com/emotionstorage/tutorial/ui/component/NotificationPermissionAutoRequest.kt
@@ -1,0 +1,36 @@
+package com.emotionstorage.tutorial.ui.component
+
+import android.Manifest
+import android.os.Build
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.hilt.navigation.compose.hiltViewModel
+import com.emotionstorage.domain.model.NotificationPermissionStatus
+import com.emotionstorage.presentation.notification.NotificationPermissionGateViewModel
+import com.emotionstorage.ui.util.RequestPermission
+import com.emotionstorage.ui.util.RequestPermissionEvent
+
+@Composable
+fun NotificationPermissionAutoRequest(
+    onEvent: RequestPermissionEvent = RequestPermissionEvent.ON_START,
+    viewModel: NotificationPermissionGateViewModel = hiltViewModel(),
+) {
+    if (Build.VERSION.SDK_INT < Build.VERSION_CODES.TIRAMISU) return
+
+    val info by viewModel.info.collectAsState()
+
+    if (info.status != NotificationPermissionStatus.Granted && info.hasPrompted.not()) {
+        LaunchedEffect(Unit) { viewModel.markPrompted() }
+
+        RequestPermission(
+            permission = Manifest.permission.POST_NOTIFICATIONS,
+            onEvent = onEvent,
+            onPermissionGranted = { viewModel.onPermissionResult(true, showRationale = true) },
+            onPermissionDenied = { showRationale ->
+                viewModel.onPermissionResult(false, showRationale)
+            },
+        )
+    }
+}

--- a/feat/tutorial/src/main/java/com/emotionstorage/tutorial/ui/component/NotificationPermissionAutoRequest.kt
+++ b/feat/tutorial/src/main/java/com/emotionstorage/tutorial/ui/component/NotificationPermissionAutoRequest.kt
@@ -22,8 +22,6 @@ fun NotificationPermissionAutoRequest(
     val info by viewModel.info.collectAsState()
 
     if (info.status != NotificationPermissionStatus.Granted && info.hasPrompted.not()) {
-        LaunchedEffect(Unit) { viewModel.markPrompted() }
-
         RequestPermission(
             permission = Manifest.permission.POST_NOTIFICATIONS,
             onEvent = onEvent,


### PR DESCRIPTION
## Related Issue
- Issue #158 

## 작업 상세 내용
- Local Data Store에 시스템 알림 상태 값 저장
- 튜토리얼 화면, 홈 화면, 알림 설정 화면에서 Local DataStore에 저장된 값에 따라 알림 Pop 및 Bottom Sheet 등장 로직 수정

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 알림 권한 상태를 관찰하고 저장하는 권한 모델·저장소 및 권한 게이트 ViewModel 추가
  * 자동 권한 요청 컴포넌트(NotificationPermissionAutoRequest) 도입 — 튜토리얼·홈 등에서 자동으로 권한 요청

* **리팩토링**
  * 앱 전반의 수동 런타임 권한 흐름을 게이트 기반 자동 요청 방식으로 전환
  * 알림 설정 화면에 권한 게이트 통합 및 흐름 간소화

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->