### PR TITLE
feat: deploy to firebase on dev pr merge

### DIFF
--- a/.github/workflows/android-cd.yml
+++ b/.github/workflows/android-cd.yml
@@ -1,0 +1,43 @@
+name: Deploy to Firebase on Push to develop branch
+
+on:
+    push:
+        branches: [ "develop" ]
+
+jobs:
+    build:
+        name: Building and distributing app
+        runs-on: ubuntu-latest
+        env:
+            MOOI_DEV_SERVER_URL: ${{ secrets.MOOI_DEV_SERVER_URL }}
+            MOOI_REPLY_EMAIL: ${{ secrets.MOOI_REPLY_EMAIL }}
+            GOOGLE_SERVER_CLIENT_ID: ${{ secrets.GOOGLE_SERVER_CLIENT_ID }}
+            KAKAO_NATIVE_APP_KEY: ${{ secrets.KAKAO_NATIVE_APP_KEY }}
+
+        steps:
+            - uses: actions/checkout@v4
+
+            - name: Create Google Services JSON File
+              env:
+                  GOOGLE_SERVICES_JSON: ${{ secrets.GOOGLE_SERVICES_JSON }}
+              run: echo $GOOGLE_SERVICES_JSON | base64 -di > app/google-services.json
+
+            - name: set up JDK 17
+              uses: actions/setup-java@v4
+              with:
+                  distribution: 'temurin'
+                  java-version: '17'
+
+            - name:  Grant execute permission for gradlew
+              run: chmod +x ./gradlew
+            - name:  Build Debug APK only
+              run: ./gradlew assembleDebug
+
+            - name: Upload Artifact to Firebase App Distribution
+              uses: wzieba/Firebase-Distribution-Github-Action@v1
+              with:
+                  appId: ${{ secrets.FIREBASE_APP_ID }}
+                  serviceCredentialsFileContent: ${{ secrets.CREDENTIAL_FILE_CONTENT }}
+                  groups: "testersteam"
+                  file: app/build/outputs/apk/debug/app-debug.apk
+                  releaseNotes: ${{ inputs.release_notes }}

--- a/.github/workflows/android-cd.yml
+++ b/.github/workflows/android-cd.yml
@@ -13,6 +13,7 @@ jobs:
             MOOI_REPLY_EMAIL: ${{ secrets.MOOI_REPLY_EMAIL }}
             GOOGLE_SERVER_CLIENT_ID: ${{ secrets.GOOGLE_SERVER_CLIENT_ID }}
             KAKAO_NATIVE_APP_KEY: ${{ secrets.KAKAO_NATIVE_APP_KEY }}
+            TITLE: ${{ github.event.pull_request.title }}
 
         steps:
             - uses: actions/checkout@v4
@@ -40,4 +41,4 @@ jobs:
                   serviceCredentialsFileContent: ${{ secrets.CREDENTIAL_FILE_CONTENT }}
                   groups: "testersteam"
                   file: app/build/outputs/apk/debug/app-debug.apk
-                  releaseNotes: ${{ inputs.release_notes }}
+                  releaseNotes: $TITLE

--- a/.github/workflows/manual-deploy-to-firebase.yml
+++ b/.github/workflows/manual-deploy-to-firebase.yml
@@ -1,4 +1,4 @@
-name: Deploy to Firebase
+name: Deploy to Firebase on Manual action
 
 on:
   workflow_dispatch:


### PR DESCRIPTION
## 작업 상세 내용
- develop 브랜치에 작업 내용 push 되었을 때, 파이어베이스로 앱 배포 자동화

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **Chores**
  * Android 앱의 빌드 및 Firebase App Distribution으로의 배포를 자동화하는 새로운 GitHub Actions 워크플로우를 추가했습니다(개발 브랜치 푸시 시 빌드 및 업로드).
  * 기존 배포 워크플로우의 이름을 "Deploy to Firebase on Manual action"으로 업데이트했습니다.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->