### PR TITLE
Dev/login error modal 2.1 로그인 화면 로그인 오류 팝업 로직 

### DIFF
--- a/core/ui/src/main/java/com/emotionstorage/ui/component/Modal.kt
+++ b/core/ui/src/main/java/com/emotionstorage/ui/component/Modal.kt
@@ -1,5 +1,6 @@
 package com.emotionstorage.ui.component
 
+import androidx.activity.compose.BackHandler
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
@@ -34,6 +35,7 @@ import com.emotionstorage.ui.util.buildHighlightAnnotatedString
 @Composable
 fun Modal(
     onDismissRequest: () -> Unit,
+    disableBackPress: Boolean = false,
     topDescription: String? = null,
     topDescriptionHighlights: List<String>? = emptyList(),
     title: String? = null,
@@ -49,6 +51,12 @@ fun Modal(
     topOuterContent: @Composable (() -> Unit)? = null,
     content: @Composable (() -> Unit)? = null,
 ) {
+    if(disableBackPress){
+        BackHandler{
+            // do nothing
+        }
+    }
+
     if (showBackground) {
         // set bg color to black with 0.8 alpha (80% opacity)
         Box(

--- a/core/ui/src/main/java/com/emotionstorage/ui/component/Modal.kt
+++ b/core/ui/src/main/java/com/emotionstorage/ui/component/Modal.kt
@@ -51,11 +51,12 @@ fun Modal(
     topOuterContent: @Composable (() -> Unit)? = null,
     content: @Composable (() -> Unit)? = null,
 ) {
-    if(disableBackPress){
-        BackHandler{
-            // do nothing
+    if (disableBackPress)
+        {
+            BackHandler {
+                // do nothing
+            }
         }
-    }
 
     if (showBackground) {
         // set bg color to black with 0.8 alpha (80% opacity)

--- a/core/ui/src/main/java/com/emotionstorage/ui/component/modal/Modal.kt
+++ b/core/ui/src/main/java/com/emotionstorage/ui/component/modal/Modal.kt
@@ -51,12 +51,11 @@ fun Modal(
     topOuterContent: @Composable (() -> Unit)? = null,
     content: @Composable (() -> Unit)? = null,
 ) {
-    if (disableBackPress)
-        {
-            BackHandler {
-                // do nothing
-            }
+    if (disableBackPress) {
+        BackHandler {
+            // do nothing
         }
+    }
 
     if (showBackground) {
         // set bg color to black with 0.8 alpha (80% opacity)

--- a/core/ui/src/main/java/com/emotionstorage/ui/component/modal/Modal.kt
+++ b/core/ui/src/main/java/com/emotionstorage/ui/component/modal/Modal.kt
@@ -1,4 +1,4 @@
-package com.emotionstorage.ui.component
+package com.emotionstorage.ui.component.modal
 
 import androidx.activity.compose.BackHandler
 import androidx.compose.foundation.background

--- a/core/ui/src/main/java/com/emotionstorage/ui/component/modal/TempErrorModal.kt
+++ b/core/ui/src/main/java/com/emotionstorage/ui/component/modal/TempErrorModal.kt
@@ -25,14 +25,12 @@ import androidx.compose.ui.tooling.preview.Preview
  *     - 스크롤 X
  */
 @Composable
-fun TempErrorModal(
-    onDismissRequest: () -> Unit
-) {
+fun TempErrorModal(onDismissRequest: () -> Unit) {
     Modal(
         onDismissRequest = onDismissRequest,
         title = "일시적인 오류가 발생했어요.\n잠시 후 다시 시도해주세요.",
         confirmLabel = "네, 확인했어요.",
-        onConfirm = onDismissRequest
+        onConfirm = onDismissRequest,
     )
 }
 

--- a/core/ui/src/main/java/com/emotionstorage/ui/component/modal/TempErrorModal.kt
+++ b/core/ui/src/main/java/com/emotionstorage/ui/component/modal/TempErrorModal.kt
@@ -1,0 +1,46 @@
+package com.emotionstorage.ui.component.modal
+
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.tooling.preview.Preview
+
+/**
+ * common_error_02
+ * - 표출 조건(트리거)
+ *     - Case : 네트워크 최상위 계층 에러
+ *     최상위 계층까지 오류가 전파되었을 경우 표시
+ *     즉, 본 알럿은 네트워크 오류가 발생했으나 해당 화면에서 별도의 에러 처리가 존재하지 않아 공통 에러 처리 정책이 적용되는 경우에 노출됩니다.
+ *     1. 화면 전용 처리 실패 알럿 (화면별 지정된)
+ *     2. 공통 네트워크 에러 알럿
+ *     중에서 1번 조건에 해당하지 않는 경우 표출합니다.
+ * - CTA 및 이동
+ *     - [네, 확인했어요.] -> 팝업 닫히며 이동 X
+ * - 차단
+ *     - 뒤로가기(Android) O (팝업 닫힘, 화면 제자리)
+ *     - push/pop X
+ *     - 하단바 상호작용 X (하단바 없음)
+ *     - 배경 터치 O (팝업 닫힘, 화면 제자리)
+ *     - 스크롤 X
+ */
+@Composable
+fun TempErrorModal(
+    onDismissRequest: () -> Unit
+) {
+    Modal(
+        onDismissRequest = onDismissRequest,
+        title = "일시적인 오류가 발생했어요.\n잠시 후 다시 시도해주세요.",
+        confirmLabel = "네, 확인했어요.",
+        onConfirm = onDismissRequest
+    )
+}
+
+@Preview(showBackground = true)
+@Composable
+private fun TempErrorModalPreview() {
+    // background ui
+    Box(modifier = Modifier.fillMaxSize())
+
+    TempErrorModal { }
+}

--- a/data/src/main/java/com/emotionstorage/data/repoImpl/AuthRepositoryImpl.kt
+++ b/data/src/main/java/com/emotionstorage/data/repoImpl/AuthRepositoryImpl.kt
@@ -70,17 +70,13 @@ class AuthRepositoryImpl @Inject constructor(
             }
         }
 
-    override suspend fun checkSession(): Flow<DataState<Boolean>> =
-        flow {
-            emit(DataState.Loading(true))
-            try {
-                emit(DataState.Success(authRemoteDataSource.checkSession()))
-            } catch (e: Exception) {
-                emit(DataState.Error(e))
-            } finally {
-                emit(DataState.Loading(false))
-            }
+    override suspend fun checkSession(): DataState<Boolean> =
+        try {
+            DataState.Success(authRemoteDataSource.checkSession())
+        } catch (e: Exception) {
+            DataState.Error(e)
         }
+
 
     override suspend fun logout(): Boolean = authRemoteDataSource.logout()
 

--- a/data/src/main/java/com/emotionstorage/data/repoImpl/AuthRepositoryImpl.kt
+++ b/data/src/main/java/com/emotionstorage/data/repoImpl/AuthRepositoryImpl.kt
@@ -77,7 +77,6 @@ class AuthRepositoryImpl @Inject constructor(
             DataState.Error(e)
         }
 
-
     override suspend fun logout(): Boolean = authRemoteDataSource.logout()
 
     override suspend fun deleteAccount(): Boolean = authRemoteDataSource.deleteAccount()

--- a/data/src/main/java/com/emotionstorage/data/repoImpl/AuthRepositoryImpl.kt
+++ b/data/src/main/java/com/emotionstorage/data/repoImpl/AuthRepositoryImpl.kt
@@ -5,8 +5,10 @@ import com.emotionstorage.data.dataSource.remote.GoogleRemoteDataSource
 import com.emotionstorage.data.dataSource.remote.KakaoRemoteDataSource
 import com.emotionstorage.data.modelMapper.SignupFormMapper
 import com.emotionstorage.domain.common.DataState
+import com.emotionstorage.domain.common.ErrorCode
 import com.emotionstorage.domain.model.SignupForm
 import com.emotionstorage.domain.model.User
+import com.emotionstorage.domain.model.User.AuthProvider
 import com.emotionstorage.domain.repo.AuthRepository
 import io.github.aakira.napier.Napier
 import kotlinx.coroutines.flow.Flow
@@ -23,18 +25,24 @@ class AuthRepositoryImpl @Inject constructor(
             // get id token from providers
             val idToken =
                 when (provider) {
-                    User.AuthProvider.KAKAO -> kakaoRemoteDataSource.getIdToken()
-                    User.AuthProvider.GOOGLE -> googleRemoteDataSource.getIdToken()
+                    AuthProvider.KAKAO -> kakaoRemoteDataSource.getIdToken()
+                    AuthProvider.GOOGLE -> googleRemoteDataSource.getIdToken()
                 }
             Napier.d("GetIdToken success, provider: $provider, idToken: ${idToken.take(6) + "..."}")
 
             loginWithIdToken(provider, idToken)
         } catch (e: Exception) {
-            DataState.Error(Throwable("failed to get social id token, $e"))
+            DataState.Error(
+                e,
+                when (provider) {
+                    AuthProvider.GOOGLE -> ErrorCode.INVALID_ID_TOKEN
+                    AuthProvider.KAKAO -> ErrorCode.INVALID_KAKAO_ACCESS_TOKEN
+                },
+            )
         }
 
     override suspend fun loginWithIdToken(
-        provider: User.AuthProvider,
+        provider: AuthProvider,
         idToken: String,
     ): DataState<String> =
         try {

--- a/data/src/main/java/com/emotionstorage/data/repoImpl/UserRepositoryImpl.kt
+++ b/data/src/main/java/com/emotionstorage/data/repoImpl/UserRepositoryImpl.kt
@@ -13,56 +13,72 @@ import kotlinx.coroutines.flow.flow
 import javax.inject.Inject
 
 class UserRepositoryImpl
-    @Inject
-    constructor(
-        private val localDataSource: UserLocalDataSource,
-        private val remoteDataSource: UserRemoteDataSource,
-    ) : UserRepository {
-        override suspend fun saveUser(user: User): Boolean = localDataSource.saveUser(UserMapper.toData(user))
+@Inject
+constructor(
+    private val localDataSource: UserLocalDataSource,
+    private val remoteDataSource: UserRemoteDataSource,
+) : UserRepository {
+    override suspend fun saveUser(user: User): Boolean = localDataSource.saveUser(UserMapper.toData(user))
 
-        override suspend fun getUser(): Flow<DataState<User>> =
-            flow {
-                emit(DataState.Loading(isLoading = true))
-                try {
-                    // return user from local data source first
-                    val localUser = localDataSource.getUser()
-                    if (localUser != null) {
-                        emit(DataState.Success(UserMapper.toDomain(localUser)))
-                    } else {
-                        // fetch user from remote & save to local & return
-                        remoteDataSource.getUserAccountInfo().handle(
-                            onSuccess = {
-                                localDataSource.saveUser(UserMapper.toData(it.toUser()))
-                                emit(DataState.Success(it.toUser()))
-                            },
-                            onError = { throwable, code, message ->
-                                emit(DataState.Error(throwable, code, message))
-                            },
-                        )
+    override suspend fun getUser(): Flow<DataState<User>> =
+        flow {
+            emit(DataState.Loading(isLoading = true))
+            try {
+                // return user from local data source first
+                val localUser = localDataSource.getUser()
+                if (localUser != null) {
+                    emit(DataState.Success(UserMapper.toDomain(localUser)))
+                } else {
+                    // fetch user from remote & save to local & return
+                    remoteDataSource.getUserAccountInfo().handle(
+                        onSuccess = {
+                            localDataSource.saveUser(UserMapper.toData(it.toUser()))
+                            emit(DataState.Success(it.toUser()))
+                        },
+                        onError = { throwable, code, message ->
+                            emit(DataState.Error(throwable, code, message))
+                        },
+                    )
+                }
+            } catch (e: Exception) {
+                emit(DataState.Error(e))
+            } finally {
+                emit(DataState.Loading(isLoading = false))
+            }
+        }
+
+    override suspend fun getAndSaveUser(): Boolean =
+        try {
+            remoteDataSource.getUserAccountInfo().handle(
+                onSuccess = {
+                    localDataSource.saveUser(UserMapper.toData(it.toUser()))
+                },
+                onError = { throwable, code, message ->
+                    false
+                },
+            )
+            true
+        } catch (e: Exception) {
+            false
+        }
+
+
+    override suspend fun deleteUser(): Boolean = localDataSource.deleteUser()
+
+    override suspend fun updateUserNickname(nickname: String) =
+        remoteDataSource
+            .updateUserNickname(nickname)
+            .also { state ->
+                if (state is DataState.Success) {
+                    val localUpdateSuccess = localDataSource.updateUserNickname(nickname)
+                    if (!localUpdateSuccess) {
+                        // delete user on update error - fetch user on next get user call
+                        deleteUser()
                     }
-                } catch (e: Exception) {
-                    emit(DataState.Error(e))
-                } finally {
-                    emit(DataState.Loading(isLoading = false))
                 }
             }
 
-        override suspend fun deleteUser(): Boolean = localDataSource.deleteUser()
+    override suspend fun getKeyCount(): DataState<Int> = remoteDataSource.getKeyCount()
 
-        override suspend fun updateUserNickname(nickname: String) =
-            remoteDataSource
-                .updateUserNickname(nickname)
-                .also { state ->
-                    if (state is DataState.Success) {
-                        val localUpdateSuccess = localDataSource.updateUserNickname(nickname)
-                        if (!localUpdateSuccess) {
-                            // delete user on update error - fetch user on next get user call
-                            deleteUser()
-                        }
-                    }
-                }
-
-        override suspend fun getKeyCount(): DataState<Int> = remoteDataSource.getKeyCount()
-
-        override suspend fun getAccountInfo(): DataState<AccountInfo> = remoteDataSource.getUserAccountInfo()
-    }
+    override suspend fun getAccountInfo(): DataState<AccountInfo> = remoteDataSource.getUserAccountInfo()
+}

--- a/data/src/main/java/com/emotionstorage/data/repoImpl/UserRepositoryImpl.kt
+++ b/data/src/main/java/com/emotionstorage/data/repoImpl/UserRepositoryImpl.kt
@@ -14,70 +14,70 @@ import kotlinx.coroutines.flow.flow
 import javax.inject.Inject
 
 class UserRepositoryImpl
-@Inject
-constructor(
-    private val localDataSource: UserLocalDataSource,
-    private val remoteDataSource: UserRemoteDataSource,
-) : UserRepository {
-    override suspend fun saveUser(user: User): Boolean = localDataSource.saveUser(UserMapper.toData(user))
+    @Inject
+    constructor(
+        private val localDataSource: UserLocalDataSource,
+        private val remoteDataSource: UserRemoteDataSource,
+    ) : UserRepository {
+        override suspend fun saveUser(user: User): Boolean = localDataSource.saveUser(UserMapper.toData(user))
 
-    override suspend fun getUser(): Flow<DataState<User>> =
-        flow {
-            emit(DataState.Loading(isLoading = true))
+        override suspend fun getUser(): Flow<DataState<User>> =
+            flow {
+                emit(DataState.Loading(isLoading = true))
+                try {
+                    // return user from local data source first
+                    val localUser = localDataSource.getUser()
+                    if (localUser != null) {
+                        emit(DataState.Success(UserMapper.toDomain(localUser)))
+                    } else {
+                        // fetch user from remote & save to local & return
+                        remoteDataSource.getUserAccountInfo().handle(
+                            onSuccess = {
+                                localDataSource.saveUser(UserMapper.toData(it.toUser()))
+                                emit(DataState.Success(it.toUser()))
+                            },
+                            onError = { throwable, code, message ->
+                                emit(DataState.Error(throwable, code, message))
+                            },
+                        )
+                    }
+                } catch (e: Exception) {
+                    emit(DataState.Error(e))
+                } finally {
+                    emit(DataState.Loading(isLoading = false))
+                }
+            }
+
+        override suspend fun getAndSaveUser(): Boolean =
             try {
-                // return user from local data source first
-                val localUser = localDataSource.getUser()
-                if (localUser != null) {
-                    emit(DataState.Success(UserMapper.toDomain(localUser)))
+                val result = remoteDataSource.getUserAccountInfo()
+                if (result is DataState.Success) {
+                    localDataSource.saveUser(UserMapper.toData(result.data.toUser()))
+                    true
                 } else {
-                    // fetch user from remote & save to local & return
-                    remoteDataSource.getUserAccountInfo().handle(
-                        onSuccess = {
-                            localDataSource.saveUser(UserMapper.toData(it.toUser()))
-                            emit(DataState.Success(it.toUser()))
-                        },
-                        onError = { throwable, code, message ->
-                            emit(DataState.Error(throwable, code, message))
-                        },
-                    )
+                    false
                 }
             } catch (e: Exception) {
-                emit(DataState.Error(e))
-            } finally {
-                emit(DataState.Loading(isLoading = false))
-            }
-        }
-
-    override suspend fun getAndSaveUser(): Boolean =
-        try {
-            val result = remoteDataSource.getUserAccountInfo()
-            if (result is DataState.Success) {
-                localDataSource.saveUser(UserMapper.toData(result.data.toUser()))
-                true
-            } else {
+                Napier.e("getAndSaveUser error", e)
                 false
             }
-        } catch (e: Exception) {
-            Napier.e("getAndSaveUser error", e)
-            false
-        }
 
-    override suspend fun deleteUser(): Boolean = localDataSource.deleteUser()
+        override suspend fun deleteUser(): Boolean = localDataSource.deleteUser()
 
-    override suspend fun updateUserNickname(nickname: String) =
-        remoteDataSource
-            .updateUserNickname(nickname)
-            .also { state ->
-                if (state is DataState.Success) {
-                    val localUpdateSuccess = localDataSource.updateUserNickname(nickname)
-                    if (!localUpdateSuccess) {
-                        // delete user on update error - fetch user on next get user call
-                        deleteUser()
+        override suspend fun updateUserNickname(nickname: String) =
+            remoteDataSource
+                .updateUserNickname(nickname)
+                .also { state ->
+                    if (state is DataState.Success) {
+                        val localUpdateSuccess = localDataSource.updateUserNickname(nickname)
+                        if (!localUpdateSuccess) {
+                            // delete user on update error - fetch user on next get user call
+                            deleteUser()
+                        }
                     }
                 }
-            }
 
-    override suspend fun getKeyCount(): DataState<Int> = remoteDataSource.getKeyCount()
+        override suspend fun getKeyCount(): DataState<Int> = remoteDataSource.getKeyCount()
 
-    override suspend fun getAccountInfo(): DataState<AccountInfo> = remoteDataSource.getUserAccountInfo()
-}
+        override suspend fun getAccountInfo(): DataState<AccountInfo> = remoteDataSource.getUserAccountInfo()
+    }

--- a/data/src/main/java/com/emotionstorage/data/repoImpl/UserRepositoryImpl.kt
+++ b/data/src/main/java/com/emotionstorage/data/repoImpl/UserRepositoryImpl.kt
@@ -53,7 +53,6 @@ class UserRepositoryImpl
                 val result = remoteDataSource.getUserAccountInfo()
                 if (result is DataState.Success) {
                     localDataSource.saveUser(UserMapper.toData(result.data.toUser()))
-                    true
                 } else {
                     false
                 }

--- a/data/src/main/java/com/emotionstorage/data/repoImpl/UserRepositoryImpl.kt
+++ b/data/src/main/java/com/emotionstorage/data/repoImpl/UserRepositoryImpl.kt
@@ -13,72 +13,71 @@ import kotlinx.coroutines.flow.flow
 import javax.inject.Inject
 
 class UserRepositoryImpl
-@Inject
-constructor(
-    private val localDataSource: UserLocalDataSource,
-    private val remoteDataSource: UserRemoteDataSource,
-) : UserRepository {
-    override suspend fun saveUser(user: User): Boolean = localDataSource.saveUser(UserMapper.toData(user))
+    @Inject
+    constructor(
+        private val localDataSource: UserLocalDataSource,
+        private val remoteDataSource: UserRemoteDataSource,
+    ) : UserRepository {
+        override suspend fun saveUser(user: User): Boolean = localDataSource.saveUser(UserMapper.toData(user))
 
-    override suspend fun getUser(): Flow<DataState<User>> =
-        flow {
-            emit(DataState.Loading(isLoading = true))
-            try {
-                // return user from local data source first
-                val localUser = localDataSource.getUser()
-                if (localUser != null) {
-                    emit(DataState.Success(UserMapper.toDomain(localUser)))
-                } else {
-                    // fetch user from remote & save to local & return
-                    remoteDataSource.getUserAccountInfo().handle(
-                        onSuccess = {
-                            localDataSource.saveUser(UserMapper.toData(it.toUser()))
-                            emit(DataState.Success(it.toUser()))
-                        },
-                        onError = { throwable, code, message ->
-                            emit(DataState.Error(throwable, code, message))
-                        },
-                    )
+        override suspend fun getUser(): Flow<DataState<User>> =
+            flow {
+                emit(DataState.Loading(isLoading = true))
+                try {
+                    // return user from local data source first
+                    val localUser = localDataSource.getUser()
+                    if (localUser != null) {
+                        emit(DataState.Success(UserMapper.toDomain(localUser)))
+                    } else {
+                        // fetch user from remote & save to local & return
+                        remoteDataSource.getUserAccountInfo().handle(
+                            onSuccess = {
+                                localDataSource.saveUser(UserMapper.toData(it.toUser()))
+                                emit(DataState.Success(it.toUser()))
+                            },
+                            onError = { throwable, code, message ->
+                                emit(DataState.Error(throwable, code, message))
+                            },
+                        )
+                    }
+                } catch (e: Exception) {
+                    emit(DataState.Error(e))
+                } finally {
+                    emit(DataState.Loading(isLoading = false))
                 }
-            } catch (e: Exception) {
-                emit(DataState.Error(e))
-            } finally {
-                emit(DataState.Loading(isLoading = false))
             }
-        }
 
-    override suspend fun getAndSaveUser(): Boolean =
-        try {
-            remoteDataSource.getUserAccountInfo().handle(
-                onSuccess = {
-                    localDataSource.saveUser(UserMapper.toData(it.toUser()))
-                },
-                onError = { throwable, code, message ->
-                    false
-                },
-            )
-            true
-        } catch (e: Exception) {
-            false
-        }
+        override suspend fun getAndSaveUser(): Boolean =
+            try {
+                remoteDataSource.getUserAccountInfo().handle(
+                    onSuccess = {
+                        localDataSource.saveUser(UserMapper.toData(it.toUser()))
+                    },
+                    onError = { throwable, code, message ->
+                        false
+                    },
+                )
+                true
+            } catch (e: Exception) {
+                false
+            }
 
+        override suspend fun deleteUser(): Boolean = localDataSource.deleteUser()
 
-    override suspend fun deleteUser(): Boolean = localDataSource.deleteUser()
-
-    override suspend fun updateUserNickname(nickname: String) =
-        remoteDataSource
-            .updateUserNickname(nickname)
-            .also { state ->
-                if (state is DataState.Success) {
-                    val localUpdateSuccess = localDataSource.updateUserNickname(nickname)
-                    if (!localUpdateSuccess) {
-                        // delete user on update error - fetch user on next get user call
-                        deleteUser()
+        override suspend fun updateUserNickname(nickname: String) =
+            remoteDataSource
+                .updateUserNickname(nickname)
+                .also { state ->
+                    if (state is DataState.Success) {
+                        val localUpdateSuccess = localDataSource.updateUserNickname(nickname)
+                        if (!localUpdateSuccess) {
+                            // delete user on update error - fetch user on next get user call
+                            deleteUser()
+                        }
                     }
                 }
-            }
 
-    override suspend fun getKeyCount(): DataState<Int> = remoteDataSource.getKeyCount()
+        override suspend fun getKeyCount(): DataState<Int> = remoteDataSource.getKeyCount()
 
-    override suspend fun getAccountInfo(): DataState<AccountInfo> = remoteDataSource.getUserAccountInfo()
-}
+        override suspend fun getAccountInfo(): DataState<AccountInfo> = remoteDataSource.getUserAccountInfo()
+    }

--- a/data/src/main/java/com/emotionstorage/data/repoImpl/UserRepositoryImpl.kt
+++ b/data/src/main/java/com/emotionstorage/data/repoImpl/UserRepositoryImpl.kt
@@ -8,76 +8,76 @@ import com.emotionstorage.domain.model.AccountInfo
 import com.emotionstorage.domain.model.User
 import com.emotionstorage.domain.model.toUser
 import com.emotionstorage.domain.repo.UserRepository
+import io.github.aakira.napier.Napier
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.flow
 import javax.inject.Inject
 
 class UserRepositoryImpl
-    @Inject
-    constructor(
-        private val localDataSource: UserLocalDataSource,
-        private val remoteDataSource: UserRemoteDataSource,
-    ) : UserRepository {
-        override suspend fun saveUser(user: User): Boolean = localDataSource.saveUser(UserMapper.toData(user))
+@Inject
+constructor(
+    private val localDataSource: UserLocalDataSource,
+    private val remoteDataSource: UserRemoteDataSource,
+) : UserRepository {
+    override suspend fun saveUser(user: User): Boolean = localDataSource.saveUser(UserMapper.toData(user))
 
-        override suspend fun getUser(): Flow<DataState<User>> =
-            flow {
-                emit(DataState.Loading(isLoading = true))
-                try {
-                    // return user from local data source first
-                    val localUser = localDataSource.getUser()
-                    if (localUser != null) {
-                        emit(DataState.Success(UserMapper.toDomain(localUser)))
-                    } else {
-                        // fetch user from remote & save to local & return
-                        remoteDataSource.getUserAccountInfo().handle(
-                            onSuccess = {
-                                localDataSource.saveUser(UserMapper.toData(it.toUser()))
-                                emit(DataState.Success(it.toUser()))
-                            },
-                            onError = { throwable, code, message ->
-                                emit(DataState.Error(throwable, code, message))
-                            },
-                        )
-                    }
-                } catch (e: Exception) {
-                    emit(DataState.Error(e))
-                } finally {
-                    emit(DataState.Loading(isLoading = false))
-                }
-            }
-
-        override suspend fun getAndSaveUser(): Boolean =
+    override suspend fun getUser(): Flow<DataState<User>> =
+        flow {
+            emit(DataState.Loading(isLoading = true))
             try {
-                remoteDataSource.getUserAccountInfo().handle(
-                    onSuccess = {
-                        localDataSource.saveUser(UserMapper.toData(it.toUser()))
-                    },
-                    onError = { throwable, code, message ->
-                        false
-                    },
-                )
-                true
+                // return user from local data source first
+                val localUser = localDataSource.getUser()
+                if (localUser != null) {
+                    emit(DataState.Success(UserMapper.toDomain(localUser)))
+                } else {
+                    // fetch user from remote & save to local & return
+                    remoteDataSource.getUserAccountInfo().handle(
+                        onSuccess = {
+                            localDataSource.saveUser(UserMapper.toData(it.toUser()))
+                            emit(DataState.Success(it.toUser()))
+                        },
+                        onError = { throwable, code, message ->
+                            emit(DataState.Error(throwable, code, message))
+                        },
+                    )
+                }
             } catch (e: Exception) {
+                emit(DataState.Error(e))
+            } finally {
+                emit(DataState.Loading(isLoading = false))
+            }
+        }
+
+    override suspend fun getAndSaveUser(): Boolean =
+        try {
+            val result = remoteDataSource.getUserAccountInfo()
+            if (result is DataState.Success) {
+                localDataSource.saveUser(UserMapper.toData(result.data.toUser()))
+                true
+            } else {
                 false
             }
+        } catch (e: Exception) {
+            Napier.e("getAndSaveUser error", e)
+            false
+        }
 
-        override suspend fun deleteUser(): Boolean = localDataSource.deleteUser()
+    override suspend fun deleteUser(): Boolean = localDataSource.deleteUser()
 
-        override suspend fun updateUserNickname(nickname: String) =
-            remoteDataSource
-                .updateUserNickname(nickname)
-                .also { state ->
-                    if (state is DataState.Success) {
-                        val localUpdateSuccess = localDataSource.updateUserNickname(nickname)
-                        if (!localUpdateSuccess) {
-                            // delete user on update error - fetch user on next get user call
-                            deleteUser()
-                        }
+    override suspend fun updateUserNickname(nickname: String) =
+        remoteDataSource
+            .updateUserNickname(nickname)
+            .also { state ->
+                if (state is DataState.Success) {
+                    val localUpdateSuccess = localDataSource.updateUserNickname(nickname)
+                    if (!localUpdateSuccess) {
+                        // delete user on update error - fetch user on next get user call
+                        deleteUser()
                     }
                 }
+            }
 
-        override suspend fun getKeyCount(): DataState<Int> = remoteDataSource.getKeyCount()
+    override suspend fun getKeyCount(): DataState<Int> = remoteDataSource.getKeyCount()
 
-        override suspend fun getAccountInfo(): DataState<AccountInfo> = remoteDataSource.getUserAccountInfo()
-    }
+    override suspend fun getAccountInfo(): DataState<AccountInfo> = remoteDataSource.getUserAccountInfo()
+}

--- a/domain/src/main/java/com/emotionstorage/domain/common/ErrorCode.kt
+++ b/domain/src/main/java/com/emotionstorage/domain/common/ErrorCode.kt
@@ -25,6 +25,8 @@ enum class ErrorCode {
     REFRESH_TOKEN_NOT_FOUND,
     UNAUTHORIZED,
     INVALID_NICKNAME,
+    // auth client
+    LOGIN_CLIENT_ERROR,
 
     // chat remote
     CHAT_ROOM_NOT_FOUND,

--- a/domain/src/main/java/com/emotionstorage/domain/common/ErrorCode.kt
+++ b/domain/src/main/java/com/emotionstorage/domain/common/ErrorCode.kt
@@ -25,6 +25,7 @@ enum class ErrorCode {
     REFRESH_TOKEN_NOT_FOUND,
     UNAUTHORIZED,
     INVALID_NICKNAME,
+
     // auth client
     LOGIN_CLIENT_ERROR,
 

--- a/domain/src/main/java/com/emotionstorage/domain/repo/AuthRepository.kt
+++ b/domain/src/main/java/com/emotionstorage/domain/repo/AuthRepository.kt
@@ -15,7 +15,7 @@ interface AuthRepository {
 
     suspend fun signup(signupForm: SignupForm): Flow<DataState<Boolean>>
 
-    suspend fun checkSession(): Flow<DataState<Boolean>>
+    suspend fun checkSession(): DataState<Boolean>
 
     suspend fun logout(): Boolean
 

--- a/domain/src/main/java/com/emotionstorage/domain/repo/UserRepository.kt
+++ b/domain/src/main/java/com/emotionstorage/domain/repo/UserRepository.kt
@@ -10,6 +10,8 @@ interface UserRepository {
 
     suspend fun getUser(): Flow<DataState<User>>
 
+    suspend fun getAndSaveUser(): Boolean
+
     suspend fun deleteUser(): Boolean
 
     suspend fun updateUserNickname(nickname: String): DataState<Unit?>

--- a/domain/src/main/java/com/emotionstorage/domain/useCase/auth/AutomaticLoginUseCase.kt
+++ b/domain/src/main/java/com/emotionstorage/domain/useCase/auth/AutomaticLoginUseCase.kt
@@ -3,32 +3,28 @@ package com.emotionstorage.domain.useCase.auth
 import com.emotionstorage.domain.common.DataState
 import com.emotionstorage.domain.repo.AuthRepository
 import com.emotionstorage.domain.repo.FcmRepository
-import com.emotionstorage.domain.repo.SessionRepository
-import com.emotionstorage.domain.repo.UserRepository
-import kotlinx.coroutines.flow.Flow
-import kotlinx.coroutines.flow.map
 import javax.inject.Inject
 
 class AutomaticLoginUseCase
-@Inject
-constructor(
-    private val authRepository: AuthRepository,
-    private val fcmRepository: FcmRepository,
-    private val handleLogout: HandleLogoutUseCase,
-) {
-    suspend operator fun invoke(): DataState<Boolean> {
-        val checkSessionResult = authRepository.checkSession()
+    @Inject
+    constructor(
+        private val authRepository: AuthRepository,
+        private val fcmRepository: FcmRepository,
+        private val handleLogout: HandleLogoutUseCase,
+    ) {
+        suspend operator fun invoke(): DataState<Boolean> {
+            val checkSessionResult = authRepository.checkSession()
 
-        if (checkSessionResult is DataState.Success) {
-            runCatching {
-                fcmRepository.getToken()?.let {
-                    fcmRepository.registerToken(it)
+            if (checkSessionResult is DataState.Success) {
+                runCatching {
+                    fcmRepository.getToken()?.let {
+                        fcmRepository.registerToken(it)
+                    }
                 }
             }
+            if (checkSessionResult is DataState.Error) {
+                handleLogout()
+            }
+            return checkSessionResult
         }
-        if (checkSessionResult is DataState.Error) {
-            handleLogout()
-        }
-        return checkSessionResult
     }
-}

--- a/domain/src/main/java/com/emotionstorage/domain/useCase/auth/AutomaticLoginUseCase.kt
+++ b/domain/src/main/java/com/emotionstorage/domain/useCase/auth/AutomaticLoginUseCase.kt
@@ -10,26 +10,25 @@ import kotlinx.coroutines.flow.map
 import javax.inject.Inject
 
 class AutomaticLoginUseCase
-    @Inject
-    constructor(
-        private val authRepository: AuthRepository,
-        private val sessionRepository: SessionRepository,
-        private val userRepository: UserRepository,
-        private val fcmRepository: FcmRepository,
-    ) {
-        suspend operator fun invoke(): Flow<DataState<Boolean>> =
-            authRepository.checkSession().map { it ->
-                if (it is DataState.Success) {
-                    fcmRepository.getToken()?.let {
-                        fcmRepository.registerToken(it)
-                    }
+@Inject
+constructor(
+    private val authRepository: AuthRepository,
+    private val fcmRepository: FcmRepository,
+    private val handleLogout: HandleLogoutUseCase,
+) {
+    suspend operator fun invoke(): DataState<Boolean> {
+        val checkSessionResult = authRepository.checkSession()
+
+        if (checkSessionResult is DataState.Success) {
+            runCatching {
+                fcmRepository.getToken()?.let {
+                    fcmRepository.registerToken(it)
                 }
-                if (it is DataState.Error) {
-                    sessionRepository.deleteSession()
-                    userRepository.deleteUser()
-                    fcmRepository.deleteToken()
-                    return@map it
-                }
-                it
             }
+        }
+        if (checkSessionResult is DataState.Error) {
+            handleLogout()
+        }
+        return checkSessionResult
     }
+}

--- a/domain/src/main/java/com/emotionstorage/domain/useCase/auth/DeleteAccountUseCase.kt
+++ b/domain/src/main/java/com/emotionstorage/domain/useCase/auth/DeleteAccountUseCase.kt
@@ -1,9 +1,6 @@
 package com.emotionstorage.domain.useCase.auth
 
 import com.emotionstorage.domain.repo.AuthRepository
-import com.emotionstorage.domain.repo.FcmRepository
-import com.emotionstorage.domain.repo.SessionRepository
-import com.emotionstorage.domain.repo.UserRepository
 import javax.inject.Inject
 
 /**
@@ -15,7 +12,7 @@ class DeleteAccountUseCase
     @Inject
     constructor(
         private val authRepository: AuthRepository,
-        private val handleLogout: HandleLogoutUseCase
+        private val handleLogout: HandleLogoutUseCase,
     ) {
         suspend operator fun invoke(): Boolean {
             val result = authRepository.deleteAccount()

--- a/domain/src/main/java/com/emotionstorage/domain/useCase/auth/DeleteAccountUseCase.kt
+++ b/domain/src/main/java/com/emotionstorage/domain/useCase/auth/DeleteAccountUseCase.kt
@@ -15,16 +15,12 @@ class DeleteAccountUseCase
     @Inject
     constructor(
         private val authRepository: AuthRepository,
-        private val userRepository: UserRepository,
-        private val sessionRepository: SessionRepository,
-        private val fcmRepository: FcmRepository,
+        private val handleLogout: HandleLogoutUseCase
     ) {
         suspend operator fun invoke(): Boolean {
             val result = authRepository.deleteAccount()
             if (result) {
-                sessionRepository.deleteSession()
-                userRepository.deleteUser()
-                fcmRepository.deleteToken()
+                handleLogout()
             }
             return result
         }

--- a/domain/src/main/java/com/emotionstorage/domain/useCase/auth/HandleLoginUseCase.kt
+++ b/domain/src/main/java/com/emotionstorage/domain/useCase/auth/HandleLoginUseCase.kt
@@ -3,8 +3,6 @@ package com.emotionstorage.domain.useCase.auth
 import com.emotionstorage.domain.common.DataState
 import com.emotionstorage.domain.common.ErrorCode
 import com.emotionstorage.domain.model.Session
-import com.emotionstorage.domain.model.User
-import com.emotionstorage.domain.repo.AuthRepository
 import com.emotionstorage.domain.repo.FcmRepository
 import com.emotionstorage.domain.repo.SessionRepository
 import com.emotionstorage.domain.repo.UserRepository

--- a/domain/src/main/java/com/emotionstorage/domain/useCase/auth/HandleLoginUseCase.kt
+++ b/domain/src/main/java/com/emotionstorage/domain/useCase/auth/HandleLoginUseCase.kt
@@ -1,0 +1,40 @@
+package com.emotionstorage.domain.useCase.auth
+
+import com.emotionstorage.domain.common.DataState
+import com.emotionstorage.domain.common.ErrorCode
+import com.emotionstorage.domain.model.Session
+import com.emotionstorage.domain.model.User
+import com.emotionstorage.domain.repo.AuthRepository
+import com.emotionstorage.domain.repo.FcmRepository
+import com.emotionstorage.domain.repo.SessionRepository
+import com.emotionstorage.domain.repo.UserRepository
+import io.github.aakira.napier.Napier
+import javax.inject.Inject
+
+class HandleLoginUseCase @Inject constructor(
+    private val sessionRepository: SessionRepository,
+    private val userRepository: UserRepository,
+    private val fcmRepository: FcmRepository,
+) {
+    suspend operator fun invoke(accessToken: String): DataState<String> {
+        try {
+            fcmRepository.getToken()?.let {
+                fcmRepository.registerToken(it)
+            }
+        } catch (e: Exception) {
+            // ignore fcm token register error for now
+            Napier.e("fcm token get/register error", e)
+        }
+
+        try {
+            if (sessionRepository.saveSession(Session(accessToken)) && userRepository.getAndSaveUser()) {
+                return DataState.Success(accessToken)
+            } else {
+                throw Exception("session/user save error")
+            }
+        } catch (e: Exception) {
+            Napier.e("handle login client error", e)
+            return DataState.Error(e, ErrorCode.LOGIN_CLIENT_ERROR, accessToken)
+        }
+    }
+}

--- a/domain/src/main/java/com/emotionstorage/domain/useCase/auth/HandleLogoutUseCase.kt
+++ b/domain/src/main/java/com/emotionstorage/domain/useCase/auth/HandleLogoutUseCase.kt
@@ -4,15 +4,14 @@ import com.emotionstorage.domain.common.DataState
 import com.emotionstorage.domain.repo.FcmRepository
 import com.emotionstorage.domain.repo.SessionRepository
 import com.emotionstorage.domain.repo.UserRepository
-import io.github.aakira.napier.Napier
 import javax.inject.Inject
 
 class HandleLogoutUseCase @Inject constructor(
     private val sessionRepository: SessionRepository,
     private val userRepository: UserRepository,
     private val fcmRepository: FcmRepository,
-){
-    suspend operator fun invoke() : DataState<Unit> {
+) {
+    suspend operator fun invoke(): DataState<Unit> {
         // ignore any client error on logout for now
         runCatching {
             sessionRepository.deleteSession()

--- a/domain/src/main/java/com/emotionstorage/domain/useCase/auth/HandleLogoutUseCase.kt
+++ b/domain/src/main/java/com/emotionstorage/domain/useCase/auth/HandleLogoutUseCase.kt
@@ -1,0 +1,28 @@
+package com.emotionstorage.domain.useCase.auth
+
+import com.emotionstorage.domain.common.DataState
+import com.emotionstorage.domain.repo.FcmRepository
+import com.emotionstorage.domain.repo.SessionRepository
+import com.emotionstorage.domain.repo.UserRepository
+import io.github.aakira.napier.Napier
+import javax.inject.Inject
+
+class HandleLogoutUseCase @Inject constructor(
+    private val sessionRepository: SessionRepository,
+    private val userRepository: UserRepository,
+    private val fcmRepository: FcmRepository,
+){
+    suspend operator fun invoke() : DataState<Unit> {
+        // ignore any client error on logout for now
+        runCatching {
+            sessionRepository.deleteSession()
+        }
+        runCatching {
+            userRepository.deleteUser()
+        }
+        runCatching {
+            fcmRepository.deleteToken()
+        }
+        return DataState.Success(Unit)
+    }
+}

--- a/domain/src/main/java/com/emotionstorage/domain/useCase/auth/LoginUseCase.kt
+++ b/domain/src/main/java/com/emotionstorage/domain/useCase/auth/LoginUseCase.kt
@@ -18,10 +18,10 @@ constructor(
         if (loginResult is DataState.Success) {
             val handleLoginResult = handleLogin(accessToken = loginResult.data)
 
-            if (handleLoginResult is DataState.Success) {
-                return loginResult
+            return if (handleLoginResult is DataState.Success) {
+                loginResult
             } else {
-                return handleLoginResult
+                handleLoginResult
             }
         }
 

--- a/domain/src/main/java/com/emotionstorage/domain/useCase/auth/LoginUseCase.kt
+++ b/domain/src/main/java/com/emotionstorage/domain/useCase/auth/LoginUseCase.kt
@@ -1,49 +1,33 @@
 package com.emotionstorage.domain.useCase.auth
 
 import com.emotionstorage.domain.common.DataState
-import com.emotionstorage.domain.model.Session
 import com.emotionstorage.domain.model.User
 import com.emotionstorage.domain.repo.AuthRepository
-import com.emotionstorage.domain.repo.FcmRepository
-import com.emotionstorage.domain.repo.SessionRepository
-import com.emotionstorage.domain.repo.UserRepository
-import io.github.aakira.napier.Napier
 import javax.inject.Inject
 
 class LoginUseCase @Inject
-    constructor(
-        private val authRepository: AuthRepository,
-        private val sessionRepository: SessionRepository,
-        private val userRepository: UserRepository,
-        private val fcmRepository: FcmRepository,
-    ) {
-        suspend operator fun invoke(provider: User.AuthProvider): DataState<String> {
-            val loginResult = authRepository.login(provider)
+constructor(
+    private val authRepository: AuthRepository,
+    private val handleLogin: HandleLoginUseCase,
+    private val handleLogout: HandleLogoutUseCase
 
-            // todo: handle login success handling logic
-            if (loginResult is DataState.Success) {
-                sessionRepository.saveSession(Session(loginResult.data))
-                try {
-                    fcmRepository.getToken()?.let {
-                        fcmRepository.registerToken(it)
-                    }
-                } catch (e: Exception) {
-                    Napier.e("fcm token get/register error", e)
-                }
-                userRepository.getAccountInfo()
+) {
+    suspend operator fun invoke(provider: User.AuthProvider): DataState<String> {
+        val loginResult = authRepository.login(provider)
+
+        if (loginResult is DataState.Success) {
+            val handleLoginResult = handleLogin(accessToken = loginResult.data)
+
+            if (handleLoginResult is DataState.Success) {
+                return loginResult
+            } else {
+                return handleLoginResult
             }
-
-            // todo: handle login error handling logic
-            if (loginResult is DataState.Error) {
-                sessionRepository.deleteSession()
-                userRepository.deleteUser()
-                try {
-                    fcmRepository.deleteToken()
-                } catch (e: Exception) {
-                    Napier.e("fcm token delete error", e)
-                }
-            }
-
-            return loginResult
         }
+
+        if (loginResult is DataState.Error) {
+            handleLogout()
+        }
+        return loginResult
     }
+}

--- a/domain/src/main/java/com/emotionstorage/domain/useCase/auth/LoginUseCase.kt
+++ b/domain/src/main/java/com/emotionstorage/domain/useCase/auth/LoginUseCase.kt
@@ -6,28 +6,27 @@ import com.emotionstorage.domain.repo.AuthRepository
 import javax.inject.Inject
 
 class LoginUseCase @Inject
-constructor(
-    private val authRepository: AuthRepository,
-    private val handleLogin: HandleLoginUseCase,
-    private val handleLogout: HandleLogoutUseCase
+    constructor(
+        private val authRepository: AuthRepository,
+        private val handleLogin: HandleLoginUseCase,
+        private val handleLogout: HandleLogoutUseCase,
+    ) {
+        suspend operator fun invoke(provider: User.AuthProvider): DataState<String> {
+            val loginResult = authRepository.login(provider)
 
-) {
-    suspend operator fun invoke(provider: User.AuthProvider): DataState<String> {
-        val loginResult = authRepository.login(provider)
+            if (loginResult is DataState.Success) {
+                val handleLoginResult = handleLogin(accessToken = loginResult.data)
 
-        if (loginResult is DataState.Success) {
-            val handleLoginResult = handleLogin(accessToken = loginResult.data)
-
-            return if (handleLoginResult is DataState.Success) {
-                loginResult
-            } else {
-                handleLoginResult
+                return if (handleLoginResult is DataState.Success) {
+                    loginResult
+                } else {
+                    handleLoginResult
+                }
             }
-        }
 
-        if (loginResult is DataState.Error) {
-            handleLogout()
+            if (loginResult is DataState.Error) {
+                handleLogout()
+            }
+            return loginResult
         }
-        return loginResult
     }
-}

--- a/domain/src/main/java/com/emotionstorage/domain/useCase/auth/LoginWithIdTokenUseCase.kt
+++ b/domain/src/main/java/com/emotionstorage/domain/useCase/auth/LoginWithIdTokenUseCase.kt
@@ -10,29 +10,30 @@ import com.emotionstorage.domain.repo.UserRepository
 import javax.inject.Inject
 
 class LoginWithIdTokenUseCase
-    @Inject
-    constructor(
-        private val authRepository: AuthRepository,
-        private val sessionRepository: SessionRepository,
-        private val userRepository: UserRepository,
-        private val fcmRepository: FcmRepository,
-    ) {
-        suspend operator fun invoke(
-            provider: User.AuthProvider,
-            idToken: String,
-        ): DataState<String> =
-            authRepository.loginWithIdToken(provider, idToken).also {
-                if (it is DataState.Success) {
-                    sessionRepository.saveSession(Session(it.data))
-                    fcmRepository.getToken()?.let {
-                        fcmRepository.registerToken(it)
-                    }
-                    userRepository.getAccountInfo()
-                }
-                if (it is DataState.Error) {
-                    sessionRepository.deleteSession()
-                    userRepository.deleteUser()
-                    fcmRepository.deleteToken()
-                }
+@Inject
+constructor(
+    private val authRepository: AuthRepository,
+    private val handleLogin: HandleLoginUseCase,
+    private val handleLogout: HandleLogoutUseCase,
+) {
+    suspend operator fun invoke(
+        provider: User.AuthProvider,
+        idToken: String,
+    ): DataState<String> {
+        val loginResult = authRepository.loginWithIdToken(provider, idToken)
+        if (loginResult is DataState.Success) {
+            val handleLoginResult = handleLogin(accessToken = loginResult.data)
+
+            return if (handleLoginResult is DataState.Success) {
+                loginResult
+            } else {
+                handleLoginResult
             }
+        }
+
+        if (loginResult is DataState.Error) {
+            handleLogout()
+        }
+        return loginResult
     }
+}

--- a/domain/src/main/java/com/emotionstorage/domain/useCase/auth/LoginWithIdTokenUseCase.kt
+++ b/domain/src/main/java/com/emotionstorage/domain/useCase/auth/LoginWithIdTokenUseCase.kt
@@ -2,38 +2,34 @@ package com.emotionstorage.domain.useCase.auth
 
 import com.emotionstorage.domain.repo.AuthRepository
 import com.emotionstorage.domain.common.DataState
-import com.emotionstorage.domain.model.Session
 import com.emotionstorage.domain.model.User
-import com.emotionstorage.domain.repo.FcmRepository
-import com.emotionstorage.domain.repo.SessionRepository
-import com.emotionstorage.domain.repo.UserRepository
 import javax.inject.Inject
 
 class LoginWithIdTokenUseCase
-@Inject
-constructor(
-    private val authRepository: AuthRepository,
-    private val handleLogin: HandleLoginUseCase,
-    private val handleLogout: HandleLogoutUseCase,
-) {
-    suspend operator fun invoke(
-        provider: User.AuthProvider,
-        idToken: String,
-    ): DataState<String> {
-        val loginResult = authRepository.loginWithIdToken(provider, idToken)
-        if (loginResult is DataState.Success) {
-            val handleLoginResult = handleLogin(accessToken = loginResult.data)
+    @Inject
+    constructor(
+        private val authRepository: AuthRepository,
+        private val handleLogin: HandleLoginUseCase,
+        private val handleLogout: HandleLogoutUseCase,
+    ) {
+        suspend operator fun invoke(
+            provider: User.AuthProvider,
+            idToken: String,
+        ): DataState<String> {
+            val loginResult = authRepository.loginWithIdToken(provider, idToken)
+            if (loginResult is DataState.Success) {
+                val handleLoginResult = handleLogin(accessToken = loginResult.data)
 
-            return if (handleLoginResult is DataState.Success) {
-                loginResult
-            } else {
-                handleLoginResult
+                return if (handleLoginResult is DataState.Success) {
+                    loginResult
+                } else {
+                    handleLoginResult
+                }
             }
-        }
 
-        if (loginResult is DataState.Error) {
-            handleLogout()
+            if (loginResult is DataState.Error) {
+                handleLogout()
+            }
+            return loginResult
         }
-        return loginResult
     }
-}

--- a/domain/src/main/java/com/emotionstorage/domain/useCase/auth/LogoutUseCase.kt
+++ b/domain/src/main/java/com/emotionstorage/domain/useCase/auth/LogoutUseCase.kt
@@ -15,16 +15,12 @@ class LogoutUseCase
     @Inject
     constructor(
         private val authRepository: AuthRepository,
-        private val userRepository: UserRepository,
-        private val sessionRepository: SessionRepository,
-        private val fcmRepository: FcmRepository,
+        private val handleLogout: HandleLogoutUseCase,
     ) {
         suspend operator fun invoke(): Boolean {
             val result = authRepository.logout()
             if (result) {
-                sessionRepository.deleteSession()
-                userRepository.deleteUser()
-                fcmRepository.deleteToken()
+                handleLogout()
             }
             return result
         }

--- a/domain/src/main/java/com/emotionstorage/domain/useCase/auth/LogoutUseCase.kt
+++ b/domain/src/main/java/com/emotionstorage/domain/useCase/auth/LogoutUseCase.kt
@@ -1,9 +1,6 @@
 package com.emotionstorage.domain.useCase.auth
 
 import com.emotionstorage.domain.repo.AuthRepository
-import com.emotionstorage.domain.repo.FcmRepository
-import com.emotionstorage.domain.repo.SessionRepository
-import com.emotionstorage.domain.repo.UserRepository
 import javax.inject.Inject
 
 /**

--- a/feat/ai-chat/src/main/java/com/emotionstorage/ai_chat/ui/component/AIChatExitModal.kt
+++ b/feat/ai-chat/src/main/java/com/emotionstorage/ai_chat/ui/component/AIChatExitModal.kt
@@ -2,7 +2,7 @@ package com.emotionstorage.ai_chat.ui.component
 
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.tooling.preview.Preview
-import com.emotionstorage.ui.component.Modal
+import com.emotionstorage.ui.component.modal.Modal
 import com.emotionstorage.ui.theme.MooiTheme
 
 @Composable

--- a/feat/ai-chat/src/main/java/com/emotionstorage/ai_chat/ui/component/NetworkErrorModal.kt
+++ b/feat/ai-chat/src/main/java/com/emotionstorage/ai_chat/ui/component/NetworkErrorModal.kt
@@ -4,7 +4,7 @@ import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
-import com.emotionstorage.ui.component.Modal
+import com.emotionstorage.ui.component.modal.Modal
 import com.emotionstorage.ui.theme.MooiTheme
 
 @Composable

--- a/feat/ai-chat/src/main/java/com/emotionstorage/ai_chat/ui/component/RecursiveRetryModal.kt
+++ b/feat/ai-chat/src/main/java/com/emotionstorage/ai_chat/ui/component/RecursiveRetryModal.kt
@@ -4,7 +4,7 @@ import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
-import com.emotionstorage.ui.component.Modal
+import com.emotionstorage.ui.component.modal.Modal
 import com.emotionstorage.ui.theme.MooiTheme
 
 @Composable

--- a/feat/ai-chat/src/main/java/com/emotionstorage/ai_chat/ui/component/TimeCapsuleCreateLoadingModal.kt
+++ b/feat/ai-chat/src/main/java/com/emotionstorage/ai_chat/ui/component/TimeCapsuleCreateLoadingModal.kt
@@ -12,7 +12,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
-import com.emotionstorage.ui.component.Modal
+import com.emotionstorage.ui.component.modal.Modal
 import com.emotionstorage.ui.theme.MooiTheme
 import com.google.accompanist.drawablepainter.rememberDrawablePainter
 import com.emotionstorage.ui.R

--- a/feat/auth/src/main/java/com/emotionstorage/auth/presentation/LoginViewModel.kt
+++ b/feat/auth/src/main/java/com/emotionstorage/auth/presentation/LoginViewModel.kt
@@ -66,6 +66,7 @@ class LoginViewModel
             reduce {
                 state.copy(isLoading = false)
             }
+            retryCount = 0
             postSideEffect(LoginSideEffect.LoginSuccess)
         }, onError = { throwable, code, data ->
             reduce {
@@ -84,6 +85,7 @@ class LoginViewModel
                 reduce {
                     state.copy(isLoading = false)
                 }
+                retryCount = 0
                 postSideEffect(LoginSideEffect.LoginSuccess)
             },
             onError = { throwable, code, data ->
@@ -98,9 +100,11 @@ class LoginViewModel
     private suspend fun handleLoginError(code: ErrorCode, provider: AuthProvider, idToken: String?) = subIntent {
         if (code == ErrorCode.INVALID_ID_TOKEN || code == ErrorCode.INVALID_KAKAO_ACCESS_TOKEN || idToken == null) {
             // invalid social id - show toast
+            retryCount = 0
             postSideEffect(LoginSideEffect.SocialLoginError)
         } else if (code == ErrorCode.NEED_SIGN_UP) {
             // need sign up - nav to on boarding
+            retryCount = 0
             postSideEffect(LoginSideEffect.NeedSignUp(provider, idToken))
         } else {
             // show login error modal on any login errors

--- a/feat/auth/src/main/java/com/emotionstorage/auth/presentation/LoginViewModel.kt
+++ b/feat/auth/src/main/java/com/emotionstorage/auth/presentation/LoginViewModel.kt
@@ -4,6 +4,7 @@ import com.emotionstorage.domain.common.ErrorCode
 import com.emotionstorage.domain.model.User.AuthProvider
 import com.emotionstorage.domain.useCase.auth.LoginUseCase
 import com.emotionstorage.domain.useCase.auth.LoginWithIdTokenUseCase
+import com.emotionstorage.presentation.BaseException
 import com.emotionstorage.presentation.BaseSideEffect
 import com.emotionstorage.presentation.BaseViewModel
 import dagger.hilt.android.lifecycle.HiltViewModel
@@ -82,7 +83,7 @@ class LoginViewModel
                     reduce {
                         state.copy(isLoading = false)
                     }
-                    handleLoginError(code, provider, data as? String)
+                    handleLoginError(throwable, code, provider, data as? String)
                 })
             }
 
@@ -105,12 +106,13 @@ class LoginViewModel
                     reduce {
                         state.copy(isLoading = false)
                     }
-                    handleLoginError(code, provider, idToken)
+                    handleLoginError(throwable, code, provider, idToken)
                 },
             )
         }
 
         private suspend fun handleLoginError(
+            throwable: Throwable,
             code: ErrorCode,
             provider: AuthProvider,
             idToken: String?,
@@ -123,8 +125,8 @@ class LoginViewModel
                 // need sign up - nav to on boarding
                 retryCount = 0
                 postSideEffect(LoginSideEffect.NeedSignUp(provider, idToken))
-            } else {
-                // show login error modal on any login errors
+            } else if(code == ErrorCode.LOGIN_CLIENT_ERROR){
+                // client login handling error - show login error modal
                 if (retryCount < 3) {
                     retryCount++
                     postSideEffect(LoginSideEffect.RetryLogin(provider, idToken))
@@ -132,6 +134,13 @@ class LoginViewModel
                     retryCount = 0
                     postSideEffect(LoginSideEffect.InquireLoginError(provider))
                 }
+            } else{
+                // throw base exception for base viewmodel to handle
+                throw BaseException(
+                    code = code,
+                    message = throwable.message,
+                    cause = throwable,
+                )
             }
         }
     }

--- a/feat/auth/src/main/java/com/emotionstorage/auth/presentation/LoginViewModel.kt
+++ b/feat/auth/src/main/java/com/emotionstorage/auth/presentation/LoginViewModel.kt
@@ -2,10 +2,12 @@ package com.emotionstorage.auth.presentation
 
 import com.emotionstorage.domain.common.ErrorCode
 import com.emotionstorage.domain.model.User
+import com.emotionstorage.domain.model.User.AuthProvider
 import com.emotionstorage.domain.useCase.auth.LoginUseCase
 import com.emotionstorage.presentation.BaseException
 import com.emotionstorage.presentation.BaseSideEffect
 import com.emotionstorage.presentation.BaseViewModel
+import com.orhanobut.logger.Logger
 import dagger.hilt.android.lifecycle.HiltViewModel
 import javax.inject.Inject
 
@@ -15,67 +17,67 @@ data class LoginState(
 
 sealed class LoginAction {
     data class Login(
-        val provider: User.AuthProvider,
+        val provider: AuthProvider,
     ) : LoginAction()
 }
 
 sealed class LoginSideEffect : BaseSideEffect {
     object LoginSuccess : LoginSideEffect()
 
+    object LoginErrorWithRetry : LoginSideEffect()
+
+    object LoginErrorWithInquiry : LoginSideEffect()
+
     data class NeedSignUp(
-        val provider: User.AuthProvider,
+        val provider: AuthProvider,
         val idToken: String,
     ) : LoginSideEffect()
 }
 
 @HiltViewModel
 class LoginViewModel
-    @Inject
-    constructor(
-        private val login: LoginUseCase,
-    ) : BaseViewModel<LoginState>(
-            LoginState(),
-        ) {
-        fun onAction(action: LoginAction) {
-            when (action) {
-                is LoginAction.Login -> {
-                    handleLogin(action.provider)
-                }
+@Inject constructor(
+    private val login: LoginUseCase,
+) : BaseViewModel<LoginState>(
+    LoginState(),
+) {
+    private var retryCount: Int = 0
+
+    fun onAction(action: LoginAction) {
+        when (action) {
+            is LoginAction.Login -> {
+                handleLogin(action.provider)
             }
         }
-
-        private fun handleLogin(provider: User.AuthProvider) =
-            baseIntent {
-                reduce {
-                    state.copy(isLoading = true)
-                }
-                login(provider).handle(
-                    onSuccess = {
-                        reduce {
-                            state.copy(isLoading = false)
-                        }
-                        postSideEffect(LoginSideEffect.LoginSuccess)
-                    },
-                    onError = { throwable, code, data ->
-                        reduce {
-                            state.copy(isLoading = false)
-                        }
-                        if (code == ErrorCode.NEED_SIGN_UP) {
-                            val idToken =
-                                (data as? String) ?: throw BaseException(
-                                    message = "idToken is null or not a String",
-                                    code = ErrorCode.UNKNOWN,
-                                    cause = IllegalStateException(),
-                                )
-                            postSideEffect(LoginSideEffect.NeedSignUp(provider, idToken))
-                        } else {
-                            throw BaseException(
-                                message = throwable.message,
-                                code = code,
-                                cause = throwable,
-                            )
-                        }
-                    },
-                )
-            }
     }
+
+    private fun handleLogin(provider: AuthProvider) = baseIntent {
+        reduce {
+            state.copy(isLoading = true)
+        }
+        login(provider).handle(onSuccess = {
+            reduce {
+                state.copy(isLoading = false)
+            }
+            postSideEffect(LoginSideEffect.LoginSuccess)
+        }, onError = { throwable, code, data ->
+            reduce {
+                state.copy(isLoading = false)
+            }
+            if (code == ErrorCode.NEED_SIGN_UP && data != null) {
+                val idToken = data as String
+                Logger.d("Need sign up, idToken: ${idToken.take(6)}...")
+                postSideEffect(LoginSideEffect.NeedSignUp(provider, idToken))
+                return@handle
+            }
+
+            // show login error modal on any login errors
+            if (retryCount < 3) {
+                retryCount++
+                postSideEffect(LoginSideEffect.LoginErrorWithRetry)
+            } else {
+                postSideEffect(LoginSideEffect.LoginErrorWithInquiry)
+            }
+        })
+    }
+}

--- a/feat/auth/src/main/java/com/emotionstorage/auth/presentation/LoginViewModel.kt
+++ b/feat/auth/src/main/java/com/emotionstorage/auth/presentation/LoginViewModel.kt
@@ -6,7 +6,6 @@ import com.emotionstorage.domain.useCase.auth.LoginUseCase
 import com.emotionstorage.domain.useCase.auth.LoginWithIdTokenUseCase
 import com.emotionstorage.presentation.BaseSideEffect
 import com.emotionstorage.presentation.BaseViewModel
-import com.orhanobut.logger.Logger
 import dagger.hilt.android.lifecycle.HiltViewModel
 import org.orbitmvi.orbit.annotation.OrbitExperimental
 import javax.inject.Inject
@@ -23,7 +22,7 @@ sealed class LoginAction {
     data class LoginWithIdToken(
         val provider: AuthProvider,
         val idToken: String,
-    ): LoginAction()
+    ) : LoginAction()
 }
 
 sealed class LoginSideEffect : BaseSideEffect {
@@ -40,7 +39,7 @@ sealed class LoginSideEffect : BaseSideEffect {
     ) : LoginSideEffect()
 
     data class InquireLoginError(
-        val provider: AuthProvider
+        val provider: AuthProvider,
     ) : LoginSideEffect()
 
     object LoginSuccess : LoginSideEffect()
@@ -49,82 +48,90 @@ sealed class LoginSideEffect : BaseSideEffect {
 @OptIn(OrbitExperimental::class)
 @HiltViewModel
 class LoginViewModel
-@Inject constructor(
-    private val login: LoginUseCase,
-    private val loginWithIdToken: LoginWithIdTokenUseCase
-) : BaseViewModel<LoginState>(
-    LoginState(),
-) {
-    private var retryCount: Int = 0
+    @Inject constructor(
+        private val login: LoginUseCase,
+        private val loginWithIdToken: LoginWithIdTokenUseCase,
+    ) : BaseViewModel<LoginState>(
+            LoginState(),
+        ) {
+        private var retryCount: Int = 0
 
-    fun onAction(action: LoginAction) {
-        when (action) {
-            is LoginAction.Login -> {
-                handleLogin(action.provider)
-            }
-            is LoginAction.LoginWithIdToken -> {
-                handleLogin(action.provider, action.idToken)
-            }
-        }
-    }
-
-    private fun handleLogin(provider: AuthProvider) = baseIntent {
-        reduce {
-            state.copy(isLoading = true)
-        }
-        login(provider).handle(onSuccess = {
-            reduce {
-                state.copy(isLoading = false)
-            }
-            retryCount = 0
-            postSideEffect(LoginSideEffect.LoginSuccess)
-        }, onError = { throwable, code, data ->
-            reduce {
-                state.copy(isLoading = false)
-            }
-            handleLoginError(code, provider, data as? String)
-        })
-    }
-
-    private fun handleLogin(provider: AuthProvider, idToken: String) = baseIntent {
-        reduce {
-            state.copy(isLoading = true)
-        }
-        loginWithIdToken(provider, idToken).handle(
-            onSuccess = {
-                reduce {
-                    state.copy(isLoading = false)
+        fun onAction(action: LoginAction) {
+            when (action) {
+                is LoginAction.Login -> {
+                    handleLogin(action.provider)
                 }
+                is LoginAction.LoginWithIdToken -> {
+                    handleLogin(action.provider, action.idToken)
+                }
+            }
+        }
+
+        private fun handleLogin(provider: AuthProvider) =
+            baseIntent {
+                reduce {
+                    state.copy(isLoading = true)
+                }
+                login(provider).handle(onSuccess = {
+                    reduce {
+                        state.copy(isLoading = false)
+                    }
+                    retryCount = 0
+                    postSideEffect(LoginSideEffect.LoginSuccess)
+                }, onError = { throwable, code, data ->
+                    reduce {
+                        state.copy(isLoading = false)
+                    }
+                    handleLoginError(code, provider, data as? String)
+                })
+            }
+
+        private fun handleLogin(
+            provider: AuthProvider,
+            idToken: String,
+        ) = baseIntent {
+            reduce {
+                state.copy(isLoading = true)
+            }
+            loginWithIdToken(provider, idToken).handle(
+                onSuccess = {
+                    reduce {
+                        state.copy(isLoading = false)
+                    }
+                    retryCount = 0
+                    postSideEffect(LoginSideEffect.LoginSuccess)
+                },
+                onError = { throwable, code, data ->
+                    reduce {
+                        state.copy(isLoading = false)
+                    }
+                    handleLoginError(code, provider, idToken)
+                },
+            )
+        }
+
+        private suspend fun handleLoginError(
+            code: ErrorCode,
+            provider: AuthProvider,
+            idToken: String?,
+        ) = subIntent {
+            if (code == ErrorCode.INVALID_ID_TOKEN || code == ErrorCode.INVALID_KAKAO_ACCESS_TOKEN || idToken == null) {
+                // invalid social id - show toast
                 retryCount = 0
-                postSideEffect(LoginSideEffect.LoginSuccess)
-            },
-            onError = { throwable, code, data ->
-                reduce {
-                    state.copy(isLoading = false)
-                }
-                handleLoginError(code, provider, idToken)
-            }
-        )
-    }
-
-    private suspend fun handleLoginError(code: ErrorCode, provider: AuthProvider, idToken: String?) = subIntent {
-        if (code == ErrorCode.INVALID_ID_TOKEN || code == ErrorCode.INVALID_KAKAO_ACCESS_TOKEN || idToken == null) {
-            // invalid social id - show toast
-            retryCount = 0
-            postSideEffect(LoginSideEffect.SocialLoginError)
-        } else if (code == ErrorCode.NEED_SIGN_UP) {
-            // need sign up - nav to on boarding
-            retryCount = 0
-            postSideEffect(LoginSideEffect.NeedSignUp(provider, idToken))
-        } else {
-            // show login error modal on any login errors
-            if (retryCount < 3) {
-                retryCount++
-                postSideEffect(LoginSideEffect.RetryLogin(provider, idToken))
+                postSideEffect(LoginSideEffect.SocialLoginError)
+            } else if (code == ErrorCode.NEED_SIGN_UP) {
+                // need sign up - nav to on boarding
+                retryCount = 0
+                postSideEffect(LoginSideEffect.NeedSignUp(provider, idToken))
             } else {
-                retryCount = 0
-                postSideEffect(LoginSideEffect.InquireLoginError(provider))
+                // show login error modal on any login errors
+                if (retryCount < 3) {
+                    retryCount++
+                    postSideEffect(LoginSideEffect.RetryLogin(provider, idToken))
+                } else {
+                    retryCount = 0
+                    postSideEffect(LoginSideEffect.InquireLoginError(provider))
+                }
             }
         }
     }
-}

--- a/feat/auth/src/main/java/com/emotionstorage/auth/presentation/LoginViewModel.kt
+++ b/feat/auth/src/main/java/com/emotionstorage/auth/presentation/LoginViewModel.kt
@@ -2,8 +2,8 @@ package com.emotionstorage.auth.presentation
 
 import com.emotionstorage.domain.common.ErrorCode
 import com.emotionstorage.domain.model.User.AuthProvider
+import com.emotionstorage.domain.useCase.auth.HandleLoginUseCase
 import com.emotionstorage.domain.useCase.auth.LoginUseCase
-import com.emotionstorage.domain.useCase.auth.LoginWithIdTokenUseCase
 import com.emotionstorage.presentation.BaseException
 import com.emotionstorage.presentation.BaseSideEffect
 import com.emotionstorage.presentation.BaseViewModel
@@ -20,9 +20,8 @@ sealed class LoginAction {
         val provider: AuthProvider,
     ) : LoginAction()
 
-    data class LoginWithIdToken(
-        val provider: AuthProvider,
-        val idToken: String,
+    data class RetryLogin(
+        val accessToken: String,
     ) : LoginAction()
 }
 
@@ -35,13 +34,10 @@ sealed class LoginSideEffect : BaseSideEffect {
     ) : LoginSideEffect()
 
     data class RetryLogin(
-        val provider: AuthProvider,
-        val idToken: String,
+        val accessToken: String,
     ) : LoginSideEffect()
 
-    data class InquireLoginError(
-        val provider: AuthProvider,
-    ) : LoginSideEffect()
+    object InquireLoginError : LoginSideEffect()
 
     object LoginSuccess : LoginSideEffect()
 }
@@ -49,98 +45,91 @@ sealed class LoginSideEffect : BaseSideEffect {
 @OptIn(OrbitExperimental::class)
 @HiltViewModel
 class LoginViewModel
-    @Inject constructor(
-        private val login: LoginUseCase,
-        private val loginWithIdToken: LoginWithIdTokenUseCase,
+@Inject constructor(
+    private val login: LoginUseCase,
+    private val handleLoginUseCase: HandleLoginUseCase,
+
     ) : BaseViewModel<LoginState>(
-            LoginState(),
-        ) {
-        private var retryCount: Int = 0
+    LoginState(),
+) {
+    private var retryCount: Int = 0
 
-        fun onAction(action: LoginAction) {
-            when (action) {
-                is LoginAction.Login -> {
-                    handleLogin(action.provider)
-                }
-                is LoginAction.LoginWithIdToken -> {
-                    handleLogin(action.provider, action.idToken)
-                }
-            }
-        }
-
-        private fun handleLogin(provider: AuthProvider) =
-            baseIntent {
-                reduce {
-                    state.copy(isLoading = true)
-                }
-                login(provider).handle(onSuccess = {
-                    reduce {
-                        state.copy(isLoading = false)
-                    }
-                    retryCount = 0
-                    postSideEffect(LoginSideEffect.LoginSuccess)
-                }, onError = { throwable, code, data ->
-                    reduce {
-                        state.copy(isLoading = false)
-                    }
-                    handleLoginError(throwable, code, provider, data as? String)
-                })
+    fun onAction(action: LoginAction) {
+        when (action) {
+            is LoginAction.Login -> {
+                handleLogin(action.provider)
             }
 
-        private fun handleLogin(
-            provider: AuthProvider,
-            idToken: String,
-        ) = baseIntent {
-            reduce {
-                state.copy(isLoading = true)
-            }
-            loginWithIdToken(provider, idToken).handle(
-                onSuccess = {
-                    reduce {
-                        state.copy(isLoading = false)
-                    }
-                    retryCount = 0
-                    postSideEffect(LoginSideEffect.LoginSuccess)
-                },
-                onError = { throwable, code, data ->
-                    reduce {
-                        state.copy(isLoading = false)
-                    }
-                    handleLoginError(throwable, code, provider, idToken)
-                },
-            )
-        }
-
-        private suspend fun handleLoginError(
-            throwable: Throwable,
-            code: ErrorCode,
-            provider: AuthProvider,
-            idToken: String?,
-        ) = subIntent {
-            if (code == ErrorCode.INVALID_ID_TOKEN || code == ErrorCode.INVALID_KAKAO_ACCESS_TOKEN || idToken == null) {
-                // invalid social id - show toast
-                retryCount = 0
-                postSideEffect(LoginSideEffect.SocialLoginError)
-            } else if (code == ErrorCode.NEED_SIGN_UP) {
-                // need sign up - nav to on boarding
-                retryCount = 0
-                postSideEffect(LoginSideEffect.NeedSignUp(provider, idToken))
-            } else if(code == ErrorCode.LOGIN_CLIENT_ERROR){
-                // client login handling error - show login error modal
-                if (retryCount < 3) {
-                    retryCount++
-                    postSideEffect(LoginSideEffect.RetryLogin(provider, idToken))
-                } else {
-                    retryCount = 0
-                    postSideEffect(LoginSideEffect.InquireLoginError(provider))
-                }
-            } else{
-                // throw base exception for base viewmodel to handle
-                throw BaseException(
-                    code = code,
-                    message = throwable.message,
-                    cause = throwable,
-                )
+            is LoginAction.RetryLogin -> {
+                handleRetryLogin(action.accessToken)
             }
         }
     }
+
+    private fun handleLogin(provider: AuthProvider) =
+        baseIntent {
+            reduce {
+                state.copy(isLoading = true)
+            }
+            retryCount = 0
+            login(provider).handle(onSuccess = {
+                reduce {
+                    state.copy(isLoading = false)
+                }
+                postSideEffect(LoginSideEffect.LoginSuccess)
+            }, onError = { throwable, code, data ->
+                reduce {
+                    state.copy(isLoading = false)
+                }
+                if (code == ErrorCode.INVALID_ID_TOKEN || code == ErrorCode.INVALID_KAKAO_ACCESS_TOKEN) {
+                    // invalid social id - show toast
+                    retryCount = 0
+                    postSideEffect(LoginSideEffect.SocialLoginError)
+                } else if (code == ErrorCode.NEED_SIGN_UP) {
+                    // need sign up - nav to on boarding
+                    retryCount = 0
+                    postSideEffect(LoginSideEffect.NeedSignUp(provider, data as String))
+                } else if (code == ErrorCode.LOGIN_CLIENT_ERROR) {
+                    // client login handling error - show login error modal
+                    retryCount++
+                    postSideEffect(LoginSideEffect.RetryLogin(data as String))
+                } else {
+                    // throw base exception for base viewmodel to handle
+                    throw BaseException(
+                        code = code,
+                        message = throwable.message,
+                        cause = throwable,
+                    )
+                }
+            })
+        }
+
+    private fun handleRetryLogin(
+        accessToken: String,
+    ) = baseIntent {
+        reduce {
+            state.copy(isLoading = true)
+        }
+        handleLoginUseCase(accessToken).handle(
+            onSuccess = {
+                reduce {
+                    state.copy(isLoading = false)
+                }
+                retryCount = 0
+                postSideEffect(LoginSideEffect.LoginSuccess)
+            },
+            onError = { throwable, code, data ->
+                reduce {
+                    state.copy(isLoading = false)
+                }
+                if (retryCount < 3) {
+                    retryCount++
+                    postSideEffect(LoginSideEffect.RetryLogin(data as String))
+                } else {
+                    retryCount = 0
+                    postSideEffect(LoginSideEffect.InquireLoginError)
+                }
+            },
+        )
+    }
+}

--- a/feat/auth/src/main/java/com/emotionstorage/auth/presentation/LoginViewModel.kt
+++ b/feat/auth/src/main/java/com/emotionstorage/auth/presentation/LoginViewModel.kt
@@ -1,10 +1,8 @@
 package com.emotionstorage.auth.presentation
 
 import com.emotionstorage.domain.common.ErrorCode
-import com.emotionstorage.domain.model.User
 import com.emotionstorage.domain.model.User.AuthProvider
 import com.emotionstorage.domain.useCase.auth.LoginUseCase
-import com.emotionstorage.presentation.BaseException
 import com.emotionstorage.presentation.BaseSideEffect
 import com.emotionstorage.presentation.BaseViewModel
 import com.orhanobut.logger.Logger
@@ -24,9 +22,9 @@ sealed class LoginAction {
 sealed class LoginSideEffect : BaseSideEffect {
     object LoginSuccess : LoginSideEffect()
 
-    object LoginErrorWithRetry : LoginSideEffect()
+    object RetryLogin : LoginSideEffect()
 
-    object LoginErrorWithInquiry : LoginSideEffect()
+    object InquireLoginError : LoginSideEffect()
 
     data class NeedSignUp(
         val provider: AuthProvider,
@@ -74,9 +72,9 @@ class LoginViewModel
             // show login error modal on any login errors
             if (retryCount < 3) {
                 retryCount++
-                postSideEffect(LoginSideEffect.LoginErrorWithRetry)
+                postSideEffect(LoginSideEffect.RetryLogin)
             } else {
-                postSideEffect(LoginSideEffect.LoginErrorWithInquiry)
+                postSideEffect(LoginSideEffect.InquireLoginError)
             }
         })
     }

--- a/feat/auth/src/main/java/com/emotionstorage/auth/presentation/LoginViewModel.kt
+++ b/feat/auth/src/main/java/com/emotionstorage/auth/presentation/LoginViewModel.kt
@@ -19,6 +19,11 @@ sealed class LoginAction {
     data class Login(
         val provider: AuthProvider,
     ) : LoginAction()
+
+    data class LoginWithIdToken(
+        val provider: AuthProvider,
+        val idToken: String,
+    ): LoginAction()
 }
 
 sealed class LoginSideEffect : BaseSideEffect {
@@ -34,7 +39,9 @@ sealed class LoginSideEffect : BaseSideEffect {
         val idToken: String,
     ) : LoginSideEffect()
 
-    object InquireLoginError : LoginSideEffect()
+    data class InquireLoginError(
+        val provider: AuthProvider
+    ) : LoginSideEffect()
 
     object LoginSuccess : LoginSideEffect()
 }
@@ -54,6 +61,9 @@ class LoginViewModel
         when (action) {
             is LoginAction.Login -> {
                 handleLogin(action.provider)
+            }
+            is LoginAction.LoginWithIdToken -> {
+                handleLogin(action.provider, action.idToken)
             }
         }
     }
@@ -112,7 +122,7 @@ class LoginViewModel
                 retryCount++
                 postSideEffect(LoginSideEffect.RetryLogin(provider, idToken))
             } else {
-                postSideEffect(LoginSideEffect.InquireLoginError)
+                postSideEffect(LoginSideEffect.InquireLoginError(provider))
             }
         }
     }

--- a/feat/auth/src/main/java/com/emotionstorage/auth/presentation/LoginViewModel.kt
+++ b/feat/auth/src/main/java/com/emotionstorage/auth/presentation/LoginViewModel.kt
@@ -122,6 +122,7 @@ class LoginViewModel
                 retryCount++
                 postSideEffect(LoginSideEffect.RetryLogin(provider, idToken))
             } else {
+                retryCount = 0
                 postSideEffect(LoginSideEffect.InquireLoginError(provider))
             }
         }

--- a/feat/auth/src/main/java/com/emotionstorage/auth/presentation/LoginViewModel.kt
+++ b/feat/auth/src/main/java/com/emotionstorage/auth/presentation/LoginViewModel.kt
@@ -45,91 +45,89 @@ sealed class LoginSideEffect : BaseSideEffect {
 @OptIn(OrbitExperimental::class)
 @HiltViewModel
 class LoginViewModel
-@Inject constructor(
-    private val login: LoginUseCase,
-    private val handleLoginUseCase: HandleLoginUseCase,
-
+    @Inject constructor(
+        private val login: LoginUseCase,
+        private val handleLoginUseCase: HandleLoginUseCase,
     ) : BaseViewModel<LoginState>(
-    LoginState(),
-) {
-    private var retryCount: Int = 0
+            LoginState(),
+        ) {
+        private var retryCount: Int = 0
 
-    fun onAction(action: LoginAction) {
-        when (action) {
-            is LoginAction.Login -> {
-                handleLogin(action.provider)
-            }
+        fun onAction(action: LoginAction) {
+            when (action) {
+                is LoginAction.Login -> {
+                    handleLogin(action.provider)
+                }
 
-            is LoginAction.RetryLogin -> {
-                handleRetryLogin(action.accessToken)
+                is LoginAction.RetryLogin -> {
+                    handleRetryLogin(action.accessToken)
+                }
             }
         }
-    }
 
-    private fun handleLogin(provider: AuthProvider) =
-        baseIntent {
-            reduce {
-                state.copy(isLoading = true)
-            }
-            retryCount = 0
-            login(provider).handle(onSuccess = {
+        private fun handleLogin(provider: AuthProvider) =
+            baseIntent {
                 reduce {
-                    state.copy(isLoading = false)
-                }
-                postSideEffect(LoginSideEffect.LoginSuccess)
-            }, onError = { throwable, code, data ->
-                reduce {
-                    state.copy(isLoading = false)
-                }
-                if (code == ErrorCode.INVALID_ID_TOKEN || code == ErrorCode.INVALID_KAKAO_ACCESS_TOKEN) {
-                    // invalid social id - show toast
-                    retryCount = 0
-                    postSideEffect(LoginSideEffect.SocialLoginError)
-                } else if (code == ErrorCode.NEED_SIGN_UP) {
-                    // need sign up - nav to on boarding
-                    retryCount = 0
-                    postSideEffect(LoginSideEffect.NeedSignUp(provider, data as String))
-                } else if (code == ErrorCode.LOGIN_CLIENT_ERROR) {
-                    // client login handling error - show login error modal
-                    retryCount++
-                    postSideEffect(LoginSideEffect.RetryLogin(data as String))
-                } else {
-                    // throw base exception for base viewmodel to handle
-                    throw BaseException(
-                        code = code,
-                        message = throwable.message,
-                        cause = throwable,
-                    )
-                }
-            })
-        }
-
-    private fun handleRetryLogin(
-        accessToken: String,
-    ) = baseIntent {
-        reduce {
-            state.copy(isLoading = true)
-        }
-        handleLoginUseCase(accessToken).handle(
-            onSuccess = {
-                reduce {
-                    state.copy(isLoading = false)
+                    state.copy(isLoading = true)
                 }
                 retryCount = 0
-                postSideEffect(LoginSideEffect.LoginSuccess)
-            },
-            onError = { throwable, code, data ->
+                login(provider).handle(onSuccess = {
+                    reduce {
+                        state.copy(isLoading = false)
+                    }
+                    postSideEffect(LoginSideEffect.LoginSuccess)
+                }, onError = { throwable, code, data ->
+                    reduce {
+                        state.copy(isLoading = false)
+                    }
+                    if (code == ErrorCode.INVALID_ID_TOKEN || code == ErrorCode.INVALID_KAKAO_ACCESS_TOKEN) {
+                        // invalid social id - show toast
+                        retryCount = 0
+                        postSideEffect(LoginSideEffect.SocialLoginError)
+                    } else if (code == ErrorCode.NEED_SIGN_UP) {
+                        // need sign up - nav to on boarding
+                        retryCount = 0
+                        postSideEffect(LoginSideEffect.NeedSignUp(provider, data as String))
+                    } else if (code == ErrorCode.LOGIN_CLIENT_ERROR) {
+                        // client login handling error - show login error modal
+                        retryCount++
+                        postSideEffect(LoginSideEffect.RetryLogin(data as String))
+                    } else {
+                        // throw base exception for base viewmodel to handle
+                        throw BaseException(
+                            code = code,
+                            message = throwable.message,
+                            cause = throwable,
+                        )
+                    }
+                })
+            }
+
+        private fun handleRetryLogin(accessToken: String) =
+            baseIntent {
                 reduce {
-                    state.copy(isLoading = false)
+                    state.copy(isLoading = true)
                 }
-                if (retryCount < 3) {
-                    retryCount++
-                    postSideEffect(LoginSideEffect.RetryLogin(data as String))
-                } else {
-                    retryCount = 0
-                    postSideEffect(LoginSideEffect.InquireLoginError)
-                }
-            },
-        )
+                handleLoginUseCase(accessToken).handle(
+                    onSuccess = {
+                        reduce {
+                            state.copy(isLoading = false)
+                        }
+                        retryCount = 0
+                        postSideEffect(LoginSideEffect.LoginSuccess)
+                    },
+                    onError = { throwable, code, data ->
+                        reduce {
+                            state.copy(isLoading = false)
+                        }
+                        if (retryCount < 3) {
+                            retryCount++
+                            postSideEffect(LoginSideEffect.RetryLogin(data as String))
+                        } else {
+                            retryCount = 0
+                            postSideEffect(LoginSideEffect.InquireLoginError)
+                        }
+                    },
+                )
+            }
     }
-}

--- a/feat/auth/src/main/java/com/emotionstorage/auth/presentation/LoginViewModel.kt
+++ b/feat/auth/src/main/java/com/emotionstorage/auth/presentation/LoginViewModel.kt
@@ -3,10 +3,12 @@ package com.emotionstorage.auth.presentation
 import com.emotionstorage.domain.common.ErrorCode
 import com.emotionstorage.domain.model.User.AuthProvider
 import com.emotionstorage.domain.useCase.auth.LoginUseCase
+import com.emotionstorage.domain.useCase.auth.LoginWithIdTokenUseCase
 import com.emotionstorage.presentation.BaseSideEffect
 import com.emotionstorage.presentation.BaseViewModel
 import com.orhanobut.logger.Logger
 import dagger.hilt.android.lifecycle.HiltViewModel
+import org.orbitmvi.orbit.annotation.OrbitExperimental
 import javax.inject.Inject
 
 data class LoginState(
@@ -20,22 +22,29 @@ sealed class LoginAction {
 }
 
 sealed class LoginSideEffect : BaseSideEffect {
-    object LoginSuccess : LoginSideEffect()
-
-    object RetryLogin : LoginSideEffect()
-
-    object InquireLoginError : LoginSideEffect()
+    object SocialLoginError : LoginSideEffect()
 
     data class NeedSignUp(
         val provider: AuthProvider,
         val idToken: String,
     ) : LoginSideEffect()
+
+    data class RetryLogin(
+        val provider: AuthProvider,
+        val idToken: String,
+    ) : LoginSideEffect()
+
+    object InquireLoginError : LoginSideEffect()
+
+    object LoginSuccess : LoginSideEffect()
 }
 
+@OptIn(OrbitExperimental::class)
 @HiltViewModel
 class LoginViewModel
 @Inject constructor(
     private val login: LoginUseCase,
+    private val loginWithIdToken: LoginWithIdTokenUseCase
 ) : BaseViewModel<LoginState>(
     LoginState(),
 ) {
@@ -62,20 +71,45 @@ class LoginViewModel
             reduce {
                 state.copy(isLoading = false)
             }
-            if (code == ErrorCode.NEED_SIGN_UP && data != null) {
-                val idToken = data as String
-                Logger.d("Need sign up, idToken: ${idToken.take(6)}...")
-                postSideEffect(LoginSideEffect.NeedSignUp(provider, idToken))
-                return@handle
-            }
+            handleLoginError(code, provider, data as? String)
+        })
+    }
 
+    private fun handleLogin(provider: AuthProvider, idToken: String) = baseIntent {
+        reduce {
+            state.copy(isLoading = true)
+        }
+        loginWithIdToken(provider, idToken).handle(
+            onSuccess = {
+                reduce {
+                    state.copy(isLoading = false)
+                }
+                postSideEffect(LoginSideEffect.LoginSuccess)
+            },
+            onError = { throwable, code, data ->
+                reduce {
+                    state.copy(isLoading = false)
+                }
+                handleLoginError(code, provider, idToken)
+            }
+        )
+    }
+
+    private suspend fun handleLoginError(code: ErrorCode, provider: AuthProvider, idToken: String?) = subIntent {
+        if (code == ErrorCode.INVALID_ID_TOKEN || code == ErrorCode.INVALID_KAKAO_ACCESS_TOKEN || idToken == null) {
+            // invalid social id - show toast
+            postSideEffect(LoginSideEffect.SocialLoginError)
+        } else if (code == ErrorCode.NEED_SIGN_UP) {
+            // need sign up - nav to on boarding
+            postSideEffect(LoginSideEffect.NeedSignUp(provider, idToken))
+        } else {
             // show login error modal on any login errors
             if (retryCount < 3) {
                 retryCount++
-                postSideEffect(LoginSideEffect.RetryLogin)
+                postSideEffect(LoginSideEffect.RetryLogin(provider, idToken))
             } else {
                 postSideEffect(LoginSideEffect.InquireLoginError)
             }
-        })
+        }
     }
 }

--- a/feat/auth/src/main/java/com/emotionstorage/auth/ui/LoginScreen.kt
+++ b/feat/auth/src/main/java/com/emotionstorage/auth/ui/LoginScreen.kt
@@ -17,6 +17,10 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
@@ -34,10 +38,17 @@ import com.emotionstorage.auth.presentation.LoginSideEffect
 import com.emotionstorage.auth.presentation.LoginState
 import com.emotionstorage.auth.presentation.LoginViewModel
 import com.emotionstorage.auth.ui.component.SocialLoginButton
+import com.emotionstorage.auth.ui.modal.RetryLoginModal
 import com.emotionstorage.domain.model.User.AuthProvider
 import com.emotionstorage.ui.component.loading.LoadingOverlay
 import com.emotionstorage.ui.theme.MooiTheme
 import com.emotionstorage.ui.util.buildHighlightAnnotatedString
+
+private enum class LoginModalState {
+    NONE,
+    RETRY_LOGIN,
+    INQUIRE_LOGIN_ERROR
+}
 
 @Composable
 fun LoginScreen(
@@ -47,6 +58,9 @@ fun LoginScreen(
     navToOnBoarding: (provider: AuthProvider, idToken: String) -> Unit = { _, _ -> },
 ) {
     val state = viewModel.container.stateFlow.collectAsState()
+    var modalState by remember {
+        mutableStateOf(LoginModalState.NONE)
+    }
 
     LaunchedEffect(Unit) {
         viewModel.container.sideEffectFlow.collect { effect ->
@@ -60,11 +74,11 @@ fun LoginScreen(
                 }
 
                 is LoginSideEffect.RetryLogin -> {
-                    // todo: show login retry modal
+                    modalState = LoginModalState.RETRY_LOGIN
                 }
 
                 is LoginSideEffect.InquireLoginError -> {
-                    // todo: show login error inquiry modal
+                    modalState = LoginModalState.INQUIRE_LOGIN_ERROR
                 }
             }
         }
@@ -75,6 +89,21 @@ fun LoginScreen(
         state = state.value,
         onAction = viewModel::onAction,
     )
+
+    when (modalState) {
+        LoginModalState.NONE -> {}
+
+        LoginModalState.RETRY_LOGIN -> {
+            RetryLoginModal {
+                viewModel.onAction(LoginAction.Login(AuthProvider.KAKAO))
+                modalState = LoginModalState.NONE
+            }
+        }
+
+        LoginModalState.INQUIRE_LOGIN_ERROR -> {
+            // todo: add login error inquiry modal
+        }
+    }
 }
 
 @Composable
@@ -154,7 +183,8 @@ private fun StatelessLoginScreen(
                         .background(
                             MooiTheme.colorScheme.backgroundTinted,
                             RoundedCornerShape(topStart = 20.dp, topEnd = 20.dp),
-                        ).padding(top = 26.dp, bottom = 36.dp)
+                        )
+                        .padding(top = 26.dp, bottom = 36.dp)
                         .padding(horizontal = 16.dp),
                 horizontalAlignment = Alignment.CenterHorizontally,
             ) {

--- a/feat/auth/src/main/java/com/emotionstorage/auth/ui/LoginScreen.kt
+++ b/feat/auth/src/main/java/com/emotionstorage/auth/ui/LoginScreen.kt
@@ -42,6 +42,7 @@ import com.emotionstorage.auth.ui.component.SocialLoginButton
 import com.emotionstorage.auth.ui.modal.InquireLoginErrorModal
 import com.emotionstorage.auth.ui.modal.RetryLoginModal
 import com.emotionstorage.domain.model.User.AuthProvider
+import com.emotionstorage.presentation.BaseSideEffect
 import com.emotionstorage.ui.component.loading.LoadingOverlay
 import com.emotionstorage.ui.component.toast.AppSnackbarHost
 import com.emotionstorage.ui.theme.MooiTheme
@@ -51,13 +52,10 @@ private sealed class LoginModalState {
     object None : LoginModalState()
 
     data class RetryLogin(
-        val provider: AuthProvider,
-        val idToken: String
+        val accessToken: String
     ) : LoginModalState()
 
-    data class InquireLoginError(
-        val provider: AuthProvider
-    ) : LoginModalState()
+    object InquireLoginError : LoginModalState()
 }
 
 @Composable
@@ -90,15 +88,20 @@ fun LoginScreen(
 
                 is LoginSideEffect.RetryLogin -> {
                     modalState = LoginModalState.RetryLogin(
-                        effect.provider,
-                        effect.idToken
+                        effect.accessToken
                     )
                 }
 
                 is LoginSideEffect.InquireLoginError -> {
-                    modalState = LoginModalState.InquireLoginError(
-                        effect.provider
-                    )
+                    modalState = LoginModalState.InquireLoginError
+                }
+
+                is BaseSideEffect.TemporalError -> {
+                    snackbarHostState.showSnackbar("로그인 실패")
+                }
+
+                is BaseSideEffect.NetworkError -> {
+                    snackbarHostState.showSnackbar("네트워크 연결 실패")
                 }
             }
         }
@@ -118,9 +121,8 @@ fun LoginScreen(
             RetryLoginModal {
                 // retry login with same provider & id token
                 viewModel.onAction(
-                    LoginAction.LoginWithIdToken(
-                        (modalState as LoginModalState.RetryLogin).provider,
-                        (modalState as LoginModalState.RetryLogin).idToken,
+                    LoginAction.RetryLogin(
+                        (modalState as LoginModalState.RetryLogin).accessToken
                     )
                 )
                 modalState = LoginModalState.None

--- a/feat/auth/src/main/java/com/emotionstorage/auth/ui/LoginScreen.kt
+++ b/feat/auth/src/main/java/com/emotionstorage/auth/ui/LoginScreen.kt
@@ -96,7 +96,6 @@ fun LoginScreen(
                 }
 
                 is LoginSideEffect.InquireLoginError -> {
-                    snackbarHostState.showSnackbar("로그인 에러 문의 팝업 표시")
                     modalState = LoginModalState.InquireLoginError(
                         effect.provider
                     )

--- a/feat/auth/src/main/java/com/emotionstorage/auth/ui/LoginScreen.kt
+++ b/feat/auth/src/main/java/com/emotionstorage/auth/ui/LoginScreen.kt
@@ -58,7 +58,7 @@ private sealed class LoginModalState {
 
     object InquireLoginError : LoginModalState()
 
-    object TempError: LoginModalState()
+    object TempError : LoginModalState()
 }
 
 @Composable
@@ -230,8 +230,7 @@ private fun StatelessLoginScreen(
                         .background(
                             MooiTheme.colorScheme.backgroundTinted,
                             RoundedCornerShape(topStart = 20.dp, topEnd = 20.dp),
-                        )
-                        .padding(top = 26.dp, bottom = 36.dp)
+                        ).padding(top = 26.dp, bottom = 36.dp)
                         .padding(horizontal = 16.dp),
                 horizontalAlignment = Alignment.CenterHorizontally,
             ) {

--- a/feat/auth/src/main/java/com/emotionstorage/auth/ui/LoginScreen.kt
+++ b/feat/auth/src/main/java/com/emotionstorage/auth/ui/LoginScreen.kt
@@ -13,6 +13,7 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.Scaffold
+import androidx.compose.material3.SnackbarHostState
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
@@ -41,13 +42,21 @@ import com.emotionstorage.auth.ui.component.SocialLoginButton
 import com.emotionstorage.auth.ui.modal.RetryLoginModal
 import com.emotionstorage.domain.model.User.AuthProvider
 import com.emotionstorage.ui.component.loading.LoadingOverlay
+import com.emotionstorage.ui.component.toast.AppSnackbarHost
 import com.emotionstorage.ui.theme.MooiTheme
 import com.emotionstorage.ui.util.buildHighlightAnnotatedString
 
-private enum class LoginModalState {
-    NONE,
-    RETRY_LOGIN,
-    INQUIRE_LOGIN_ERROR
+private sealed class LoginModalState {
+    object None : LoginModalState()
+
+    data class RetryLogin(
+        val provider: AuthProvider,
+        val idToken: String
+    ) : LoginModalState()
+
+    data class InquireLoginError(
+        val provider: AuthProvider
+    ) : LoginModalState()
 }
 
 @Composable
@@ -58,8 +67,9 @@ fun LoginScreen(
     navToOnBoarding: (provider: AuthProvider, idToken: String) -> Unit = { _, _ -> },
 ) {
     val state = viewModel.container.stateFlow.collectAsState()
+    val snackbarHostState = remember { SnackbarHostState() }
     var modalState by remember {
-        mutableStateOf(LoginModalState.NONE)
+        mutableStateOf<LoginModalState>(LoginModalState.None)
     }
 
     LaunchedEffect(Unit) {
@@ -73,12 +83,22 @@ fun LoginScreen(
                     navToOnBoarding(effect.provider, effect.idToken)
                 }
 
+                is LoginSideEffect.SocialLoginError -> {
+                    snackbarHostState.showSnackbar("소셜 로그인 실패")
+                }
+
                 is LoginSideEffect.RetryLogin -> {
-                    modalState = LoginModalState.RETRY_LOGIN
+                    modalState = LoginModalState.RetryLogin(
+                        effect.provider,
+                        effect.idToken
+                    )
                 }
 
                 is LoginSideEffect.InquireLoginError -> {
-                    modalState = LoginModalState.INQUIRE_LOGIN_ERROR
+                    snackbarHostState.showSnackbar("로그인 에러 문의 팝업 표시")
+                    modalState = LoginModalState.InquireLoginError(
+                        effect.provider
+                    )
                 }
             }
         }
@@ -86,21 +106,28 @@ fun LoginScreen(
 
     StatelessLoginScreen(
         modifier = modifier,
+        snackbarHostState = snackbarHostState,
         state = state.value,
         onAction = viewModel::onAction,
     )
 
     when (modalState) {
-        LoginModalState.NONE -> {}
+        is LoginModalState.None -> {}
 
-        LoginModalState.RETRY_LOGIN -> {
+        is LoginModalState.RetryLogin -> {
             RetryLoginModal {
-                viewModel.onAction(LoginAction.Login(AuthProvider.KAKAO))
-                modalState = LoginModalState.NONE
+                // retry login with same provider & id token
+                viewModel.onAction(
+                    LoginAction.LoginWithIdToken(
+                        (modalState as LoginModalState.RetryLogin).provider,
+                        (modalState as LoginModalState.RetryLogin).idToken,
+                    )
+                )
+                modalState = LoginModalState.None
             }
         }
 
-        LoginModalState.INQUIRE_LOGIN_ERROR -> {
+        is LoginModalState.InquireLoginError -> {
             // todo: add login error inquiry modal
         }
     }
@@ -109,6 +136,7 @@ fun LoginScreen(
 @Composable
 private fun StatelessLoginScreen(
     modifier: Modifier = Modifier,
+    snackbarHostState: SnackbarHostState = SnackbarHostState(),
     state: LoginState = LoginState(),
     onAction: (LoginAction) -> Unit = {},
 ) {
@@ -117,6 +145,11 @@ private fun StatelessLoginScreen(
             modifier
                 .background(MooiTheme.colorScheme.backgroundDefault)
                 .fillMaxSize(),
+        snackbarHost = {
+            AppSnackbarHost(
+                hostState = snackbarHostState,
+            )
+        }
     ) { padding ->
         Box(
             modifier =

--- a/feat/auth/src/main/java/com/emotionstorage/auth/ui/LoginScreen.kt
+++ b/feat/auth/src/main/java/com/emotionstorage/auth/ui/LoginScreen.kt
@@ -52,7 +52,7 @@ private sealed class LoginModalState {
     object None : LoginModalState()
 
     data class RetryLogin(
-        val accessToken: String
+        val accessToken: String,
     ) : LoginModalState()
 
     object InquireLoginError : LoginModalState()
@@ -87,9 +87,10 @@ fun LoginScreen(
                 }
 
                 is LoginSideEffect.RetryLogin -> {
-                    modalState = LoginModalState.RetryLogin(
-                        effect.accessToken
-                    )
+                    modalState =
+                        LoginModalState.RetryLogin(
+                            effect.accessToken,
+                        )
                 }
 
                 is LoginSideEffect.InquireLoginError -> {
@@ -101,7 +102,7 @@ fun LoginScreen(
                 }
 
                 is BaseSideEffect.NetworkError -> {
-                    snackbarHostState.showSnackbar("네트워크 연결 실패")
+                    snackbarHostState.showSnackbar("연결이 잠시 불안정해요. \uD83D\uDE22\n인터넷 연결을 확인 후 다시 시도해주세요.")
                 }
             }
         }
@@ -122,8 +123,8 @@ fun LoginScreen(
                 // retry login with same provider & id token
                 viewModel.onAction(
                     LoginAction.RetryLogin(
-                        (modalState as LoginModalState.RetryLogin).accessToken
-                    )
+                        (modalState as LoginModalState.RetryLogin).accessToken,
+                    ),
                 )
                 modalState = LoginModalState.None
             }
@@ -153,7 +154,7 @@ private fun StatelessLoginScreen(
             AppSnackbarHost(
                 hostState = snackbarHostState,
             )
-        }
+        },
     ) { padding ->
         Box(
             modifier =

--- a/feat/auth/src/main/java/com/emotionstorage/auth/ui/LoginScreen.kt
+++ b/feat/auth/src/main/java/com/emotionstorage/auth/ui/LoginScreen.kt
@@ -13,16 +13,13 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.Scaffold
-import androidx.compose.material3.SnackbarHostState
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
-import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.SpanStyle
@@ -41,8 +38,6 @@ import com.emotionstorage.domain.model.User.AuthProvider
 import com.emotionstorage.ui.component.loading.LoadingOverlay
 import com.emotionstorage.ui.theme.MooiTheme
 import com.emotionstorage.ui.util.buildHighlightAnnotatedString
-import com.orhanobut.logger.Logger
-import com.emotionstorage.presentation.BaseSideEffect
 
 @Composable
 fun LoginScreen(
@@ -64,11 +59,11 @@ fun LoginScreen(
                     navToOnBoarding(effect.provider, effect.idToken)
                 }
 
-                is LoginSideEffect.LoginErrorWithRetry -> {
+                is LoginSideEffect.RetryLogin -> {
                     // todo: show login retry modal
                 }
 
-                is LoginSideEffect.LoginErrorWithInquiry -> {
+                is LoginSideEffect.InquireLoginError -> {
                     // todo: show login error inquiry modal
                 }
             }

--- a/feat/auth/src/main/java/com/emotionstorage/auth/ui/LoginScreen.kt
+++ b/feat/auth/src/main/java/com/emotionstorage/auth/ui/LoginScreen.kt
@@ -44,6 +44,7 @@ import com.emotionstorage.auth.ui.modal.RetryLoginModal
 import com.emotionstorage.domain.model.User.AuthProvider
 import com.emotionstorage.presentation.BaseSideEffect
 import com.emotionstorage.ui.component.loading.LoadingOverlay
+import com.emotionstorage.ui.component.modal.TempErrorModal
 import com.emotionstorage.ui.component.toast.AppSnackbarHost
 import com.emotionstorage.ui.theme.MooiTheme
 import com.emotionstorage.ui.util.buildHighlightAnnotatedString
@@ -56,6 +57,8 @@ private sealed class LoginModalState {
     ) : LoginModalState()
 
     object InquireLoginError : LoginModalState()
+
+    object TempError: LoginModalState()
 }
 
 @Composable
@@ -97,12 +100,12 @@ fun LoginScreen(
                     modalState = LoginModalState.InquireLoginError
                 }
 
-                is BaseSideEffect.TemporalError -> {
-                    snackbarHostState.showSnackbar("로그인 실패")
-                }
-
                 is BaseSideEffect.NetworkError -> {
                     snackbarHostState.showSnackbar("연결이 잠시 불안정해요. \uD83D\uDE22\n인터넷 연결을 확인 후 다시 시도해주세요.")
+                }
+
+                is BaseSideEffect.TemporalError -> {
+                    modalState = LoginModalState.TempError
                 }
             }
         }
@@ -132,6 +135,12 @@ fun LoginScreen(
 
         is LoginModalState.InquireLoginError -> {
             InquireLoginErrorModal {
+                modalState = LoginModalState.None
+            }
+        }
+
+        is LoginModalState.TempError -> {
+            TempErrorModal {
                 modalState = LoginModalState.None
             }
         }

--- a/feat/auth/src/main/java/com/emotionstorage/auth/ui/LoginScreen.kt
+++ b/feat/auth/src/main/java/com/emotionstorage/auth/ui/LoginScreen.kt
@@ -51,10 +51,7 @@ fun LoginScreen(
     navToHome: () -> Unit = {},
     navToOnBoarding: (provider: AuthProvider, idToken: String) -> Unit = { _, _ -> },
 ) {
-    val context = LocalContext.current
-
     val state = viewModel.container.stateFlow.collectAsState()
-    val snackbarHostState = remember { SnackbarHostState() }
 
     LaunchedEffect(Unit) {
         viewModel.container.sideEffectFlow.collect { effect ->
@@ -67,13 +64,12 @@ fun LoginScreen(
                     navToOnBoarding(effect.provider, effect.idToken)
                 }
 
-                is BaseSideEffect.NetworkError -> {
-                    snackbarHostState.showSnackbar(context.getString(R.string.toast_network_error))
+                is LoginSideEffect.LoginErrorWithRetry -> {
+                    // todo: show login retry modal
                 }
 
-                else -> {
-                    Logger.e("Unknown side effect: $effect")
-                    // todo: add error modal
+                is LoginSideEffect.LoginErrorWithInquiry -> {
+                    // todo: show login error inquiry modal
                 }
             }
         }

--- a/feat/auth/src/main/java/com/emotionstorage/auth/ui/LoginScreen.kt
+++ b/feat/auth/src/main/java/com/emotionstorage/auth/ui/LoginScreen.kt
@@ -39,6 +39,7 @@ import com.emotionstorage.auth.presentation.LoginSideEffect
 import com.emotionstorage.auth.presentation.LoginState
 import com.emotionstorage.auth.presentation.LoginViewModel
 import com.emotionstorage.auth.ui.component.SocialLoginButton
+import com.emotionstorage.auth.ui.modal.InquireLoginErrorModal
 import com.emotionstorage.auth.ui.modal.RetryLoginModal
 import com.emotionstorage.domain.model.User.AuthProvider
 import com.emotionstorage.ui.component.loading.LoadingOverlay
@@ -128,7 +129,9 @@ fun LoginScreen(
         }
 
         is LoginModalState.InquireLoginError -> {
-            // todo: add login error inquiry modal
+            InquireLoginErrorModal {
+                modalState = LoginModalState.None
+            }
         }
     }
 }

--- a/feat/auth/src/main/java/com/emotionstorage/auth/ui/modal/InquireLoginErrorModal.kt
+++ b/feat/auth/src/main/java/com/emotionstorage/auth/ui/modal/InquireLoginErrorModal.kt
@@ -1,0 +1,54 @@
+package com.emotionstorage.auth.ui.modal
+
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.tooling.preview.Preview
+import com.emotionstorage.ui.component.Modal
+
+/**
+ * login_02
+ * - 표출 조건(트리거)
+ *     - Case : 로그인 처리 최종 실패
+ *     login_01 알럿을 3번 표출 후 최종 실패 처리가 되었을 때 표시
+ * - 표시 화면
+ *     - 2.1 로그인 화면
+ * - CTA 및 이동
+ *     - [이메일로 문의하기] -> 팝업 닫히며 이메일 작성 인텐트 시작(화면 유지)
+ *     - [닫기] -> 팝업 닫히며 이동 X(재시도 유도)
+ * - 차단
+ *   - 뒤로가기(Android) O (팝업 닫힘, 화면 제자리)
+ *   - push/pop X
+ *   - 하단바 상호작용 X (하단바 없음)
+ *   - 배경 터치 O (팝업 닫힘, 화면 제자리)
+ *   - 스크롤 X
+ */
+@Composable
+fun InquireLoginErrorModal(
+    onDismissRequest: () -> Unit,
+) {
+    Modal(
+        onDismissRequest = onDismissRequest,
+        topDescription = "여러 번 시도했지만\n로그인에 계속 문제가 있어요.",
+        title = "잠시 후 다시 시도하거나\n메일로 문의해주세요.",
+        confirmLabel = "이메일로 문의하기",
+        onConfirm = {
+            // todo: start email intent
+            onDismissRequest()
+        },
+        dismissLabel = "닫기",
+        onDismiss = onDismissRequest,
+    )
+}
+
+@Preview(showBackground = true)
+@Composable
+private fun InquireLoginErrorModalPreview() {
+    // background ui
+    Box(modifier = Modifier.fillMaxSize())
+
+    InquireLoginErrorModal(
+        onDismissRequest = {},
+    )
+}

--- a/feat/auth/src/main/java/com/emotionstorage/auth/ui/modal/InquireLoginErrorModal.kt
+++ b/feat/auth/src/main/java/com/emotionstorage/auth/ui/modal/InquireLoginErrorModal.kt
@@ -25,9 +25,7 @@ import com.emotionstorage.ui.component.Modal
  *   - 스크롤 X
  */
 @Composable
-fun InquireLoginErrorModal(
-    onDismissRequest: () -> Unit,
-) {
+fun InquireLoginErrorModal(onDismissRequest: () -> Unit) {
     Modal(
         onDismissRequest = onDismissRequest,
         topDescription = "여러 번 시도했지만\n로그인에 계속 문제가 있어요.",

--- a/feat/auth/src/main/java/com/emotionstorage/auth/ui/modal/InquireLoginErrorModal.kt
+++ b/feat/auth/src/main/java/com/emotionstorage/auth/ui/modal/InquireLoginErrorModal.kt
@@ -5,7 +5,7 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.tooling.preview.Preview
-import com.emotionstorage.ui.component.Modal
+import com.emotionstorage.ui.component.modal.Modal
 
 /**
  * login_02

--- a/feat/auth/src/main/java/com/emotionstorage/auth/ui/modal/RetryLoginModal.kt
+++ b/feat/auth/src/main/java/com/emotionstorage/auth/ui/modal/RetryLoginModal.kt
@@ -28,9 +28,7 @@ import com.emotionstorage.ui.component.Modal
  *     - 스크롤 X
  */
 @Composable
-fun RetryLoginModal(
-    onConfirm: () -> Unit
-) {
+fun RetryLoginModal(onConfirm: () -> Unit) {
     // todo: disable back press to dismiss
     Modal(
         onDismissRequest = {

--- a/feat/auth/src/main/java/com/emotionstorage/auth/ui/modal/RetryLoginModal.kt
+++ b/feat/auth/src/main/java/com/emotionstorage/auth/ui/modal/RetryLoginModal.kt
@@ -31,6 +31,7 @@ import com.emotionstorage.ui.component.Modal
 fun RetryLoginModal(
     onConfirm: () -> Unit
 ) {
+    // todo: disable back press to dismiss
     Modal(
         onDismissRequest = {
             // disable bg click to dismiss

--- a/feat/auth/src/main/java/com/emotionstorage/auth/ui/modal/RetryLoginModal.kt
+++ b/feat/auth/src/main/java/com/emotionstorage/auth/ui/modal/RetryLoginModal.kt
@@ -29,11 +29,11 @@ import com.emotionstorage.ui.component.Modal
  */
 @Composable
 fun RetryLoginModal(onConfirm: () -> Unit) {
-    // todo: disable back press to dismiss
     Modal(
         onDismissRequest = {
             // disable bg click to dismiss
         },
+        disableBackPress = true,
         title = "일시적인 문제로\n로그인이 완료되지 않았어요.\n잠시 후 다시 시도해주세요.",
         bottomDescription = "네트워크가 불안정한 경우에도\n이런 현상이 발생할 수 있어요.",
         confirmLabel = "다시 로그인하기",

--- a/feat/auth/src/main/java/com/emotionstorage/auth/ui/modal/RetryLoginModal.kt
+++ b/feat/auth/src/main/java/com/emotionstorage/auth/ui/modal/RetryLoginModal.kt
@@ -5,7 +5,7 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.tooling.preview.Preview
-import com.emotionstorage.ui.component.Modal
+import com.emotionstorage.ui.component.modal.Modal
 
 /**
  * login_01

--- a/feat/auth/src/main/java/com/emotionstorage/auth/ui/modal/RetryLoginModal.kt
+++ b/feat/auth/src/main/java/com/emotionstorage/auth/ui/modal/RetryLoginModal.kt
@@ -1,0 +1,52 @@
+package com.emotionstorage.auth.ui.modal
+
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.tooling.preview.Preview
+import com.emotionstorage.ui.component.Modal
+
+/**
+ * login_01
+ * - 표출 조건(트리거)
+ *     - Case : 로그인 처리 실패
+ *     로그인 요청 자체는 성공하였으나, 로그인 처리(세션/유저 정보 저장 등)에 실패한 경우 표시
+ *     (서버 오류 아님)
+ * - 표시 화면
+ *     - 2.1 로그인 화면
+ * - CTA 및 이동
+ *     - [다시 로그인하기]
+ *     -> 로딩 애니메이션과 함께 로그인 재시도
+ *     -> 재시도 실패 시 팝업 다시 표출(2회 더, 총 3회)
+ *     -> 최종 실패 시 login_02 팝업 표출
+ * - 차단
+ *     - 뒤로가기(Android) X
+ *     - push/pop X
+ *     - 하단바 상호작용 X (하단바 없음)
+ *     - 배경 터치 X
+ *     - 스크롤 X
+ */
+@Composable
+fun RetryLoginModal(
+    onConfirm: () -> Unit
+) {
+    Modal(
+        onDismissRequest = {
+            // disable bg click to dismiss
+        },
+        title = "일시적인 문제로\n로그인이 완료되지 않았어요.\n잠시 후 다시 시도해주세요.",
+        bottomDescription = "네트워크가 불안정한 경우에도\n이런 현상이 발생할 수 있어요.",
+        confirmLabel = "다시 로그인하기",
+        onConfirm = onConfirm,
+    )
+}
+
+@Preview(showBackground = true)
+@Composable
+private fun RetryLoginModalPreview() {
+    // background ui
+    Box(modifier = Modifier.fillMaxSize())
+
+    RetryLoginModal { }
+}

--- a/feat/daily-report/src/main/java/com/emotionstorage/daily_report/ui/DailyReportDetailScreen.kt
+++ b/feat/daily-report/src/main/java/com/emotionstorage/daily_report/ui/DailyReportDetailScreen.kt
@@ -37,7 +37,7 @@ import com.emotionstorage.daily_report.ui.component.DailyReportKeywords
 import com.emotionstorage.daily_report.ui.component.DailyReportSummaries
 import com.emotionstorage.domain.model.DailyReport
 import com.emotionstorage.domain.model.DailyReport.EmotionLog
-import com.emotionstorage.ui.component.Modal
+import com.emotionstorage.ui.component.modal.Modal
 import com.emotionstorage.ui.component.loading.LoadingScreen
 import com.emotionstorage.ui.component.appBar.TopAppBar
 import com.emotionstorage.ui.theme.MooiTheme

--- a/feat/my/src/main/java/com/emotionstorage/my/ui/myPage/MyPageScreen.kt
+++ b/feat/my/src/main/java/com/emotionstorage/my/ui/myPage/MyPageScreen.kt
@@ -38,7 +38,7 @@ import com.emotionstorage.my.presentation.MyPageViewModel
 import com.emotionstorage.my.ui.keyDescription.component.KeyCard
 import com.emotionstorage.my.ui.myPage.component.MenuSection
 import com.emotionstorage.my.ui.myPage.component.ProfileHeader
-import com.emotionstorage.ui.component.Modal
+import com.emotionstorage.ui.component.modal.Modal
 import com.emotionstorage.ui.theme.MooiTheme
 import com.orhanobut.logger.Logger
 

--- a/feat/my/src/main/java/com/emotionstorage/my/ui/withdraw/WithDrawNoticeScreen.kt
+++ b/feat/my/src/main/java/com/emotionstorage/my/ui/withdraw/WithDrawNoticeScreen.kt
@@ -21,7 +21,7 @@ import androidx.hilt.navigation.compose.hiltViewModel
 import com.emotionstorage.my.presentation.MyPageAction
 import com.emotionstorage.my.presentation.MyPageSideEffect
 import com.emotionstorage.my.presentation.MyPageViewModel
-import com.emotionstorage.ui.component.Modal
+import com.emotionstorage.ui.component.modal.Modal
 import com.emotionstorage.ui.component.appBar.TopAppBar
 import com.emotionstorage.ui.component.button.CtaButton
 import com.emotionstorage.ui.component.button.CtaButtonType

--- a/feat/time-capsule-detail/src/main/java/com/emotionstorage/time_capsule_detail/ui/modal/CheckOpenDateModal.kt
+++ b/feat/time-capsule-detail/src/main/java/com/emotionstorage/time_capsule_detail/ui/modal/CheckOpenDateModal.kt
@@ -25,7 +25,7 @@ import androidx.compose.ui.text.withStyle
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import com.emotionstorage.ui.R
-import com.emotionstorage.ui.component.Modal
+import com.emotionstorage.ui.component.modal.Modal
 import com.emotionstorage.ui.theme.MooiTheme
 import java.time.LocalDate
 import java.time.format.DateTimeFormatter

--- a/feat/time-capsule-detail/src/main/java/com/emotionstorage/time_capsule_detail/ui/modal/DeleteTimeCapsuleModal.kt
+++ b/feat/time-capsule-detail/src/main/java/com/emotionstorage/time_capsule_detail/ui/modal/DeleteTimeCapsuleModal.kt
@@ -5,7 +5,7 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.tooling.preview.Preview
-import com.emotionstorage.ui.component.Modal
+import com.emotionstorage.ui.component.modal.Modal
 
 @Composable
 fun DeleteTimeCapsuleModal(

--- a/feat/time-capsule-detail/src/main/java/com/emotionstorage/time_capsule_detail/ui/modal/ExitTimeCapsuleModal.kt
+++ b/feat/time-capsule-detail/src/main/java/com/emotionstorage/time_capsule_detail/ui/modal/ExitTimeCapsuleModal.kt
@@ -20,7 +20,7 @@ import androidx.compose.ui.text.withStyle
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
-import com.emotionstorage.ui.component.Modal
+import com.emotionstorage.ui.component.modal.Modal
 import com.emotionstorage.ui.theme.MooiTheme
 
 @Composable

--- a/feat/time-capsule-detail/src/main/java/com/emotionstorage/time_capsule_detail/ui/modal/SaveChangesModal.kt
+++ b/feat/time-capsule-detail/src/main/java/com/emotionstorage/time_capsule_detail/ui/modal/SaveChangesModal.kt
@@ -5,7 +5,7 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.tooling.preview.Preview
-import com.emotionstorage.ui.component.Modal
+import com.emotionstorage.ui.component.modal.Modal
 
 @Composable
 fun SaveChangesModal(

--- a/feat/time-capsule-detail/src/main/java/com/emotionstorage/time_capsule_detail/ui/modal/TimeCapsuleExpiredModal.kt
+++ b/feat/time-capsule-detail/src/main/java/com/emotionstorage/time_capsule_detail/ui/modal/TimeCapsuleExpiredModal.kt
@@ -5,7 +5,7 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.tooling.preview.Preview
-import com.emotionstorage.ui.component.Modal
+import com.emotionstorage.ui.component.modal.Modal
 
 @Composable
 fun TimeCapsuleExpiredModal(onConfirm: () -> Unit = {}) {

--- a/feat/time-capsule-detail/src/main/java/com/emotionstorage/time_capsule_detail/ui/modal/TimeCapsuleSavedModal.kt
+++ b/feat/time-capsule-detail/src/main/java/com/emotionstorage/time_capsule_detail/ui/modal/TimeCapsuleSavedModal.kt
@@ -6,7 +6,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.tooling.preview.Preview
-import com.emotionstorage.ui.component.Modal
+import com.emotionstorage.ui.component.modal.Modal
 import kotlinx.coroutines.delay
 
 @Composable

--- a/feat/time-capsule-detail/src/main/java/com/emotionstorage/time_capsule_detail/ui/modal/TimeCapsuleUnlockModal.kt
+++ b/feat/time-capsule-detail/src/main/java/com/emotionstorage/time_capsule_detail/ui/modal/TimeCapsuleUnlockModal.kt
@@ -26,7 +26,7 @@ import com.emotionstorage.common.getDaysBetween
 import com.emotionstorage.ui.R
 import com.emotionstorage.ui.component.CountDownTimer
 import com.emotionstorage.ui.component.button.CtaButton
-import com.emotionstorage.ui.component.Modal
+import com.emotionstorage.ui.component.modal.Modal
 import com.emotionstorage.ui.theme.MooiTheme
 import java.time.LocalDate
 import java.time.LocalDateTime

--- a/feat/tutorial/src/main/java/com/emotionstorage/tutorial/presentation/SplashViewModel.kt
+++ b/feat/tutorial/src/main/java/com/emotionstorage/tutorial/presentation/SplashViewModel.kt
@@ -1,6 +1,5 @@
 package com.emotionstorage.tutorial.presentation
 
-import com.emotionstorage.domain.common.DataState
 import com.emotionstorage.domain.useCase.auth.AutomaticLoginUseCase
 import com.orhanobut.logger.Logger
 import com.emotionstorage.presentation.BaseException
@@ -22,35 +21,35 @@ sealed class SplashSideEffect : BaseSideEffect {
 
 @HiltViewModel
 class SplashViewModel
-@Inject
-constructor(
-    private val automaticLogin: AutomaticLoginUseCase,
-) : BaseViewModel<Unit>(
-    initialState = Unit,
-) {
-    suspend fun onAction(action: SplashAction) {
-        when (action) {
-            SplashAction.Init -> {
-                delay(SPLASH_DURATION)
-                handleAutoLogin()
+    @Inject
+    constructor(
+        private val automaticLogin: AutomaticLoginUseCase,
+    ) : BaseViewModel<Unit>(
+            initialState = Unit,
+        ) {
+        suspend fun onAction(action: SplashAction) {
+            when (action) {
+                SplashAction.Init -> {
+                    delay(SPLASH_DURATION)
+                    handleAutoLogin()
+                }
             }
         }
-    }
 
-    private fun handleAutoLogin() =
-        baseIntent {
-            automaticLogin().handle(
-                onSuccess = {
-                    Logger.i("Auto login success")
-                    postSideEffect(SplashSideEffect.AutoLoginSuccess)
-                },
-                onError = { throwable, code, data ->
-                    throw BaseException(
-                        message = throwable.message,
-                        code = code,
-                        cause = throwable,
-                    )
-                }
-            )
-        }
-}
+        private fun handleAutoLogin() =
+            baseIntent {
+                automaticLogin().handle(
+                    onSuccess = {
+                        Logger.i("Auto login success")
+                        postSideEffect(SplashSideEffect.AutoLoginSuccess)
+                    },
+                    onError = { throwable, code, data ->
+                        throw BaseException(
+                            message = throwable.message,
+                            code = code,
+                            cause = throwable,
+                        )
+                    },
+                )
+            }
+    }

--- a/feat/tutorial/src/main/java/com/emotionstorage/tutorial/presentation/SplashViewModel.kt
+++ b/feat/tutorial/src/main/java/com/emotionstorage/tutorial/presentation/SplashViewModel.kt
@@ -22,44 +22,35 @@ sealed class SplashSideEffect : BaseSideEffect {
 
 @HiltViewModel
 class SplashViewModel
-    @Inject
-    constructor(
-        private val automaticLogin: AutomaticLoginUseCase,
-    ) : BaseViewModel<Unit>(
-            initialState = Unit,
-        ) {
-        suspend fun onAction(action: SplashAction) {
-            when (action) {
-                SplashAction.Init -> {
-                    delay(SPLASH_DURATION)
-                    handleAutoLogin()
-                }
+@Inject
+constructor(
+    private val automaticLogin: AutomaticLoginUseCase,
+) : BaseViewModel<Unit>(
+    initialState = Unit,
+) {
+    suspend fun onAction(action: SplashAction) {
+        when (action) {
+            SplashAction.Init -> {
+                delay(SPLASH_DURATION)
+                handleAutoLogin()
             }
         }
-
-        private fun handleAutoLogin() =
-            baseIntent {
-                automaticLogin().collect { result ->
-                    Logger.d("SplashViewModel handleAutoLogin, result: $result")
-
-                    when (result) {
-                        is DataState.Loading -> {
-                            // do nothing
-                        }
-
-                        is DataState.Success -> {
-                            Logger.i("Auto login success")
-                            postSideEffect(SplashSideEffect.AutoLoginSuccess)
-                        }
-
-                        is DataState.Error -> {
-                            throw BaseException(
-                                message = result.throwable.message,
-                                code = result.code,
-                                cause = result.throwable,
-                            )
-                        }
-                    }
-                }
-            }
     }
+
+    private fun handleAutoLogin() =
+        baseIntent {
+            automaticLogin().handle(
+                onSuccess = {
+                    Logger.i("Auto login success")
+                    postSideEffect(SplashSideEffect.AutoLoginSuccess)
+                },
+                onError = { throwable, code, data ->
+                    throw BaseException(
+                        message = throwable.message,
+                        code = code,
+                        cause = throwable,
+                    )
+                }
+            )
+        }
+}

--- a/feat/tutorial/src/main/java/com/emotionstorage/tutorial/ui/onBoarding/NicknameScreen.kt
+++ b/feat/tutorial/src/main/java/com/emotionstorage/tutorial/ui/onBoarding/NicknameScreen.kt
@@ -35,7 +35,7 @@ import com.emotionstorage.tutorial.presentation.onBoarding.NicknameViewModel.Sta
 import com.emotionstorage.tutorial.ui.component.OnBoardingTitle
 import com.emotionstorage.ui.component.button.CtaButton
 import com.emotionstorage.ui.component.HideKeyboard
-import com.emotionstorage.ui.component.Modal
+import com.emotionstorage.ui.component.modal.Modal
 import com.emotionstorage.ui.component.text.TextInput
 import com.emotionstorage.ui.component.text.TextInputState
 import com.emotionstorage.ui.component.appBar.TopAppBar


### PR DESCRIPTION
## Issue
- #163
## 작업 상세 내용
- 로그인 화면 로그인 오류 처리 로직 작업
  - 소셜 토큰 오류 - '소셜 로그인 실패' 토스트 표시 (*디버깅용*)
  - 회원가입 필요 - 소셜 id 토큰 전달하여 온보딩 화면 이동
  - **클라이언트 로그인 처리 오류 - 로그인 처리 재시도 팝업(login_01) 3회 표출 -> 로그인 오류 문의 팝업 표출(login_02)**
  (*이메일 인텐트 구현 필요*)
  - 네트워크 오류 - 네트워크 오류 토스트(common_error_01) 표시
  - 서버 내부 오류 - 일시적인 오류 팝업(common_error_02) 표시
- Auth 관련 유즈케이스 로직 리팩토링
  - 로그인 처리 로직 **HandleLoginUseCase로 분리 -> 에러 시 LOGIN_CLIENT_ERROR 에러코드 반환**
  - 로그아웃 처리 로직 HAndleLogoutUseCase로 분리 -> 에러 무시

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * 로그인 재시도 모달과 재시도 흐름 도입
  * 반복 로그인 실패 시 고객문의(이메일) 안내 모달 추가
  * 임시 오류를 보여주는 모달 추가 및 모달에 뒤로가기 비활성화 옵션 제공
  * 로그인 관련 토큰 처리·재시도 UI 강화 및 안내 메시지 추가

* **Bug Fixes**
  * 소셜 로그인 오류 코드별 처리 세분화
  * 세션 확인 및 자동 로그인 안정성 개선

* **Refactor**
  * 로그인/로그아웃 책임 분리로 제어 흐름 단순화

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->