### PR TITLE
Dev/withdraw error modal 로그아웃 & 회원탈퇴 에러 팝업 작업

### DIFF
--- a/core/remote/src/main/java/com/emotionstorage/remote/dataSourceImpl/AuthRemoteDataSourceImpl.kt
+++ b/core/remote/src/main/java/com/emotionstorage/remote/dataSourceImpl/AuthRemoteDataSourceImpl.kt
@@ -121,6 +121,6 @@ class AuthRemoteDataSourceImpl
 
         override suspend fun deleteAccount(): Boolean {
             val response = authApiService.deleteAccount()
-            return response.status == ResponseStatus.OK.code
+            return response.status == ResponseStatus.NoContent.code
         }
     }

--- a/core/ui/src/main/java/com/emotionstorage/ui/component/modal/Modal.kt
+++ b/core/ui/src/main/java/com/emotionstorage/ui/component/modal/Modal.kt
@@ -48,20 +48,9 @@ fun Modal(
     onDismiss: () -> Unit = {},
     contentPadding: PaddingValues = PaddingValues(top = 22.dp, bottom = 28.dp, start = 30.dp, end = 30.dp),
     verticalSpacing: Dp = 18.dp,
-    showBackground: Boolean = true,
     topOuterContent: @Composable (() -> Unit)? = null,
     content: @Composable (() -> Unit)? = null,
 ) {
-    if (showBackground) {
-        // set bg color to black with 0.8 alpha (80% opacity)
-        Box(
-            modifier =
-                Modifier
-                    .fillMaxSize()
-                    .background(Color.Black.copy(alpha = 0.8f)),
-        )
-    }
-
     Dialog(
         onDismissRequest = onDismissRequest,
         properties =
@@ -84,7 +73,7 @@ fun Modal(
                         .clip(RoundedCornerShape(15.dp))
                         .background(MooiTheme.colorScheme.backgroundDefault)
                         .padding(contentPadding)
-                        .widthIn(max = 293.dp),
+                        .widthIn(max = 298.dp),
                 verticalArrangement = Arrangement.spacedBy(verticalSpacing),
                 horizontalAlignment = Alignment.CenterHorizontally,
             ) {

--- a/data/src/main/java/com/emotionstorage/data/repoImpl/UserRepositoryImpl.kt
+++ b/data/src/main/java/com/emotionstorage/data/repoImpl/UserRepositoryImpl.kt
@@ -35,10 +35,9 @@ class UserRepositoryImpl
                         .map {
                             it.toUser()
                         }.also {
-                            if (it is DataState.Success)
-                                {
-                                    localDataSource.saveUser(UserMapper.toData(it.data))
-                                }
+                            if (it is DataState.Success) {
+                                localDataSource.saveUser(UserMapper.toData(it.data))
+                            }
                         }
                 }
             } catch (e: Exception) {

--- a/data/src/main/java/com/emotionstorage/data/repoImpl/UserRepositoryImpl.kt
+++ b/data/src/main/java/com/emotionstorage/data/repoImpl/UserRepositoryImpl.kt
@@ -4,6 +4,7 @@ import com.emotionstorage.data.dataSource.local.UserLocalDataSource
 import com.emotionstorage.data.dataSource.remote.UserRemoteDataSource
 import com.emotionstorage.data.modelMapper.UserMapper
 import com.emotionstorage.domain.common.DataState
+import com.emotionstorage.domain.common.map
 import com.emotionstorage.domain.model.AccountInfo
 import com.emotionstorage.domain.model.User
 import com.emotionstorage.domain.model.toUser
@@ -14,69 +15,85 @@ import kotlinx.coroutines.flow.flow
 import javax.inject.Inject
 
 class UserRepositoryImpl
-    @Inject
-    constructor(
-        private val localDataSource: UserLocalDataSource,
-        private val remoteDataSource: UserRemoteDataSource,
-    ) : UserRepository {
-        override suspend fun saveUser(user: User): Boolean = localDataSource.saveUser(UserMapper.toData(user))
+@Inject
+constructor(
+    private val localDataSource: UserLocalDataSource,
+    private val remoteDataSource: UserRemoteDataSource,
+) : UserRepository {
+    override suspend fun saveUser(user: User): Boolean = localDataSource.saveUser(UserMapper.toData(user))
 
-        override suspend fun getUser(): Flow<DataState<User>> =
-            flow {
-                emit(DataState.Loading(isLoading = true))
-                try {
-                    // return user from local data source first
-                    val localUser = localDataSource.getUser()
-                    if (localUser != null) {
-                        emit(DataState.Success(UserMapper.toDomain(localUser)))
-                    } else {
-                        // fetch user from remote & save to local & return
-                        remoteDataSource.getUserAccountInfo().handle(
-                            onSuccess = {
-                                localDataSource.saveUser(UserMapper.toData(it.toUser()))
-                                emit(DataState.Success(it.toUser()))
-                            },
-                            onError = { throwable, code, message ->
-                                emit(DataState.Error(throwable, code, message))
-                            },
-                        )
-                    }
-                } catch (e: Exception) {
-                    emit(DataState.Error(e))
-                } finally {
-                    emit(DataState.Loading(isLoading = false))
+    override suspend fun getUserSnapshot(): DataState<User> =
+        try {
+            // return user from local data source first
+            val localUser = localDataSource.getUser()
+            if (localUser != null) {
+                DataState.Success(UserMapper.toDomain(localUser))
+            } else {
+                // fetch user from remote & save to local & return
+                remoteDataSource.getUserAccountInfo().map{
+                    it.toUser()
                 }
             }
+        } catch (e: Exception) {
+            DataState.Error(e)
+        }
 
-        override suspend fun getAndSaveUser(): Boolean =
+    override suspend fun getUser(): Flow<DataState<User>> =
+        flow {
+            emit(DataState.Loading(isLoading = true))
             try {
-                val result = remoteDataSource.getUserAccountInfo()
-                if (result is DataState.Success) {
-                    localDataSource.saveUser(UserMapper.toData(result.data.toUser()))
+                // return user from local data source first
+                val localUser = localDataSource.getUser()
+                if (localUser != null) {
+                    emit(DataState.Success(UserMapper.toDomain(localUser)))
                 } else {
-                    false
+                    // fetch user from remote & save to local & return
+                    remoteDataSource.getUserAccountInfo().handle(
+                        onSuccess = {
+                            localDataSource.saveUser(UserMapper.toData(it.toUser()))
+                            emit(DataState.Success(it.toUser()))
+                        },
+                        onError = { throwable, code, message ->
+                            emit(DataState.Error(throwable, code, message))
+                        },
+                    )
                 }
             } catch (e: Exception) {
-                Napier.e("getAndSaveUser error", e)
+                emit(DataState.Error(e))
+            } finally {
+                emit(DataState.Loading(isLoading = false))
+            }
+        }
+
+    override suspend fun getAndSaveUser(): Boolean =
+        try {
+            val result = remoteDataSource.getUserAccountInfo()
+            if (result is DataState.Success) {
+                localDataSource.saveUser(UserMapper.toData(result.data.toUser()))
+            } else {
                 false
             }
+        } catch (e: Exception) {
+            Napier.e("getAndSaveUser error", e)
+            false
+        }
 
-        override suspend fun deleteUser(): Boolean = localDataSource.deleteUser()
+    override suspend fun deleteUser(): Boolean = localDataSource.deleteUser()
 
-        override suspend fun updateUserNickname(nickname: String) =
-            remoteDataSource
-                .updateUserNickname(nickname)
-                .also { state ->
-                    if (state is DataState.Success) {
-                        val localUpdateSuccess = localDataSource.updateUserNickname(nickname)
-                        if (!localUpdateSuccess) {
-                            // delete user on update error - fetch user on next get user call
-                            deleteUser()
-                        }
+    override suspend fun updateUserNickname(nickname: String) =
+        remoteDataSource
+            .updateUserNickname(nickname)
+            .also { state ->
+                if (state is DataState.Success) {
+                    val localUpdateSuccess = localDataSource.updateUserNickname(nickname)
+                    if (!localUpdateSuccess) {
+                        // delete user on update error - fetch user on next get user call
+                        deleteUser()
                     }
                 }
+            }
 
-        override suspend fun getKeyCount(): DataState<Int> = remoteDataSource.getKeyCount()
+    override suspend fun getKeyCount(): DataState<Int> = remoteDataSource.getKeyCount()
 
-        override suspend fun getAccountInfo(): DataState<AccountInfo> = remoteDataSource.getUserAccountInfo()
-    }
+    override suspend fun getAccountInfo(): DataState<AccountInfo> = remoteDataSource.getUserAccountInfo()
+}

--- a/data/src/main/java/com/emotionstorage/data/repoImpl/UserRepositoryImpl.kt
+++ b/data/src/main/java/com/emotionstorage/data/repoImpl/UserRepositoryImpl.kt
@@ -30,13 +30,16 @@ class UserRepositoryImpl
                     DataState.Success(UserMapper.toDomain(localUser))
                 } else {
                     // fetch user from remote & save to local & return
-                    remoteDataSource.getUserAccountInfo().map {
-                        it.toUser()
-                    }.also{
-                        if(it is DataState.Success){
-                            localDataSource.saveUser(UserMapper.toData(it.data))
+                    remoteDataSource
+                        .getUserAccountInfo()
+                        .map {
+                            it.toUser()
+                        }.also {
+                            if (it is DataState.Success)
+                                {
+                                    localDataSource.saveUser(UserMapper.toData(it.data))
+                                }
                         }
-                    }
                 }
             } catch (e: Exception) {
                 DataState.Error(e)

--- a/data/src/main/java/com/emotionstorage/data/repoImpl/UserRepositoryImpl.kt
+++ b/data/src/main/java/com/emotionstorage/data/repoImpl/UserRepositoryImpl.kt
@@ -39,8 +39,8 @@ class UserRepositoryImpl
                                 // save to local if successful
                                 try {
                                     val isSaveSuccess = localDataSource.saveUser(UserMapper.toData(it.data))
-                                    if(!isSaveSuccess) throw Exception("save user failed")
-                                }catch (e: Exception){
+                                    if (!isSaveSuccess) throw Exception("save user failed")
+                                } catch (e: Exception) {
                                     Napier.e("save user failed", e)
                                 }
                             }
@@ -65,8 +65,8 @@ class UserRepositoryImpl
                                 // save to local if successful
                                 try {
                                     val isSaveSuccess = localDataSource.saveUser(UserMapper.toData(it.toUser()))
-                                    if(!isSaveSuccess) throw Exception("save user failed")
-                                }catch (e: Exception){
+                                    if (!isSaveSuccess) throw Exception("save user failed")
+                                } catch (e: Exception) {
                                     Napier.e("save user failed", e)
                                 }
                                 // return success with remote user data, regardless of save success/failure

--- a/data/src/main/java/com/emotionstorage/data/repoImpl/UserRepositoryImpl.kt
+++ b/data/src/main/java/com/emotionstorage/data/repoImpl/UserRepositoryImpl.kt
@@ -15,85 +15,85 @@ import kotlinx.coroutines.flow.flow
 import javax.inject.Inject
 
 class UserRepositoryImpl
-@Inject
-constructor(
-    private val localDataSource: UserLocalDataSource,
-    private val remoteDataSource: UserRemoteDataSource,
-) : UserRepository {
-    override suspend fun saveUser(user: User): Boolean = localDataSource.saveUser(UserMapper.toData(user))
+    @Inject
+    constructor(
+        private val localDataSource: UserLocalDataSource,
+        private val remoteDataSource: UserRemoteDataSource,
+    ) : UserRepository {
+        override suspend fun saveUser(user: User): Boolean = localDataSource.saveUser(UserMapper.toData(user))
 
-    override suspend fun getUserSnapshot(): DataState<User> =
-        try {
-            // return user from local data source first
-            val localUser = localDataSource.getUser()
-            if (localUser != null) {
-                DataState.Success(UserMapper.toDomain(localUser))
-            } else {
-                // fetch user from remote & save to local & return
-                remoteDataSource.getUserAccountInfo().map{
-                    it.toUser()
-                }
-            }
-        } catch (e: Exception) {
-            DataState.Error(e)
-        }
-
-    override suspend fun getUser(): Flow<DataState<User>> =
-        flow {
-            emit(DataState.Loading(isLoading = true))
+        override suspend fun getUserSnapshot(): DataState<User> =
             try {
                 // return user from local data source first
                 val localUser = localDataSource.getUser()
                 if (localUser != null) {
-                    emit(DataState.Success(UserMapper.toDomain(localUser)))
+                    DataState.Success(UserMapper.toDomain(localUser))
                 } else {
                     // fetch user from remote & save to local & return
-                    remoteDataSource.getUserAccountInfo().handle(
-                        onSuccess = {
-                            localDataSource.saveUser(UserMapper.toData(it.toUser()))
-                            emit(DataState.Success(it.toUser()))
-                        },
-                        onError = { throwable, code, message ->
-                            emit(DataState.Error(throwable, code, message))
-                        },
-                    )
-                }
-            } catch (e: Exception) {
-                emit(DataState.Error(e))
-            } finally {
-                emit(DataState.Loading(isLoading = false))
-            }
-        }
-
-    override suspend fun getAndSaveUser(): Boolean =
-        try {
-            val result = remoteDataSource.getUserAccountInfo()
-            if (result is DataState.Success) {
-                localDataSource.saveUser(UserMapper.toData(result.data.toUser()))
-            } else {
-                false
-            }
-        } catch (e: Exception) {
-            Napier.e("getAndSaveUser error", e)
-            false
-        }
-
-    override suspend fun deleteUser(): Boolean = localDataSource.deleteUser()
-
-    override suspend fun updateUserNickname(nickname: String) =
-        remoteDataSource
-            .updateUserNickname(nickname)
-            .also { state ->
-                if (state is DataState.Success) {
-                    val localUpdateSuccess = localDataSource.updateUserNickname(nickname)
-                    if (!localUpdateSuccess) {
-                        // delete user on update error - fetch user on next get user call
-                        deleteUser()
+                    remoteDataSource.getUserAccountInfo().map {
+                        it.toUser()
                     }
                 }
+            } catch (e: Exception) {
+                DataState.Error(e)
             }
 
-    override suspend fun getKeyCount(): DataState<Int> = remoteDataSource.getKeyCount()
+        override suspend fun getUser(): Flow<DataState<User>> =
+            flow {
+                emit(DataState.Loading(isLoading = true))
+                try {
+                    // return user from local data source first
+                    val localUser = localDataSource.getUser()
+                    if (localUser != null) {
+                        emit(DataState.Success(UserMapper.toDomain(localUser)))
+                    } else {
+                        // fetch user from remote & save to local & return
+                        remoteDataSource.getUserAccountInfo().handle(
+                            onSuccess = {
+                                localDataSource.saveUser(UserMapper.toData(it.toUser()))
+                                emit(DataState.Success(it.toUser()))
+                            },
+                            onError = { throwable, code, message ->
+                                emit(DataState.Error(throwable, code, message))
+                            },
+                        )
+                    }
+                } catch (e: Exception) {
+                    emit(DataState.Error(e))
+                } finally {
+                    emit(DataState.Loading(isLoading = false))
+                }
+            }
 
-    override suspend fun getAccountInfo(): DataState<AccountInfo> = remoteDataSource.getUserAccountInfo()
-}
+        override suspend fun getAndSaveUser(): Boolean =
+            try {
+                val result = remoteDataSource.getUserAccountInfo()
+                if (result is DataState.Success) {
+                    localDataSource.saveUser(UserMapper.toData(result.data.toUser()))
+                } else {
+                    false
+                }
+            } catch (e: Exception) {
+                Napier.e("getAndSaveUser error", e)
+                false
+            }
+
+        override suspend fun deleteUser(): Boolean = localDataSource.deleteUser()
+
+        override suspend fun updateUserNickname(nickname: String) =
+            remoteDataSource
+                .updateUserNickname(nickname)
+                .also { state ->
+                    if (state is DataState.Success) {
+                        val localUpdateSuccess = localDataSource.updateUserNickname(nickname)
+                        if (!localUpdateSuccess) {
+                            // delete user on update error - fetch user on next get user call
+                            deleteUser()
+                        }
+                    }
+                }
+
+        override suspend fun getKeyCount(): DataState<Int> = remoteDataSource.getKeyCount()
+
+        override suspend fun getAccountInfo(): DataState<AccountInfo> = remoteDataSource.getUserAccountInfo()
+    }

--- a/data/src/main/java/com/emotionstorage/data/repoImpl/UserRepositoryImpl.kt
+++ b/data/src/main/java/com/emotionstorage/data/repoImpl/UserRepositoryImpl.kt
@@ -32,6 +32,10 @@ class UserRepositoryImpl
                     // fetch user from remote & save to local & return
                     remoteDataSource.getUserAccountInfo().map {
                         it.toUser()
+                    }.also{
+                        if(it is DataState.Success){
+                            localDataSource.saveUser(UserMapper.toData(it.data))
+                        }
                     }
                 }
             } catch (e: Exception) {

--- a/data/src/main/java/com/emotionstorage/data/repoImpl/UserRepositoryImpl.kt
+++ b/data/src/main/java/com/emotionstorage/data/repoImpl/UserRepositoryImpl.kt
@@ -69,7 +69,6 @@ class UserRepositoryImpl
                                 }catch (e: Exception){
                                     Napier.e("save user failed", e)
                                 }
-
                                 // return success with remote user data, regardless of save success/failure
                                 emit(DataState.Success(it.toUser()))
                             },
@@ -91,6 +90,7 @@ class UserRepositoryImpl
                 if (result is DataState.Success) {
                     localDataSource.saveUser(UserMapper.toData(result.data.toUser()))
                 } else {
+                    Napier.e("getUser error in getAndSaveUser", (result as DataState.Error).throwable)
                     false
                 }
             } catch (e: Exception) {

--- a/data/src/main/java/com/emotionstorage/data/repoImpl/UserRepositoryImpl.kt
+++ b/data/src/main/java/com/emotionstorage/data/repoImpl/UserRepositoryImpl.kt
@@ -29,14 +29,20 @@ class UserRepositoryImpl
                 if (localUser != null) {
                     DataState.Success(UserMapper.toDomain(localUser))
                 } else {
-                    // fetch user from remote & save to local & return
+                    // fetch user from remote
                     remoteDataSource
                         .getUserAccountInfo()
                         .map {
                             it.toUser()
                         }.also {
                             if (it is DataState.Success) {
-                                localDataSource.saveUser(UserMapper.toData(it.data))
+                                // save to local if successful
+                                try {
+                                    val isSaveSuccess = localDataSource.saveUser(UserMapper.toData(it.data))
+                                    if(!isSaveSuccess) throw Exception("save user failed")
+                                }catch (e: Exception){
+                                    Napier.e("save user failed", e)
+                                }
                             }
                         }
                 }
@@ -53,10 +59,18 @@ class UserRepositoryImpl
                     if (localUser != null) {
                         emit(DataState.Success(UserMapper.toDomain(localUser)))
                     } else {
-                        // fetch user from remote & save to local & return
+                        // fetch user from remote
                         remoteDataSource.getUserAccountInfo().handle(
                             onSuccess = {
-                                localDataSource.saveUser(UserMapper.toData(it.toUser()))
+                                // save to local if successful
+                                try {
+                                    val isSaveSuccess = localDataSource.saveUser(UserMapper.toData(it.toUser()))
+                                    if(!isSaveSuccess) throw Exception("save user failed")
+                                }catch (e: Exception){
+                                    Napier.e("save user failed", e)
+                                }
+
+                                // return success with remote user data, regardless of save success/failure
                                 emit(DataState.Success(it.toUser()))
                             },
                             onError = { throwable, code, message ->

--- a/domain/src/main/java/com/emotionstorage/domain/repo/UserRepository.kt
+++ b/domain/src/main/java/com/emotionstorage/domain/repo/UserRepository.kt
@@ -8,6 +8,8 @@ import kotlinx.coroutines.flow.Flow
 interface UserRepository {
     suspend fun saveUser(user: User): Boolean
 
+    suspend fun getUserSnapshot(): DataState<User>
+
     suspend fun getUser(): Flow<DataState<User>>
 
     suspend fun getAndSaveUser(): Boolean

--- a/domain/src/main/java/com/emotionstorage/domain/useCase/user/GetUserEmailAndNicknameUseCase.kt
+++ b/domain/src/main/java/com/emotionstorage/domain/useCase/user/GetUserEmailAndNicknameUseCase.kt
@@ -5,7 +5,7 @@ import com.emotionstorage.domain.repo.UserRepository
 import javax.inject.Inject
 
 class GetUserEmailAndNicknameUseCase @Inject constructor(
-    private val userRepository: UserRepository
+    private val userRepository: UserRepository,
 ) {
     suspend operator fun invoke(): Pair<String, String>? {
         val userResult = userRepository.getUserSnapshot()

--- a/domain/src/main/java/com/emotionstorage/domain/useCase/user/GetUserEmailAndNicknameUseCase.kt
+++ b/domain/src/main/java/com/emotionstorage/domain/useCase/user/GetUserEmailAndNicknameUseCase.kt
@@ -1,0 +1,19 @@
+package com.emotionstorage.domain.useCase.user
+
+import com.emotionstorage.domain.common.DataState
+import com.emotionstorage.domain.repo.UserRepository
+import javax.inject.Inject
+
+class GetUserEmailAndNicknameUseCase @Inject constructor(
+    private val userRepository: UserRepository
+) {
+    suspend operator fun invoke(): Pair<String, String>? {
+        val userResult = userRepository.getUserSnapshot()
+
+        return if (userResult is DataState.Success) {
+            Pair(userResult.data.email, userResult.data.nickname)
+        } else {
+            null
+        }
+    }
+}

--- a/feat/auth/src/main/java/com/emotionstorage/auth/ui/LoginScreen.kt
+++ b/feat/auth/src/main/java/com/emotionstorage/auth/ui/LoginScreen.kt
@@ -130,6 +130,7 @@ fun LoginScreen(
         is LoginModalState.None -> {}
 
         is LoginModalState.RetryHandleLogin -> {
+            val retryState = modalState as LoginModalState.RetryHandleLogin
             RetryHandleLoginModal(
                 onDismissRequest = {
                     modalState = LoginModalState.None
@@ -137,7 +138,7 @@ fun LoginScreen(
                 onConfirm = {
                     viewModel.onAction(
                         LoginAction.RetryLogin(
-                            (modalState as LoginModalState.RetryHandleLogin).accessToken,
+                            retryState.accessToken,
                         ),
                     )
                 },

--- a/feat/auth/src/main/java/com/emotionstorage/auth/ui/modal/RetryLoginModal.kt
+++ b/feat/auth/src/main/java/com/emotionstorage/auth/ui/modal/RetryLoginModal.kt
@@ -4,13 +4,20 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.tooling.preview.Preview
 import com.emotionstorage.ui.component.modal.Modal
 
-// todo: 알럿 정의서에 따라 코멘트 내용 수정하기
-
 /**
- * 로그인 재시도 팝업
- * 회원가입 완료 화면에서, 회원가입 성공 but 로그인 실패한 경우 표시
- * [다시 로그인하기] -> 로그인 화면으로 이동
- * 배경 클릭 X, 뒤로가기 X
+ * login_03
+ * - Case : 가입 완료 직후 로그인 요청 실패(네트워크 오류 포함)
+ *      - 가입완료 화면에서 [메인 화면으로 이동]을 눌렀을 때, 로그인 실패 시 중앙 차단 팝업 표출
+ * - 표시 화면
+ *      - 2.6 온보딩(5) - 가입 완료 화면
+ * - CTA 및 이동
+ *      - [다시 로그인하기] -> 로그인 화면으로 이동
+ * - 차단
+ *      - 뒤로가기(Android) X
+ *      - push/pop X
+ *      - 하단바 상호작용 X (하단바 없음)
+ *      - 배경 터치 X
+ *      - 스크롤 X
  */
 @Composable
 fun RetryLoginModal(

--- a/feat/my/src/main/java/com/emotionstorage/my/presentation/MyPageViewModel.kt
+++ b/feat/my/src/main/java/com/emotionstorage/my/presentation/MyPageViewModel.kt
@@ -25,16 +25,12 @@ sealed class MyPageAction {
     object Initiate : MyPageAction()
 
     object Logout : MyPageAction()
-
-    object WithDraw : MyPageAction()
 }
 
 sealed class MyPageSideEffect {
     object LogoutSuccess : MyPageSideEffect()
 
     object LogoutError: MyPageSideEffect()
-
-    object WithDrawSuccess : MyPageSideEffect()
 
     data class ShowToast(
         val message: String,
@@ -44,7 +40,6 @@ sealed class MyPageSideEffect {
 @HiltViewModel
 class MyPageViewModel @Inject constructor(
     private val logoutUseCase: LogoutUseCase,
-    private val deleteAccountUseCase: DeleteAccountUseCase,
     private val myPageOverviewUseCase: GetMyPageOverviewUseCase,
 ) : ViewModel(),
     ContainerHost<MyPageState, MyPageSideEffect> {
@@ -58,10 +53,6 @@ class MyPageViewModel @Inject constructor(
 
             is MyPageAction.Logout -> {
                 handleLogout()
-            }
-
-            is MyPageAction.WithDraw -> {
-                handleWithDraw()
             }
         }
     }
@@ -104,16 +95,6 @@ class MyPageViewModel @Inject constructor(
             } catch (t: Throwable) {
                 Logger.e("LogoutUseCase error: $t")
                 postSideEffect(MyPageSideEffect.LogoutError)
-            }
-        }
-
-    private fun handleWithDraw() =
-        intent {
-            try {
-                deleteAccountUseCase()
-                postSideEffect(MyPageSideEffect.WithDrawSuccess)
-            } catch (t: Throwable) {
-                postSideEffect(MyPageSideEffect.ShowToast(t.message ?: "회원탈퇴 실패"))
             }
         }
 

--- a/feat/my/src/main/java/com/emotionstorage/my/presentation/MyPageViewModel.kt
+++ b/feat/my/src/main/java/com/emotionstorage/my/presentation/MyPageViewModel.kt
@@ -2,7 +2,6 @@ package com.emotionstorage.my.presentation
 
 import androidx.lifecycle.ViewModel
 import com.emotionstorage.domain.common.DataState
-import com.emotionstorage.domain.useCase.auth.DeleteAccountUseCase
 import com.emotionstorage.domain.useCase.auth.LogoutUseCase
 import com.emotionstorage.domain.useCase.myPage.GetMyPageOverviewUseCase
 import com.emotionstorage.my.BuildConfig
@@ -30,7 +29,7 @@ sealed class MyPageAction {
 sealed class MyPageSideEffect {
     object LogoutSuccess : MyPageSideEffect()
 
-    object LogoutError: MyPageSideEffect()
+    object LogoutError : MyPageSideEffect()
 
     data class ShowToast(
         val message: String,
@@ -87,15 +86,15 @@ class MyPageViewModel @Inject constructor(
     private fun handleLogout() =
         intent {
             try {
-                if(logoutUseCase()) {
+                if (logoutUseCase()) {
                     postSideEffect(MyPageSideEffect.LogoutSuccess)
-                }else{
-                    postSideEffect(MyPageSideEffect.LogoutError)
-                }
+                } else
+                    {
+                        postSideEffect(MyPageSideEffect.LogoutError)
+                    }
             } catch (t: Throwable) {
                 Logger.e("LogoutUseCase error: $t")
                 postSideEffect(MyPageSideEffect.LogoutError)
             }
         }
-
 }

--- a/feat/my/src/main/java/com/emotionstorage/my/presentation/MyPageViewModel.kt
+++ b/feat/my/src/main/java/com/emotionstorage/my/presentation/MyPageViewModel.kt
@@ -6,6 +6,7 @@ import com.emotionstorage.domain.useCase.auth.DeleteAccountUseCase
 import com.emotionstorage.domain.useCase.auth.LogoutUseCase
 import com.emotionstorage.domain.useCase.myPage.GetMyPageOverviewUseCase
 import com.emotionstorage.my.BuildConfig
+import com.orhanobut.logger.Logger
 import dagger.hilt.android.lifecycle.HiltViewModel
 import org.orbitmvi.orbit.ContainerHost
 import org.orbitmvi.orbit.viewmodel.container
@@ -95,9 +96,13 @@ class MyPageViewModel @Inject constructor(
     private fun handleLogout() =
         intent {
             try {
-                logoutUseCase()
-                postSideEffect(MyPageSideEffect.LogoutSuccess)
+                if(logoutUseCase()) {
+                    postSideEffect(MyPageSideEffect.LogoutSuccess)
+                }else{
+                    postSideEffect(MyPageSideEffect.LogoutError)
+                }
             } catch (t: Throwable) {
+                Logger.e("LogoutUseCase error: $t")
                 postSideEffect(MyPageSideEffect.LogoutError)
             }
         }

--- a/feat/my/src/main/java/com/emotionstorage/my/presentation/MyPageViewModel.kt
+++ b/feat/my/src/main/java/com/emotionstorage/my/presentation/MyPageViewModel.kt
@@ -41,6 +41,8 @@ sealed class MyPageAction {
 sealed class MyPageSideEffect {
     object LogoutSuccess : MyPageSideEffect()
 
+    object LogoutError: MyPageSideEffect()
+
     object NavigateToNicknameChange : MyPageSideEffect()
 
     object NavigateToAccountInfo : MyPageSideEffect()
@@ -140,7 +142,7 @@ class MyPageViewModel @Inject constructor(
                 logoutUseCase()
                 postSideEffect(MyPageSideEffect.LogoutSuccess)
             } catch (t: Throwable) {
-                postSideEffect(MyPageSideEffect.ShowToast(t.message ?: "로그아웃 실패"))
+                postSideEffect(MyPageSideEffect.LogoutError)
             }
         }
 

--- a/feat/my/src/main/java/com/emotionstorage/my/presentation/MyPageViewModel.kt
+++ b/feat/my/src/main/java/com/emotionstorage/my/presentation/MyPageViewModel.kt
@@ -25,17 +25,7 @@ sealed class MyPageAction {
 
     object Logout : MyPageAction()
 
-    object NicknameChange : MyPageAction()
-
-    object KeyDescription : MyPageAction()
-
-    object AccountInfo : MyPageAction()
-
-    object TermsAndPrivacy : MyPageAction()
-
-    object WithDrawConfirm : MyPageAction()
-
-    object NotificationSetting : MyPageAction()
+    object WithDraw : MyPageAction()
 }
 
 sealed class MyPageSideEffect {
@@ -43,21 +33,7 @@ sealed class MyPageSideEffect {
 
     object LogoutError: MyPageSideEffect()
 
-    object NavigateToNicknameChange : MyPageSideEffect()
-
-    object NavigateToAccountInfo : MyPageSideEffect()
-
-    object NavigateToKeyDescription : MyPageSideEffect()
-
-    object NavigateToNotificationSetting : MyPageSideEffect()
-
-    object NavigateToTermsAndPrivacy : MyPageSideEffect()
-
-    object NavigateToWithDrawNotice : MyPageSideEffect()
-
     object WithDrawSuccess : MyPageSideEffect()
-
-    object NavigateToSplash : MyPageSideEffect()
 
     data class ShowToast(
         val message: String,
@@ -79,32 +55,12 @@ class MyPageViewModel @Inject constructor(
                 handleInitiate()
             }
 
-            is MyPageAction.NicknameChange -> {
-                handleNicknameChange()
-            }
-
             is MyPageAction.Logout -> {
                 handleLogout()
             }
 
-            is MyPageAction.KeyDescription -> {
-                handleKeyDescription()
-            }
-
-            is MyPageAction.AccountInfo -> {
-                handleAccountInfo()
-            }
-
-            is MyPageAction.TermsAndPrivacy -> {
-                handleTermsAndPrivacy()
-            }
-
-            is MyPageAction.WithDrawConfirm -> {
+            is MyPageAction.WithDraw -> {
                 handleWithDraw()
-            }
-
-            is MyPageAction.NotificationSetting -> {
-                handleNotificationSetting()
             }
         }
     }
@@ -146,39 +102,14 @@ class MyPageViewModel @Inject constructor(
             }
         }
 
-    private fun handleNicknameChange() =
-        intent {
-            postSideEffect(MyPageSideEffect.NavigateToNicknameChange)
-        }
-
-    private fun handleKeyDescription() =
-        intent {
-            postSideEffect(MyPageSideEffect.NavigateToKeyDescription)
-        }
-
-    private fun handleTermsAndPrivacy() =
-        intent {
-            postSideEffect(MyPageSideEffect.NavigateToTermsAndPrivacy)
-        }
-
     private fun handleWithDraw() =
         intent {
             try {
                 deleteAccountUseCase()
                 postSideEffect(MyPageSideEffect.WithDrawSuccess)
-                postSideEffect(MyPageSideEffect.NavigateToSplash)
             } catch (t: Throwable) {
                 postSideEffect(MyPageSideEffect.ShowToast(t.message ?: "회원탈퇴 실패"))
             }
         }
 
-    private fun handleAccountInfo() =
-        intent {
-            postSideEffect(MyPageSideEffect.NavigateToAccountInfo)
-        }
-
-    private fun handleNotificationSetting() =
-        intent {
-            postSideEffect(MyPageSideEffect.NavigateToNotificationSetting)
-        }
 }

--- a/feat/my/src/main/java/com/emotionstorage/my/presentation/MyPageViewModel.kt
+++ b/feat/my/src/main/java/com/emotionstorage/my/presentation/MyPageViewModel.kt
@@ -88,10 +88,9 @@ class MyPageViewModel @Inject constructor(
             try {
                 if (logoutUseCase()) {
                     postSideEffect(MyPageSideEffect.LogoutSuccess)
-                } else
-                    {
-                        postSideEffect(MyPageSideEffect.LogoutError)
-                    }
+                } else {
+                    postSideEffect(MyPageSideEffect.LogoutError)
+                }
             } catch (t: Throwable) {
                 Logger.e("LogoutUseCase error: $t")
                 postSideEffect(MyPageSideEffect.LogoutError)

--- a/feat/my/src/main/java/com/emotionstorage/my/presentation/WithdrawNoticeViewModel.kt
+++ b/feat/my/src/main/java/com/emotionstorage/my/presentation/WithdrawNoticeViewModel.kt
@@ -31,10 +31,10 @@ sealed class WithdrawNoticeEffect : BaseSideEffect {
 @HiltViewModel
 class WithdrawNoticeViewModel @Inject constructor(
     private val deleteAccountUseCase: DeleteAccountUseCase,
-    private val getUserEmailAndNickname: GetUserEmailAndNicknameUseCase
+    private val getUserEmailAndNickname: GetUserEmailAndNicknameUseCase,
 ) : BaseViewModel<WithdrawNoticeState>(
-    WithdrawNoticeState(),
-) {
+        WithdrawNoticeState(),
+    ) {
     fun onAction(action: WithdrawNoticeAction) {
         when (action) {
             is WithdrawNoticeAction.WithDraw -> {
@@ -43,40 +43,44 @@ class WithdrawNoticeViewModel @Inject constructor(
         }
     }
 
-    private fun handleWithDraw() = intent {
-        reduce {
-            state.copy(isLoading = true)
-        }
-        try {
-            if (deleteAccountUseCase()) {
-                postSideEffect(WithdrawNoticeEffect.WithDrawSuccess)
+    private fun handleWithDraw() =
+        intent {
+            reduce {
+                state.copy(isLoading = true)
+            }
+            try {
+                if (deleteAccountUseCase()) {
+                    postSideEffect(WithdrawNoticeEffect.WithDrawSuccess)
+                    reduce {
+                        state.copy(isLoading = false)
+                    }
+                } else {
+                    throw Throwable("deleteAccountUseCase failed")
+                }
+            } catch (t: Throwable) {
+                Logger.e("deleteAccountUseCase error $t")
+
+                // get user email & nickname if possible
+                var email: String? = null
+                var nickname: String? = null
+                runCatching {
+                    getUserEmailAndNickname()?.let {
+                        email = it.first
+                        nickname = it.second
+                    }
+                }
+
                 reduce {
                     state.copy(isLoading = false)
                 }
-            } else {
-                throw Throwable("deleteAccountUseCase failed")
-            }
-        } catch (t: Throwable) {
-            Logger.e("deleteAccountUseCase error $t")
-
-            // get user email & nickname if possible
-            var email: String? = null
-            var nickname: String? = null
-            runCatching {
-                getUserEmailAndNickname()?.let {
-                    email = it.first
-                    nickname = it.second
-                }
-            }
-
-            reduce {
-                state.copy(isLoading = false)
-            }
-            postSideEffect(
-                WithdrawNoticeEffect.WithdrawError(
-                    ErrorCode.UNKNOWN, t, email, nickname
+                postSideEffect(
+                    WithdrawNoticeEffect.WithdrawError(
+                        ErrorCode.UNKNOWN,
+                        t,
+                        email,
+                        nickname,
+                    ),
                 )
-            )
+            }
         }
-    }
 }

--- a/feat/my/src/main/java/com/emotionstorage/my/presentation/WithdrawNoticeViewModel.kt
+++ b/feat/my/src/main/java/com/emotionstorage/my/presentation/WithdrawNoticeViewModel.kt
@@ -2,6 +2,7 @@ package com.emotionstorage.my.presentation
 
 import com.emotionstorage.domain.common.ErrorCode
 import com.emotionstorage.domain.useCase.auth.DeleteAccountUseCase
+import com.emotionstorage.domain.useCase.user.GetUserEmailAndNicknameUseCase
 import com.emotionstorage.presentation.BaseSideEffect
 import com.emotionstorage.presentation.BaseViewModel
 import com.orhanobut.logger.Logger
@@ -22,15 +23,18 @@ sealed class WithdrawNoticeEffect : BaseSideEffect {
     data class WithdrawError(
         val errorCode: ErrorCode,
         val throwable: Throwable,
+        val userEmail: String? = null,
+        val userNickname: String? = null,
     ) : WithdrawNoticeEffect()
 }
 
 @HiltViewModel
 class WithdrawNoticeViewModel @Inject constructor(
     private val deleteAccountUseCase: DeleteAccountUseCase,
+    private val getUserEmailAndNickname: GetUserEmailAndNicknameUseCase
 ) : BaseViewModel<WithdrawNoticeState>(
-        WithdrawNoticeState(),
-    ) {
+    WithdrawNoticeState(),
+) {
     fun onAction(action: WithdrawNoticeAction) {
         when (action) {
             is WithdrawNoticeAction.WithDraw -> {
@@ -39,31 +43,40 @@ class WithdrawNoticeViewModel @Inject constructor(
         }
     }
 
-    private fun handleWithDraw() =
-        intent {
+    private fun handleWithDraw() = intent {
+        reduce {
+            state.copy(isLoading = true)
+        }
+        try {
+            if (deleteAccountUseCase()) {
+                postSideEffect(WithdrawNoticeEffect.WithDrawSuccess)
+                reduce {
+                    state.copy(isLoading = false)
+                }
+            } else {
+                throw Throwable("deleteAccountUseCase failed")
+            }
+        } catch (t: Throwable) {
+            Logger.e("deleteAccountUseCase error $t")
+
+            // get user email & nickname if possible
+            var email: String? = null
+            var nickname: String? = null
+            runCatching {
+                getUserEmailAndNickname()?.let {
+                    email = it.first
+                    nickname = it.second
+                }
+            }
+
+            reduce {
+                state.copy(isLoading = false)
+            }
             postSideEffect(
                 WithdrawNoticeEffect.WithdrawError(
-                    ErrorCode.UNKNOWN,
-                    Throwable(
-                        "deleteAccountUseCase failed",
-                    ),
-                ),
+                    ErrorCode.UNKNOWN, t, email, nickname
+                )
             )
-            try {
-//                if (deleteAccountUseCase()) {
-//                    postSideEffect(WithdrawNoticeEffect.WithDrawSuccess)
-//                } else {
-//                    postSideEffect(
-//                        WithdrawNoticeEffect.WithdrawError(
-//                            ErrorCode.UNKNOWN, Throwable(
-//                                "deleteAccountUseCase failed"
-//                            )
-//                        )
-//                    )
-//                }
-            } catch (t: Throwable) {
-                Logger.e("deleteAccountUseCase error $t")
-                postSideEffect(WithdrawNoticeEffect.WithdrawError(ErrorCode.UNKNOWN, t))
-            }
         }
+    }
 }

--- a/feat/my/src/main/java/com/emotionstorage/my/presentation/WithdrawNoticeViewModel.kt
+++ b/feat/my/src/main/java/com/emotionstorage/my/presentation/WithdrawNoticeViewModel.kt
@@ -17,7 +17,6 @@ sealed class WithdrawNoticeAction {
 }
 
 sealed class WithdrawNoticeEffect : BaseSideEffect {
-
     object WithDrawSuccess : WithdrawNoticeEffect()
 
     data class WithdrawError(
@@ -30,8 +29,8 @@ sealed class WithdrawNoticeEffect : BaseSideEffect {
 class WithdrawNoticeViewModel @Inject constructor(
     private val deleteAccountUseCase: DeleteAccountUseCase,
 ) : BaseViewModel<WithdrawNoticeState>(
-    WithdrawNoticeState()
-) {
+        WithdrawNoticeState(),
+    ) {
     fun onAction(action: WithdrawNoticeAction) {
         when (action) {
             is WithdrawNoticeAction.WithDraw -> {
@@ -42,18 +41,26 @@ class WithdrawNoticeViewModel @Inject constructor(
 
     private fun handleWithDraw() =
         intent {
+            postSideEffect(
+                WithdrawNoticeEffect.WithdrawError(
+                    ErrorCode.UNKNOWN,
+                    Throwable(
+                        "deleteAccountUseCase failed",
+                    ),
+                ),
+            )
             try {
-                if (deleteAccountUseCase()) {
-                    postSideEffect(WithdrawNoticeEffect.WithDrawSuccess)
-                } else {
-                    postSideEffect(
-                        WithdrawNoticeEffect.WithdrawError(
-                            ErrorCode.UNKNOWN, Throwable(
-                                "deleteAccountUseCase failed"
-                            )
-                        )
-                    )
-                }
+//                if (deleteAccountUseCase()) {
+//                    postSideEffect(WithdrawNoticeEffect.WithDrawSuccess)
+//                } else {
+//                    postSideEffect(
+//                        WithdrawNoticeEffect.WithdrawError(
+//                            ErrorCode.UNKNOWN, Throwable(
+//                                "deleteAccountUseCase failed"
+//                            )
+//                        )
+//                    )
+//                }
             } catch (t: Throwable) {
                 Logger.e("deleteAccountUseCase error $t")
                 postSideEffect(WithdrawNoticeEffect.WithdrawError(ErrorCode.UNKNOWN, t))

--- a/feat/my/src/main/java/com/emotionstorage/my/presentation/WithdrawNoticeViewModel.kt
+++ b/feat/my/src/main/java/com/emotionstorage/my/presentation/WithdrawNoticeViewModel.kt
@@ -1,0 +1,62 @@
+package com.emotionstorage.my.presentation
+
+import com.emotionstorage.domain.common.ErrorCode
+import com.emotionstorage.domain.useCase.auth.DeleteAccountUseCase
+import com.emotionstorage.presentation.BaseSideEffect
+import com.emotionstorage.presentation.BaseViewModel
+import com.orhanobut.logger.Logger
+import dagger.hilt.android.lifecycle.HiltViewModel
+import javax.inject.Inject
+
+data class WithdrawNoticeState(
+    val isLoading: Boolean = false,
+)
+
+sealed class WithdrawNoticeAction {
+    object WithDraw : WithdrawNoticeAction()
+}
+
+sealed class WithdrawNoticeEffect : BaseSideEffect {
+
+    object WithDrawSuccess : WithdrawNoticeEffect()
+
+    data class WithdrawError(
+        val errorCode: ErrorCode,
+        val throwable: Throwable,
+    ) : WithdrawNoticeEffect()
+}
+
+@HiltViewModel
+class WithdrawNoticeViewModel @Inject constructor(
+    private val deleteAccountUseCase: DeleteAccountUseCase,
+) : BaseViewModel<WithdrawNoticeState>(
+    WithdrawNoticeState()
+) {
+    fun onAction(action: WithdrawNoticeAction) {
+        when (action) {
+            is WithdrawNoticeAction.WithDraw -> {
+                handleWithDraw()
+            }
+        }
+    }
+
+    private fun handleWithDraw() =
+        intent {
+            try {
+                if (deleteAccountUseCase()) {
+                    postSideEffect(WithdrawNoticeEffect.WithDrawSuccess)
+                } else {
+                    postSideEffect(
+                        WithdrawNoticeEffect.WithdrawError(
+                            ErrorCode.UNKNOWN, Throwable(
+                                "deleteAccountUseCase failed"
+                            )
+                        )
+                    )
+                }
+            } catch (t: Throwable) {
+                Logger.e("deleteAccountUseCase error $t")
+                postSideEffect(WithdrawNoticeEffect.WithdrawError(ErrorCode.UNKNOWN, t))
+            }
+        }
+}

--- a/feat/my/src/main/java/com/emotionstorage/my/ui/modal/ConfirmLogoutModal.kt
+++ b/feat/my/src/main/java/com/emotionstorage/my/ui/modal/ConfirmLogoutModal.kt
@@ -24,7 +24,7 @@ import com.emotionstorage.ui.component.modal.Modal
 fun ConfirmLogoutModal(
     onDismissRequest: () -> Unit,
     onLogout: () -> Unit,
-)  {
+) {
     Modal(
         onDismissRequest = onDismissRequest,
         title = "정말 로그아웃 하시겠어요?",
@@ -40,7 +40,7 @@ fun ConfirmLogoutModal(
 
 @Preview
 @Composable
-private fun ConfirmLogoutModalPreview()  {
+private fun ConfirmLogoutModalPreview() {
     ConfirmLogoutModal(
         onDismissRequest = {},
         onLogout = {},

--- a/feat/my/src/main/java/com/emotionstorage/my/ui/modal/ConfirmLogoutModal.kt
+++ b/feat/my/src/main/java/com/emotionstorage/my/ui/modal/ConfirmLogoutModal.kt
@@ -21,10 +21,10 @@ import com.emotionstorage.ui.component.modal.Modal
  *      - 스크롤 X
  */
 @Composable
-fun ConfirmLogoutModal (
+fun ConfirmLogoutModal(
     onDismissRequest: () -> Unit,
     onLogout: () -> Unit,
-){
+)  {
     Modal(
         onDismissRequest = onDismissRequest,
         title = "정말 로그아웃 하시겠어요?",
@@ -40,7 +40,7 @@ fun ConfirmLogoutModal (
 
 @Preview
 @Composable
-private fun ConfirmLogoutModalPreview(){
+private fun ConfirmLogoutModalPreview()  {
     ConfirmLogoutModal(
         onDismissRequest = {},
         onLogout = {},

--- a/feat/my/src/main/java/com/emotionstorage/my/ui/modal/ConfirmLogoutModal.kt
+++ b/feat/my/src/main/java/com/emotionstorage/my/ui/modal/ConfirmLogoutModal.kt
@@ -1,0 +1,49 @@
+package com.emotionstorage.my.ui.modal
+
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.tooling.preview.Preview
+import com.emotionstorage.my.presentation.MyPageAction
+import com.emotionstorage.ui.component.modal.Modal
+
+/**
+ * logout_confirm
+ * - Case : 로그아웃 확인
+ *      - [로그아웃] 버튼을 눌렀을 때 표출
+ * - 표시 화면
+ *      - 6.1 마이페이지
+ * - CTA 및 이동
+ *      - [아니요, 그냥 있을래요.] -> 팝업 닫히며 이동 X
+ *      - [네, 로그아웃 할래요.] -> 팝업 닫히며 로그아웃 api 호출, 로그인 페이지로 이동
+ * - 차단
+ *      - 뒤로가기(Android) O (팝업 닫힘, 화면 제자리)
+ *      - push/pop X
+ *      - 하단바 상호작용 X (하단바 없음)
+ *      - 배경 터치 O (팝업 닫힘, 화면 제자리)
+ *      - 스크롤 X
+ */
+@Composable
+fun ConfirmLogoutModal (
+    onDismissRequest: () -> Unit,
+    onLogout: () -> Unit,
+){
+    Modal(
+        onDismissRequest = onDismissRequest,
+        title = "정말 로그아웃 하시겠어요?",
+        bottomDescription = "다시 돌아오실거죠? 기다리고있을게요 \uD83E\uDD7A",
+        confirmLabel = "아니요, 그냥 있을래요.",
+        onConfirm = {
+            // do nothing before dismiss
+        },
+        dismissLabel = "네, 로그아웃 할래요.",
+        onDismiss = onLogout,
+    )
+}
+
+@Preview
+@Composable
+private fun ConfirmLogoutModalPreview(){
+    ConfirmLogoutModal(
+        onDismissRequest = {},
+        onLogout = {},
+    )
+}

--- a/feat/my/src/main/java/com/emotionstorage/my/ui/modal/ConfirmLogoutModal.kt
+++ b/feat/my/src/main/java/com/emotionstorage/my/ui/modal/ConfirmLogoutModal.kt
@@ -2,7 +2,6 @@ package com.emotionstorage.my.ui.modal
 
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.tooling.preview.Preview
-import com.emotionstorage.my.presentation.MyPageAction
 import com.emotionstorage.ui.component.modal.Modal
 
 /**

--- a/feat/my/src/main/java/com/emotionstorage/my/ui/modal/ConfirmWithdrawModal.kt
+++ b/feat/my/src/main/java/com/emotionstorage/my/ui/modal/ConfirmWithdrawModal.kt
@@ -38,7 +38,7 @@ fun ConfirmWithdrawModal(
 
 @Preview
 @Composable
-private fun ConfirmWithdrawModalPreview()  {
+private fun ConfirmWithdrawModalPreview() {
     ConfirmWithdrawModal(
         onDismissRequest = {},
         onChangeNotification = {},

--- a/feat/my/src/main/java/com/emotionstorage/my/ui/modal/ConfirmWithdrawModal.kt
+++ b/feat/my/src/main/java/com/emotionstorage/my/ui/modal/ConfirmWithdrawModal.kt
@@ -24,7 +24,7 @@ import com.emotionstorage.ui.component.modal.Modal
 fun ConfirmWithdrawModal(
     onDismissRequest: () -> Unit,
     onChangeNotification: () -> Unit,
-    onWithDraw: () -> Unit
+    onWithDraw: () -> Unit,
 ) {
     Modal(
         onDismissRequest = onDismissRequest,
@@ -38,7 +38,7 @@ fun ConfirmWithdrawModal(
 
 @Preview
 @Composable
-private fun ConfirmWithdrawModalPreview(){
+private fun ConfirmWithdrawModalPreview()  {
     ConfirmWithdrawModal(
         onDismissRequest = {},
         onChangeNotification = {},

--- a/feat/my/src/main/java/com/emotionstorage/my/ui/modal/ConfirmWithdrawModal.kt
+++ b/feat/my/src/main/java/com/emotionstorage/my/ui/modal/ConfirmWithdrawModal.kt
@@ -1,0 +1,47 @@
+package com.emotionstorage.my.ui.modal
+
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.tooling.preview.Preview
+import com.emotionstorage.ui.component.modal.Modal
+
+/**
+ * withdraw_confirm
+ * - Case : 회원 탈퇴 확인
+ *      - [MOOI 서비스 탈퇴하기]를 눌렀을 때 표출
+ * - 표시 화면
+ *      - 8.7 마이페이지 - 회원 탈퇴
+ * - CTA 및 이동
+ *      - [알림을 끄고 쉬어갈래요.] -> 6.5 알림 설정 페이지로 이동
+ *      - [서비스를 탈퇴할래요.] -> 회원 탈퇴 api 호출하며 withdraw_success 팝업 표출
+ * - 차단
+ *      - 뒤로가기(Android) O
+ *      - push/pop X
+ *      - 하단바 상호작용 X (하단바 없음)
+ *      - 배경 터치 O (팝업 닫힘, 화면 제자리)
+ *      - 스크롤 X
+ */
+@Composable
+fun ConfirmWithdrawModal(
+    onDismissRequest: () -> Unit,
+    onChangeNotification: () -> Unit,
+    onWithDraw: () -> Unit
+) {
+    Modal(
+        onDismissRequest = onDismissRequest,
+        title = "기록을 잠시 멈추고 싶다면,\n알림을 끄거나\n앱을 쉬어가보는 건 어떨까요?",
+        confirmLabel = "알림을 끄고 쉬어갈래요.",
+        onConfirm = onChangeNotification,
+        dismissLabel = "서비스를 탈퇴할래요.",
+        onDismiss = onWithDraw,
+    )
+}
+
+@Preview
+@Composable
+private fun ConfirmWithdrawModalPreview(){
+    ConfirmWithdrawModal(
+        onDismissRequest = {},
+        onChangeNotification = {},
+        onWithDraw = {},
+    )
+}

--- a/feat/my/src/main/java/com/emotionstorage/my/ui/modal/InquireWithdrawErrorModal.kt
+++ b/feat/my/src/main/java/com/emotionstorage/my/ui/modal/InquireWithdrawErrorModal.kt
@@ -1,0 +1,143 @@
+package com.emotionstorage.my.ui.modal
+
+import android.content.Intent
+import androidx.compose.foundation.background
+import androidx.compose.foundation.border
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.unit.dp
+import androidx.core.net.toUri
+import com.emotionstorage.common.formatToKorDateTime
+import com.emotionstorage.domain.common.ErrorCode
+import com.emotionstorage.ui.component.modal.Modal
+import com.emotionstorage.ui.theme.MooiTheme
+import com.orhanobut.logger.Logger
+import java.time.LocalDateTime
+
+/**
+ * withdraw_failed
+ * - Case : 회원 탈퇴 실패
+ *      - withdraw_confirm 팝업에서 [서비스를 탈퇴할래요.]를 누른 후, api 호출 및 처리에 실패했을 때 표출
+ *      - (네트워크 오류 아님)
+ * - 표시 화면
+ *      - 6.7 마이페이지 - 회원탈퇴
+ * - CTA 및 이동
+ *      - [이메일로 문의하기] -> 팝업 닫히며 이메일 작성 인텐트 시작(화면 유지)
+ *      - [닫기] -> 팝업 닫히며 이동 X(재시도 유도)
+ * - 차단
+ *      - 뒤로가기(Android) O (팝업 닫힘, 화면 제자리)
+ *      - push/pop X
+ *      - 하단바 상호작용 X (하단바 없음)
+ *      - 배경 터치 O (팝업 닫힘, 화면 제자리)
+ *      - 스크롤 X
+ */
+@Composable
+fun InquireWithdrawErrorModal(
+    errorCode: ErrorCode,
+    throwable: Throwable,
+    onDismissRequest: () -> Unit,
+) {
+    // todo: 유저 이메일 & 닉네임 자동 채우기
+    val context = LocalContext.current
+    Modal(
+        onDismissRequest = onDismissRequest,
+        topDescription = "회원탈퇴에 실패했어요.",
+        title = "잠시 후 다시 시도하거나\n같은 문제가 반복되면\n문의해주세요.",
+        content = @Composable{
+            ErrorCodeBox(errorCode)
+        },
+        confirmLabel = "이메일로 문의하기",
+        onConfirm = {
+            val emailIntent =
+                Intent(Intent.ACTION_SENDTO).apply {
+                    data = "mailto:".toUri()
+                    putExtra(
+                        Intent.EXTRA_EMAIL,
+                        arrayOf("mooi.reply@gmail.com"),
+                    )
+                    putExtra(
+                        Intent.EXTRA_SUBJECT,
+                        "[MOOI] 회원탈퇴 요청 (자동생성 코드: ${LocalDateTime.now()})",
+                    )
+                    putExtra(
+                        Intent.EXTRA_TEXT,
+                        """
+                        ────────────────────
+                        📮 문의 유형: 회원탈퇴 요청
+                        ────────────────────
+
+                        ■ 탈퇴를 원하는 계정의 로그인 방식
+                        ( ) 구글
+                        ( ) 카카오
+                        ( ) 애플
+                        ( ) 기타: ________________________
+
+                        ■ 계정에 등록된 이메일과 닉네임
+                        예: hello_user@naver.com / 닉네임 ‘moodlover’
+
+                        ■ 탈퇴를 요청하시는 이유(선택)
+                        ( ) 더 이상 앱을 사용하지 않아요
+                        ( ) 개인 정보 삭제를 원해요
+                        ( ) 이용 중 불편함이 있었어요
+                        ( ) 기타: ________________________________________
+
+                        ■ 탈퇴를 요청하신 시점
+                        예: ${LocalDateTime.now().formatToKorDateTime("yyyy년 MM월 dd일")}경
+
+                        ■ 추가로 알려주실 내용이 있다면 자유롭게 적어주세요
+
+
+                        📎 자동 포함 정보
+                        - 오류 코드: $errorCode
+                        - 오류 메세지: ${throwable.message}
+                        - 오류 원인: ${throwable.cause}
+                        """.trimIndent(),
+                    )
+                }
+            try {
+                context.startActivity(Intent.createChooser(emailIntent, "이메일 앱을 선택해주세요."))
+            } catch (e: Exception) {
+                Logger.e("이메일 앱 선택 불가능", e)
+            }
+        },
+        dismissLabel = "닫기",
+        onDismiss = {
+            // do nothing before dismiss
+        },
+    )
+}
+
+@Composable
+private fun ErrorCodeBox(
+    errorCode: ErrorCode,
+    modifier: Modifier = Modifier,
+) {
+    Box(
+        modifier =
+            modifier
+                .fillMaxWidth()
+                .background(
+                    MooiTheme.colorScheme.primaryBlue500.copy(alpha = 0.04f),
+                    RoundedCornerShape(16.dp),
+                ).border(
+                    1.dp,
+                    MooiTheme.colorScheme.secondaryBlue700.copy(alpha = 0.2f),
+                    RoundedCornerShape(16.dp),
+                ).padding(vertical = 16.dp, horizontal = 8.dp),
+        contentAlignment = Alignment.Center,
+    ) {
+        Text(
+            text = "오류 코드: $errorCode",
+            modifier = Modifier.align(Alignment.Center),
+            style = MooiTheme.typography.body5,
+            color = MooiTheme.colorScheme.gray500,
+        )
+    }
+}

--- a/feat/my/src/main/java/com/emotionstorage/my/ui/modal/InquireWithdrawErrorModal.kt
+++ b/feat/my/src/main/java/com/emotionstorage/my/ui/modal/InquireWithdrawErrorModal.kt
@@ -43,8 +43,9 @@ fun InquireWithdrawErrorModal(
     errorCode: ErrorCode,
     throwable: Throwable,
     onDismissRequest: () -> Unit,
+    userEmail: String?,
+    userNickname: String?,
 ) {
-    // todo: 유저 이메일 & 닉네임 자동 채우기
     val context = LocalContext.current
     Modal(
         onDismissRequest = onDismissRequest,
@@ -80,7 +81,7 @@ fun InquireWithdrawErrorModal(
                         ( ) 기타: ________________________
 
                         ■ 계정에 등록된 이메일과 닉네임
-                        예: hello_user@naver.com / 닉네임 ‘moodlover’
+                        예: ${userEmail ?: "hello_user@naver.com"} / 닉네임 ‘${userNickname ?: "moodlover"}’
 
                         ■ 탈퇴를 요청하시는 이유(선택)
                         ( ) 더 이상 앱을 사용하지 않아요
@@ -126,11 +127,13 @@ private fun ErrorCodeBox(
                 .background(
                     MooiTheme.colorScheme.primaryBlue500.copy(alpha = 0.04f),
                     RoundedCornerShape(16.dp),
-                ).border(
+                )
+                .border(
                     1.dp,
                     MooiTheme.colorScheme.secondaryBlue700.copy(alpha = 0.2f),
                     RoundedCornerShape(16.dp),
-                ).padding(vertical = 16.dp, horizontal = 8.dp),
+                )
+                .padding(vertical = 16.dp, horizontal = 8.dp),
         contentAlignment = Alignment.Center,
     ) {
         Text(

--- a/feat/my/src/main/java/com/emotionstorage/my/ui/modal/InquireWithdrawErrorModal.kt
+++ b/feat/my/src/main/java/com/emotionstorage/my/ui/modal/InquireWithdrawErrorModal.kt
@@ -127,13 +127,11 @@ private fun ErrorCodeBox(
                 .background(
                     MooiTheme.colorScheme.primaryBlue500.copy(alpha = 0.04f),
                     RoundedCornerShape(16.dp),
-                )
-                .border(
+                ).border(
                     1.dp,
                     MooiTheme.colorScheme.secondaryBlue700.copy(alpha = 0.2f),
                     RoundedCornerShape(16.dp),
-                )
-                .padding(vertical = 16.dp, horizontal = 8.dp),
+                ).padding(vertical = 16.dp, horizontal = 8.dp),
         contentAlignment = Alignment.Center,
     ) {
         Text(

--- a/feat/my/src/main/java/com/emotionstorage/my/ui/modal/InquireWithdrawErrorModal.kt
+++ b/feat/my/src/main/java/com/emotionstorage/my/ui/modal/InquireWithdrawErrorModal.kt
@@ -50,7 +50,7 @@ fun InquireWithdrawErrorModal(
         onDismissRequest = onDismissRequest,
         topDescription = "회원탈퇴에 실패했어요.",
         title = "잠시 후 다시 시도하거나\n같은 문제가 반복되면\n문의해주세요.",
-        content = @Composable{
+        content = @Composable {
             ErrorCodeBox(errorCode)
         },
         confirmLabel = "이메일로 문의하기",

--- a/feat/my/src/main/java/com/emotionstorage/my/ui/modal/LogoutErrorModal.kt
+++ b/feat/my/src/main/java/com/emotionstorage/my/ui/modal/LogoutErrorModal.kt
@@ -28,7 +28,7 @@ fun LogoutErrorModal(
         onDismissRequest = onDismissRequest,
         topDescription = "로그아웃에 실패했어요.",
         title = "연결 상태를 확인한 뒤\n다시 시도해주세요.",
-        confirmLabel = "다시 로그인하기",
+        confirmLabel = "다시 로그아웃하기",
         onConfirm = onRetry,
     )
 }

--- a/feat/my/src/main/java/com/emotionstorage/my/ui/modal/LogoutErrorModal.kt
+++ b/feat/my/src/main/java/com/emotionstorage/my/ui/modal/LogoutErrorModal.kt
@@ -33,10 +33,9 @@ fun LogoutErrorModal(
     )
 }
 
-
 @Preview
 @Composable
-private fun LogoutErrorModalPreview(){
+private fun LogoutErrorModalPreview()  {
     LogoutErrorModal(
         onDismissRequest = {},
         onRetry = {},

--- a/feat/my/src/main/java/com/emotionstorage/my/ui/modal/LogoutErrorModal.kt
+++ b/feat/my/src/main/java/com/emotionstorage/my/ui/modal/LogoutErrorModal.kt
@@ -22,14 +22,14 @@ import com.emotionstorage.ui.component.modal.Modal
 @Composable
 fun LogoutErrorModal(
     onDismissRequest: () -> Unit,
-    onConfirm: () -> Unit,
+    onRetry: () -> Unit,
 ) {
     Modal(
         onDismissRequest = onDismissRequest,
         topDescription = "로그아웃에 실패했어요.",
         title = "연결 상태를 확인한 뒤\n다시 시도해주세요.",
         confirmLabel = "다시 로그인하기",
-        onConfirm = onConfirm,
+        onConfirm = onRetry,
     )
 }
 
@@ -39,6 +39,6 @@ fun LogoutErrorModal(
 private fun LogoutErrorModalPreview(){
     LogoutErrorModal(
         onDismissRequest = {},
-        onConfirm = {},
+        onRetry = {},
     )
 }

--- a/feat/my/src/main/java/com/emotionstorage/my/ui/modal/LogoutErrorModal.kt
+++ b/feat/my/src/main/java/com/emotionstorage/my/ui/modal/LogoutErrorModal.kt
@@ -1,6 +1,7 @@
 package com.emotionstorage.my.ui.modal
 
 import androidx.compose.runtime.Composable
+import androidx.compose.ui.tooling.preview.Preview
 import com.emotionstorage.ui.component.modal.Modal
 
 /**
@@ -29,5 +30,15 @@ fun LogoutErrorModal(
         title = "연결 상태를 확인한 뒤\n다시 시도해주세요.",
         confirmLabel = "다시 로그인하기",
         onConfirm = onConfirm,
+    )
+}
+
+
+@Preview
+@Composable
+private fun LogoutErrorModalPreview(){
+    LogoutErrorModal(
+        onDismissRequest = {},
+        onConfirm = {},
     )
 }

--- a/feat/my/src/main/java/com/emotionstorage/my/ui/modal/LogoutErrorModal.kt
+++ b/feat/my/src/main/java/com/emotionstorage/my/ui/modal/LogoutErrorModal.kt
@@ -1,0 +1,33 @@
+package com.emotionstorage.my.ui.modal
+
+import androidx.compose.runtime.Composable
+import com.emotionstorage.ui.component.modal.Modal
+
+/**
+ * logout_failed
+ * - Case : 로그아웃 실패(네트워크 오류 포함)
+ *      - 로그아웃 api 호출 및 처리 실패 시 표시
+ * - 표시 화면
+ *      - 6.1 마이페이지
+ * - CTA 및 이동
+ *      - [다시 시도하기] -> 로딩 애니메이션 띄우며 로그아웃 api 재호출
+ * - 차단
+ *      - 뒤로가기(Android) O (팝업 닫힘, 화면 제자리)
+ *      - push/pop X
+ *      - 하단바 상호작용 X (하단바 없음)
+ *      - 배경 터치 O (팝업 닫힘, 화면 제자리)
+ *      - 스크롤 X
+ */
+@Composable
+fun LogoutErrorModal(
+    onDismissRequest: () -> Unit,
+    onConfirm: () -> Unit,
+) {
+    Modal(
+        onDismissRequest = onDismissRequest,
+        topDescription = "로그아웃에 실패했어요.",
+        title = "연결 상태를 확인한 뒤\n다시 시도해주세요.",
+        confirmLabel = "다시 로그인하기",
+        onConfirm = onConfirm,
+    )
+}

--- a/feat/my/src/main/java/com/emotionstorage/my/ui/modal/LogoutErrorModal.kt
+++ b/feat/my/src/main/java/com/emotionstorage/my/ui/modal/LogoutErrorModal.kt
@@ -35,7 +35,7 @@ fun LogoutErrorModal(
 
 @Preview
 @Composable
-private fun LogoutErrorModalPreview()  {
+private fun LogoutErrorModalPreview() {
     LogoutErrorModal(
         onDismissRequest = {},
         onRetry = {},

--- a/feat/my/src/main/java/com/emotionstorage/my/ui/modal/WithdrawSuccessModal.kt
+++ b/feat/my/src/main/java/com/emotionstorage/my/ui/modal/WithdrawSuccessModal.kt
@@ -23,9 +23,7 @@ import kotlinx.coroutines.delay
  *      - 스크롤 X
  */
 @Composable
-fun WithdrawSuccessModal (
-    onDismissRequest: () -> Unit,
-){
+fun WithdrawSuccessModal(onDismissRequest: () -> Unit)  {
     // dismiss modal automatically after 5 sec
     LaunchedEffect(Unit) {
         delay(5_000)
@@ -46,10 +44,8 @@ fun WithdrawSuccessModal (
 
 @Preview
 @Composable
-private fun WithdrawSuccessModalPreview(){
+private fun WithdrawSuccessModalPreview()  {
     WithdrawSuccessModal(
         onDismissRequest = {},
     )
 }
-
-

--- a/feat/my/src/main/java/com/emotionstorage/my/ui/modal/WithdrawSuccessModal.kt
+++ b/feat/my/src/main/java/com/emotionstorage/my/ui/modal/WithdrawSuccessModal.kt
@@ -23,7 +23,7 @@ import kotlinx.coroutines.delay
  *      - 스크롤 X
  */
 @Composable
-fun WithdrawSuccessModal(onDismissRequest: () -> Unit)  {
+fun WithdrawSuccessModal(onDismissRequest: () -> Unit) {
     // dismiss modal automatically after 5 sec
     LaunchedEffect(Unit) {
         delay(5_000)
@@ -44,7 +44,7 @@ fun WithdrawSuccessModal(onDismissRequest: () -> Unit)  {
 
 @Preview
 @Composable
-private fun WithdrawSuccessModalPreview()  {
+private fun WithdrawSuccessModalPreview() {
     WithdrawSuccessModal(
         onDismissRequest = {},
     )

--- a/feat/my/src/main/java/com/emotionstorage/my/ui/modal/WithdrawSuccessModal.kt
+++ b/feat/my/src/main/java/com/emotionstorage/my/ui/modal/WithdrawSuccessModal.kt
@@ -1,0 +1,55 @@
+package com.emotionstorage.my.ui.modal
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.ui.tooling.preview.Preview
+import com.emotionstorage.ui.component.modal.Modal
+import kotlinx.coroutines.delay
+
+/**
+ * withdraw_success
+ * - Case : 회원 탈퇴 성공
+ *      - withdraw_confirm 팝업에서 [서비스를 탈퇴할래요.]를 누른 후, 성공적으로 api 호출 및 처리가 완료되었을 때 표
+ * - 표시 화면
+ *      - 6.7 마이페이지 - 회원탈퇴
+ * - CTA 및 이동
+ *      - [확인] -> 팝업 닫히며 로그인 화면으로 이동
+ *      - 5초 후 Auto-dismiss -> 팝업 닫히며 로그인 화면으로 이동
+ * - 차단
+ *      - 뒤로가기(Android) X
+ *      - push/pop X
+ *      - 하단바 상호작용 X (하단바 없음)
+ *      - 배경 터치 X
+ *      - 스크롤 X
+ */
+@Composable
+fun WithdrawSuccessModal (
+    onDismissRequest: () -> Unit,
+){
+    // dismiss modal automatically after 5 sec
+    LaunchedEffect(Unit) {
+        delay(5_000)
+        onDismissRequest()
+    }
+
+    Modal(
+        onDismissRequest = onDismissRequest,
+        dismissOnBackPress = false,
+        dismissOnClickOutside = false,
+        title = "회원 탈퇴가\n완료되었습니다.",
+        confirmLabel = "확인",
+        onConfirm = {
+            // do nothing before dismiss
+        },
+    )
+}
+
+@Preview
+@Composable
+private fun WithdrawSuccessModalPreview(){
+    WithdrawSuccessModal(
+        onDismissRequest = {},
+    )
+}
+
+

--- a/feat/my/src/main/java/com/emotionstorage/my/ui/myPage/MyPageScreen.kt
+++ b/feat/my/src/main/java/com/emotionstorage/my/ui/myPage/MyPageScreen.kt
@@ -37,6 +37,7 @@ import com.emotionstorage.my.presentation.MyPageSideEffect
 import com.emotionstorage.my.presentation.MyPageState
 import com.emotionstorage.my.presentation.MyPageViewModel
 import com.emotionstorage.my.ui.keyDescription.component.KeyCard
+import com.emotionstorage.my.ui.modal.ConfirmLogoutModal
 import com.emotionstorage.my.ui.myPage.component.MenuSection
 import com.emotionstorage.my.ui.myPage.component.ProfileHeader
 import com.emotionstorage.ui.component.modal.Modal
@@ -58,6 +59,7 @@ fun MyPageScreen(
     navToNotificationSetting: () -> Unit = {},
 ) {
     val state = viewModel.container.stateFlow.collectAsState()
+    val (showLogoutModal, setShowLogoutModal) = remember { mutableStateOf(false) }
 
     LifecycleResumeEffect(Unit) {
         Logger.d("MyPageScreen: onResume triggered")
@@ -112,8 +114,8 @@ fun MyPageScreen(
     StatelessMyPageScreen(
         modifier = modifier,
         bottomAppBar = bottomAppBar,
+        setShowLogoutModal = setShowLogoutModal,
         state = state.value,
-        onAction = viewModel::onAction,
         navToWithdraw = navToWithdrawNotice,
         navToNickNameChange = navToNickNameChange,
         navToKeyDescription = navToKeyDescription,
@@ -121,14 +123,21 @@ fun MyPageScreen(
         navToTermsAndPrivacy = navToTermsAndPrivacy,
         navToNotificationSetting = navToNotificationSetting,
     )
+
+    if (showLogoutModal) {
+        ConfirmLogoutModal(
+            onDismissRequest = { setShowLogoutModal(false) },
+            onLogout = { viewModel.onAction(MyPageAction.Logout) }
+        )
+    }
 }
 
 @Composable
 private fun StatelessMyPageScreen(
     modifier: Modifier = Modifier,
     bottomAppBar: @Composable () -> Unit = {},
+    setShowLogoutModal: (Boolean) -> Unit = {},
     state: MyPageState = MyPageState(),
-    onAction: (MyPageAction) -> Unit = {},
     navToWithdraw: () -> Unit = {},
     navToNickNameChange: () -> Unit = {},
     navToKeyDescription: () -> Unit = {},
@@ -137,7 +146,6 @@ private fun StatelessMyPageScreen(
     navToNotificationSetting: () -> Unit = {},
 ) {
     val clipboardManager = LocalClipboardManager.current
-    var showLogoutModal by remember { mutableStateOf(false) }
 
     Scaffold(
         modifier =
@@ -160,7 +168,7 @@ private fun StatelessMyPageScreen(
                 verticalArrangement = Arrangement.Top,
             ) {
                 ProfileHeader(
-                    modifier = Modifier.offset(x = -9.dp),
+                    modifier = Modifier.offset(x = (-9).dp),
                     nickname = state.nickname,
                     signupDday = state.signupDday,
                     onEditClick = {
@@ -185,22 +193,9 @@ private fun StatelessMyPageScreen(
                         clipboardManager.setText(AnnotatedString("mooi.reply@gmail.com"))
                     },
                     onTermsAndPrivacyClick = navToTermsAndPrivacy,
-                    onLogoutClick = { showLogoutModal = true },
+                    onLogoutClick = { setShowLogoutModal(true) },
                     onNotificationClick = navToNotificationSetting,
                 )
-
-                if (showLogoutModal) {
-                    Modal(
-                        title = "정말 로그아웃 하시겠어요?",
-                        confirmLabel = "아니요, 그냥 있을래요.",
-                        onDismissRequest = { showLogoutModal = false },
-                        topDescription = null,
-                        bottomDescription = "다시 돌아오실거죠? 기다리고있을게요 \uD83E\uDD7A",
-                        dismissLabel = "네, 로그아웃 할래요.",
-                        onDismiss = { onAction(MyPageAction.Logout) },
-                        onConfirm = { showLogoutModal = false },
-                    )
-                }
 
                 Spacer(modifier = Modifier.size(8.dp))
                 Text(

--- a/feat/my/src/main/java/com/emotionstorage/my/ui/myPage/MyPageScreen.kt
+++ b/feat/my/src/main/java/com/emotionstorage/my/ui/myPage/MyPageScreen.kt
@@ -19,10 +19,8 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
-import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
-import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalClipboardManager
@@ -38,12 +36,18 @@ import com.emotionstorage.my.presentation.MyPageState
 import com.emotionstorage.my.presentation.MyPageViewModel
 import com.emotionstorage.my.ui.keyDescription.component.KeyCard
 import com.emotionstorage.my.ui.modal.ConfirmLogoutModal
+import com.emotionstorage.my.ui.modal.LogoutErrorModal
 import com.emotionstorage.my.ui.myPage.component.MenuSection
 import com.emotionstorage.my.ui.myPage.component.ProfileHeader
-import com.emotionstorage.ui.component.modal.Modal
 import com.emotionstorage.ui.component.loading.LoadingOverlay
 import com.emotionstorage.ui.theme.MooiTheme
 import com.orhanobut.logger.Logger
+
+private enum class MyPageModalState {
+    NONE,
+    LOGOUT_CONFIRM,
+    LOGOUT_ERROR,
+}
 
 @Composable
 fun MyPageScreen(
@@ -59,7 +63,7 @@ fun MyPageScreen(
     navToNotificationSetting: () -> Unit = {},
 ) {
     val state = viewModel.container.stateFlow.collectAsState()
-    val (showLogoutModal, setShowLogoutModal) = remember { mutableStateOf(false) }
+    val (modalState, setModalState) = remember { mutableStateOf<MyPageModalState>(MyPageModalState.NONE) }
 
     LifecycleResumeEffect(Unit) {
         Logger.d("MyPageScreen: onResume triggered")
@@ -74,6 +78,10 @@ fun MyPageScreen(
             when (sideEffect) {
                 is MyPageSideEffect.LogoutSuccess -> {
                     navToLogin()
+                }
+
+                is MyPageSideEffect.LogoutError -> {
+                    setModalState(MyPageModalState.LOGOUT_ERROR)
                 }
 
                 is MyPageSideEffect.NavigateToNicknameChange -> {
@@ -104,9 +112,8 @@ fun MyPageScreen(
                     navToNotificationSetting()
                 }
 
-                else -> {
-                    Unit
-                }
+                MyPageSideEffect.NavigateToSplash -> {}
+                MyPageSideEffect.WithDrawSuccess -> {}
             }
         }
     }
@@ -114,7 +121,7 @@ fun MyPageScreen(
     StatelessMyPageScreen(
         modifier = modifier,
         bottomAppBar = bottomAppBar,
-        setShowLogoutModal = setShowLogoutModal,
+        setModalState = setModalState,
         state = state.value,
         navToWithdraw = navToWithdrawNotice,
         navToNickNameChange = navToNickNameChange,
@@ -124,11 +131,30 @@ fun MyPageScreen(
         navToNotificationSetting = navToNotificationSetting,
     )
 
-    if (showLogoutModal) {
-        ConfirmLogoutModal(
-            onDismissRequest = { setShowLogoutModal(false) },
-            onLogout = { viewModel.onAction(MyPageAction.Logout) }
-        )
+    when (modalState) {
+        MyPageModalState.NONE -> {
+            // no modal
+        }
+
+        MyPageModalState.LOGOUT_CONFIRM -> {
+            ConfirmLogoutModal(
+                onDismissRequest = {
+                    setModalState(MyPageModalState.NONE)
+                },
+                onLogout = { viewModel.onAction(MyPageAction.Logout) }
+            )
+        }
+
+        MyPageModalState.LOGOUT_ERROR -> {
+            LogoutErrorModal(
+                onDismissRequest = {
+                    setModalState(MyPageModalState.NONE)
+                },
+                onRetry = {
+                    viewModel.onAction(MyPageAction.Logout)
+                }
+            )
+        }
     }
 }
 
@@ -136,7 +162,7 @@ fun MyPageScreen(
 private fun StatelessMyPageScreen(
     modifier: Modifier = Modifier,
     bottomAppBar: @Composable () -> Unit = {},
-    setShowLogoutModal: (Boolean) -> Unit = {},
+    setModalState: (MyPageModalState) -> Unit = {},
     state: MyPageState = MyPageState(),
     navToWithdraw: () -> Unit = {},
     navToNickNameChange: () -> Unit = {},
@@ -193,7 +219,7 @@ private fun StatelessMyPageScreen(
                         clipboardManager.setText(AnnotatedString("mooi.reply@gmail.com"))
                     },
                     onTermsAndPrivacyClick = navToTermsAndPrivacy,
-                    onLogoutClick = { setShowLogoutModal(true) },
+                    onLogoutClick = { setModalState(MyPageModalState.LOGOUT_CONFIRM) },
                     onNotificationClick = navToNotificationSetting,
                 )
 

--- a/feat/my/src/main/java/com/emotionstorage/my/ui/myPage/MyPageScreen.kt
+++ b/feat/my/src/main/java/com/emotionstorage/my/ui/myPage/MyPageScreen.kt
@@ -114,7 +114,7 @@ fun MyPageScreen(
                 onDismissRequest = {
                     setModalState(MyPageModalState.NONE)
                 },
-                onLogout = { viewModel.onAction(MyPageAction.Logout) }
+                onLogout = { viewModel.onAction(MyPageAction.Logout) },
             )
         }
 
@@ -125,7 +125,7 @@ fun MyPageScreen(
                 },
                 onRetry = {
                     viewModel.onAction(MyPageAction.Logout)
-                }
+                },
             )
         }
     }

--- a/feat/my/src/main/java/com/emotionstorage/my/ui/myPage/MyPageScreen.kt
+++ b/feat/my/src/main/java/com/emotionstorage/my/ui/myPage/MyPageScreen.kt
@@ -84,36 +84,13 @@ fun MyPageScreen(
                     setModalState(MyPageModalState.LOGOUT_ERROR)
                 }
 
-                is MyPageSideEffect.NavigateToNicknameChange -> {
-                    navToNickNameChange()
-                }
-
-                is MyPageSideEffect.NavigateToKeyDescription -> {
-                    navToKeyDescription()
-                }
-
                 is MyPageSideEffect.ShowToast -> {
                     // todo: add error toast
                 }
 
-                is MyPageSideEffect.NavigateToTermsAndPrivacy -> {
-                    navToTermsAndPrivacy()
+                is MyPageSideEffect.WithDrawSuccess -> {
+                    navToLogin()
                 }
-
-                is MyPageSideEffect.NavigateToWithDrawNotice -> {
-                    navToWithdrawNotice()
-                }
-
-                is MyPageSideEffect.NavigateToAccountInfo -> {
-                    navToAccountInfo()
-                }
-
-                is MyPageSideEffect.NavigateToNotificationSetting -> {
-                    navToNotificationSetting()
-                }
-
-                MyPageSideEffect.NavigateToSplash -> {}
-                MyPageSideEffect.WithDrawSuccess -> {}
             }
         }
     }

--- a/feat/my/src/main/java/com/emotionstorage/my/ui/myPage/MyPageScreen.kt
+++ b/feat/my/src/main/java/com/emotionstorage/my/ui/myPage/MyPageScreen.kt
@@ -87,10 +87,6 @@ fun MyPageScreen(
                 is MyPageSideEffect.ShowToast -> {
                     // todo: add error toast
                 }
-
-                is MyPageSideEffect.WithDrawSuccess -> {
-                    navToLogin()
-                }
             }
         }
     }

--- a/feat/my/src/main/java/com/emotionstorage/my/ui/withdraw/WithDrawNoticeScreen.kt
+++ b/feat/my/src/main/java/com/emotionstorage/my/ui/withdraw/WithDrawNoticeScreen.kt
@@ -83,7 +83,7 @@ fun WithDrawNoticeScreen(
         },
         onWithDrawClick = {
             showSuggestDialog = false
-            viewModel.onAction(MyPageAction.WithDrawConfirm)
+            viewModel.onAction(MyPageAction.WithDraw)
         },
         onFinalConfirmClick = {
             pendingNavigate = true

--- a/feat/my/src/main/java/com/emotionstorage/my/ui/withdraw/WithDrawNoticeScreen.kt
+++ b/feat/my/src/main/java/com/emotionstorage/my/ui/withdraw/WithDrawNoticeScreen.kt
@@ -21,6 +21,7 @@ import androidx.hilt.navigation.compose.hiltViewModel
 import com.emotionstorage.my.presentation.MyPageAction
 import com.emotionstorage.my.presentation.MyPageSideEffect
 import com.emotionstorage.my.presentation.MyPageViewModel
+import com.emotionstorage.my.ui.modal.ConfirmWithdrawModal
 import com.emotionstorage.ui.component.modal.Modal
 import com.emotionstorage.ui.component.appBar.TopAppBar
 import com.emotionstorage.ui.component.button.CtaButton
@@ -117,15 +118,10 @@ fun StatelessWithDrawNoticeScreen(
         },
     ) { innerPadding ->
         if (showSuggestDialog) {
-            Modal(
-                title = "기록을 잠시 멈추고 싶다면,\n알림을 끄거나\n앱을 쉬어가보는 건 어떨까요?",
-                confirmLabel = "알림을 끄고 쉬어갈래요.",
-                dismissLabel = "서비스를 탈퇴할래요.",
+            ConfirmWithdrawModal(
                 onDismissRequest = onSuggestDismiss,
-                onConfirm = onKeepClick,
-                onDismiss = onWithDrawClick,
-                topDescription = null,
-                contentPadding = PaddingValues(top = 23.dp, bottom = 28.dp, start = 24.5.dp, end = 24.5.dp),
+                onChangeNotification = onKeepClick,
+                onWithDraw = onWithDrawClick,
             )
         }
 

--- a/feat/my/src/main/java/com/emotionstorage/my/ui/withdraw/WithDrawNoticeScreen.kt
+++ b/feat/my/src/main/java/com/emotionstorage/my/ui/withdraw/WithDrawNoticeScreen.kt
@@ -15,21 +15,30 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
+import com.emotionstorage.domain.common.ErrorCode
 import com.emotionstorage.my.presentation.MyPageAction
 import com.emotionstorage.my.presentation.WithdrawNoticeAction
 import com.emotionstorage.my.presentation.WithdrawNoticeEffect
 import com.emotionstorage.my.presentation.WithdrawNoticeViewModel
 import com.emotionstorage.my.ui.modal.ConfirmWithdrawModal
+import com.emotionstorage.my.ui.modal.InquireWithdrawErrorModal
 import com.emotionstorage.my.ui.modal.WithdrawSuccessModal
 import com.emotionstorage.ui.component.appBar.TopAppBar
 import com.emotionstorage.ui.component.button.CtaButton
 import com.emotionstorage.ui.component.button.CtaButtonType
 import com.emotionstorage.ui.theme.MooiTheme
 
-private enum class WithdrawNoticeModalState {
-    NONE,
-    CONFIRM_WITHDRAW,
-    WITHDRAW_SUCCESS,
+private sealed class WithdrawNoticeModalState {
+    object None : WithdrawNoticeModalState()
+
+    object ConfirmWithdraw : WithdrawNoticeModalState()
+
+    object WithdrawSuccess : WithdrawNoticeModalState()
+
+    data class InquireWithdrawError(
+        val errorCode: ErrorCode,
+        val throwable: Throwable,
+    ) : WithdrawNoticeModalState()
 }
 
 @Composable
@@ -40,18 +49,23 @@ fun WithDrawNoticeScreen(
     navToLogin: () -> Unit = {},
 ) {
     val (modalState, setModalState) = remember {
-        mutableStateOf<WithdrawNoticeModalState>(WithdrawNoticeModalState.NONE)
+        mutableStateOf<WithdrawNoticeModalState>(WithdrawNoticeModalState.None)
     }
 
     LaunchedEffect(Unit) {
         viewModel.container.sideEffectFlow.collect { sideEffect ->
             when (sideEffect) {
                 is WithdrawNoticeEffect.WithDrawSuccess -> {
-                    setModalState(WithdrawNoticeModalState.WITHDRAW_SUCCESS)
+                    setModalState(WithdrawNoticeModalState.WithdrawSuccess)
                 }
 
                 is WithdrawNoticeEffect.WithdrawError -> {
-                    // todo: add error modal
+                    setModalState(
+                        WithdrawNoticeModalState.InquireWithdrawError(
+                            sideEffect.errorCode,
+                            sideEffect.throwable,
+                        ),
+                    )
                 }
             }
         }
@@ -63,14 +77,14 @@ fun WithDrawNoticeScreen(
     )
 
     when (modalState) {
-        WithdrawNoticeModalState.NONE -> {
+        is WithdrawNoticeModalState.None -> {
             // no modal
         }
 
-        WithdrawNoticeModalState.CONFIRM_WITHDRAW -> {
+        is WithdrawNoticeModalState.ConfirmWithdraw -> {
             ConfirmWithdrawModal(
                 onDismissRequest = {
-                    setModalState(WithdrawNoticeModalState.NONE)
+                    setModalState(WithdrawNoticeModalState.None)
                 },
                 onChangeNotification = {
                     navToNotificationSetting()
@@ -81,11 +95,21 @@ fun WithDrawNoticeScreen(
             )
         }
 
-        WithdrawNoticeModalState.WITHDRAW_SUCCESS -> {
+        is WithdrawNoticeModalState.WithdrawSuccess -> {
             WithdrawSuccessModal(
                 onDismissRequest = {
-                    setModalState(WithdrawNoticeModalState.NONE)
+                    setModalState(WithdrawNoticeModalState.None)
                     navToLogin()
+                },
+            )
+        }
+
+        is WithdrawNoticeModalState.InquireWithdrawError -> {
+            InquireWithdrawErrorModal(
+                errorCode = modalState.errorCode,
+                throwable = modalState.throwable,
+                onDismissRequest = {
+                    setModalState(WithdrawNoticeModalState.None)
                 },
             )
         }
@@ -128,7 +152,7 @@ private fun StatelessWithDrawNoticeScreen(
                 type = CtaButtonType.OUTLINED,
                 labelString = "MOOI 서비스 탈퇴하기",
                 onClick = {
-                    setModalState(WithdrawNoticeModalState.CONFIRM_WITHDRAW)
+                    setModalState(WithdrawNoticeModalState.ConfirmWithdraw)
                 },
                 isDefaultWidth = false,
                 textStyle =

--- a/feat/my/src/main/java/com/emotionstorage/my/ui/withdraw/WithDrawNoticeScreen.kt
+++ b/feat/my/src/main/java/com/emotionstorage/my/ui/withdraw/WithDrawNoticeScreen.kt
@@ -7,10 +7,8 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.Scaffold
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
-import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
-import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
@@ -18,16 +16,15 @@ import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import com.emotionstorage.my.presentation.MyPageAction
-import com.emotionstorage.my.presentation.MyPageSideEffect
-import com.emotionstorage.my.presentation.MyPageViewModel
+import com.emotionstorage.my.presentation.WithdrawNoticeAction
+import com.emotionstorage.my.presentation.WithdrawNoticeEffect
+import com.emotionstorage.my.presentation.WithdrawNoticeViewModel
 import com.emotionstorage.my.ui.modal.ConfirmWithdrawModal
 import com.emotionstorage.my.ui.modal.WithdrawSuccessModal
-import com.emotionstorage.ui.component.modal.Modal
 import com.emotionstorage.ui.component.appBar.TopAppBar
 import com.emotionstorage.ui.component.button.CtaButton
 import com.emotionstorage.ui.component.button.CtaButtonType
 import com.emotionstorage.ui.theme.MooiTheme
-import kotlinx.coroutines.delay
 
 private enum class WithdrawNoticeModalState {
     NONE,
@@ -37,7 +34,7 @@ private enum class WithdrawNoticeModalState {
 
 @Composable
 fun WithDrawNoticeScreen(
-    viewModel: MyPageViewModel = hiltViewModel(),
+    viewModel: WithdrawNoticeViewModel = hiltViewModel(),
     navToBack: () -> Unit = {},
     navToNotificationSetting: () -> Unit = {},
     navToLogin: () -> Unit = {},
@@ -49,12 +46,12 @@ fun WithDrawNoticeScreen(
     LaunchedEffect(Unit) {
         viewModel.container.sideEffectFlow.collect { sideEffect ->
             when (sideEffect) {
-                is MyPageSideEffect.WithDrawSuccess -> {
+                is WithdrawNoticeEffect.WithDrawSuccess -> {
                     setModalState(WithdrawNoticeModalState.WITHDRAW_SUCCESS)
                 }
 
-                else -> {
-                    Unit
+                is WithdrawNoticeEffect.WithdrawError -> {
+                    // todo: add error modal
                 }
             }
         }
@@ -65,10 +62,11 @@ fun WithDrawNoticeScreen(
         setModalState = setModalState,
     )
 
-    when(modalState){
+    when (modalState) {
         WithdrawNoticeModalState.NONE -> {
             // no modal
         }
+
         WithdrawNoticeModalState.CONFIRM_WITHDRAW -> {
             ConfirmWithdrawModal(
                 onDismissRequest = {
@@ -78,10 +76,11 @@ fun WithDrawNoticeScreen(
                     navToNotificationSetting()
                 },
                 onWithDraw = {
-                    viewModel.onAction(MyPageAction.WithDraw)
+                    viewModel.onAction(WithdrawNoticeAction.WithDraw)
                 },
             )
         }
+
         WithdrawNoticeModalState.WITHDRAW_SUCCESS -> {
             WithdrawSuccessModal(
                 onDismissRequest = {

--- a/feat/my/src/main/java/com/emotionstorage/my/ui/withdraw/WithDrawNoticeScreen.kt
+++ b/feat/my/src/main/java/com/emotionstorage/my/ui/withdraw/WithDrawNoticeScreen.kt
@@ -16,7 +16,6 @@ import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import com.emotionstorage.domain.common.ErrorCode
-import com.emotionstorage.my.presentation.MyPageAction
 import com.emotionstorage.my.presentation.WithdrawNoticeAction
 import com.emotionstorage.my.presentation.WithdrawNoticeEffect
 import com.emotionstorage.my.presentation.WithdrawNoticeViewModel
@@ -48,9 +47,10 @@ fun WithDrawNoticeScreen(
     navToNotificationSetting: () -> Unit = {},
     navToLogin: () -> Unit = {},
 ) {
-    val (modalState, setModalState) = remember {
-        mutableStateOf<WithdrawNoticeModalState>(WithdrawNoticeModalState.None)
-    }
+    val (modalState, setModalState) =
+        remember {
+            mutableStateOf<WithdrawNoticeModalState>(WithdrawNoticeModalState.None)
+        }
 
     LaunchedEffect(Unit) {
         viewModel.container.sideEffectFlow.collect { sideEffect ->

--- a/feat/my/src/main/java/com/emotionstorage/my/ui/withdraw/WithDrawNoticeScreen.kt
+++ b/feat/my/src/main/java/com/emotionstorage/my/ui/withdraw/WithDrawNoticeScreen.kt
@@ -7,7 +7,9 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.Scaffold
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -25,6 +27,7 @@ import com.emotionstorage.my.ui.modal.WithdrawSuccessModal
 import com.emotionstorage.ui.component.appBar.TopAppBar
 import com.emotionstorage.ui.component.button.CtaButton
 import com.emotionstorage.ui.component.button.CtaButtonType
+import com.emotionstorage.ui.component.loading.LoadingOverlay
 import com.emotionstorage.ui.theme.MooiTheme
 
 private sealed class WithdrawNoticeModalState {
@@ -37,6 +40,8 @@ private sealed class WithdrawNoticeModalState {
     data class InquireWithdrawError(
         val errorCode: ErrorCode,
         val throwable: Throwable,
+        val userEmail: String? = null,
+        val userNickname: String? = null,
     ) : WithdrawNoticeModalState()
 }
 
@@ -47,6 +52,7 @@ fun WithDrawNoticeScreen(
     navToNotificationSetting: () -> Unit = {},
     navToLogin: () -> Unit = {},
 ) {
+    val state by viewModel.container.stateFlow.collectAsState()
     val (modalState, setModalState) =
         remember {
             mutableStateOf<WithdrawNoticeModalState>(WithdrawNoticeModalState.None)
@@ -64,11 +70,17 @@ fun WithDrawNoticeScreen(
                         WithdrawNoticeModalState.InquireWithdrawError(
                             sideEffect.errorCode,
                             sideEffect.throwable,
+                            sideEffect.userEmail,
+                            sideEffect.userNickname,
                         ),
                     )
                 }
             }
         }
+    }
+
+    if(state.isLoading){
+        LoadingOverlay()
     }
 
     StatelessWithDrawNoticeScreen(
@@ -108,6 +120,8 @@ fun WithDrawNoticeScreen(
             InquireWithdrawErrorModal(
                 errorCode = modalState.errorCode,
                 throwable = modalState.throwable,
+                userEmail = modalState.userEmail,
+                userNickname = modalState.userNickname,
                 onDismissRequest = {
                     setModalState(WithdrawNoticeModalState.None)
                 },

--- a/feat/my/src/main/java/com/emotionstorage/my/ui/withdraw/WithDrawNoticeScreen.kt
+++ b/feat/my/src/main/java/com/emotionstorage/my/ui/withdraw/WithDrawNoticeScreen.kt
@@ -79,10 +79,9 @@ fun WithDrawNoticeScreen(
         }
     }
 
-    if (state.isLoading)
-        {
-            LoadingOverlay()
-        }
+    if (state.isLoading) {
+        LoadingOverlay()
+    }
 
     StatelessWithDrawNoticeScreen(
         onBackClick = navToBack,

--- a/feat/my/src/main/java/com/emotionstorage/my/ui/withdraw/WithDrawNoticeScreen.kt
+++ b/feat/my/src/main/java/com/emotionstorage/my/ui/withdraw/WithDrawNoticeScreen.kt
@@ -2,7 +2,6 @@ package com.emotionstorage.my.ui.withdraw
 
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Box
-import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.Scaffold
@@ -22,12 +21,19 @@ import com.emotionstorage.my.presentation.MyPageAction
 import com.emotionstorage.my.presentation.MyPageSideEffect
 import com.emotionstorage.my.presentation.MyPageViewModel
 import com.emotionstorage.my.ui.modal.ConfirmWithdrawModal
+import com.emotionstorage.my.ui.modal.WithdrawSuccessModal
 import com.emotionstorage.ui.component.modal.Modal
 import com.emotionstorage.ui.component.appBar.TopAppBar
 import com.emotionstorage.ui.component.button.CtaButton
 import com.emotionstorage.ui.component.button.CtaButtonType
 import com.emotionstorage.ui.theme.MooiTheme
 import kotlinx.coroutines.delay
+
+private enum class WithdrawNoticeModalState {
+    NONE,
+    CONFIRM_WITHDRAW,
+    WITHDRAW_SUCCESS,
+}
 
 @Composable
 fun WithDrawNoticeScreen(
@@ -36,15 +42,15 @@ fun WithDrawNoticeScreen(
     navToNotificationSetting: () -> Unit = {},
     navToLogin: () -> Unit = {},
 ) {
-    var showSuggestDialog by remember { mutableStateOf(false) }
-    var showDoneDialog by remember { mutableStateOf(false) }
-    var pendingNavigate by remember { mutableStateOf(false) }
+    val (modalState, setModalState) = remember {
+        mutableStateOf<WithdrawNoticeModalState>(WithdrawNoticeModalState.NONE)
+    }
 
     LaunchedEffect(Unit) {
         viewModel.container.sideEffectFlow.collect { sideEffect ->
             when (sideEffect) {
                 is MyPageSideEffect.WithDrawSuccess -> {
-                    showDoneDialog = true
+                    setModalState(WithdrawNoticeModalState.WITHDRAW_SUCCESS)
                 }
 
                 else -> {
@@ -54,55 +60,43 @@ fun WithDrawNoticeScreen(
         }
     }
 
-    LaunchedEffect(showDoneDialog) {
-        if (showDoneDialog) {
-            delay(5_000)
-            if (showDoneDialog) {
-                pendingNavigate = true
-                showDoneDialog = false
-            }
-        }
-    }
-
-    LaunchedEffect(showDoneDialog, pendingNavigate) {
-        if (!showDoneDialog && pendingNavigate) {
-            delay(250)
-            pendingNavigate = false
-            navToLogin()
-        }
-    }
-
     StatelessWithDrawNoticeScreen(
-        showSuggestDialog = showSuggestDialog,
-        showFinalConfirmDialog = showDoneDialog,
         onBackClick = navToBack,
-        onSuggestDismiss = { showSuggestDialog = false },
-        onWithDrawButtonClick = { showSuggestDialog = true },
-        onKeepClick = {
-            showSuggestDialog = false
-            navToNotificationSetting()
-        },
-        onWithDrawClick = {
-            showSuggestDialog = false
-            viewModel.onAction(MyPageAction.WithDraw)
-        },
-        onFinalConfirmClick = {
-            pendingNavigate = true
-            showDoneDialog = false
-        },
+        setModalState = setModalState,
     )
+
+    when(modalState){
+        WithdrawNoticeModalState.NONE -> {
+            // no modal
+        }
+        WithdrawNoticeModalState.CONFIRM_WITHDRAW -> {
+            ConfirmWithdrawModal(
+                onDismissRequest = {
+                    setModalState(WithdrawNoticeModalState.NONE)
+                },
+                onChangeNotification = {
+                    navToNotificationSetting()
+                },
+                onWithDraw = {
+                    viewModel.onAction(MyPageAction.WithDraw)
+                },
+            )
+        }
+        WithdrawNoticeModalState.WITHDRAW_SUCCESS -> {
+            WithdrawSuccessModal(
+                onDismissRequest = {
+                    setModalState(WithdrawNoticeModalState.NONE)
+                    navToLogin()
+                },
+            )
+        }
+    }
 }
 
 @Composable
-fun StatelessWithDrawNoticeScreen(
-    showSuggestDialog: Boolean,
-    showFinalConfirmDialog: Boolean,
-    onSuggestDismiss: () -> Unit,
-    onWithDrawButtonClick: () -> Unit,
+private fun StatelessWithDrawNoticeScreen(
     onBackClick: () -> Unit,
-    onKeepClick: () -> Unit,
-    onWithDrawClick: () -> Unit,
-    onFinalConfirmClick: () -> Unit,
+    setModalState: (WithdrawNoticeModalState) -> Unit,
 ) {
     Scaffold(
         modifier =
@@ -117,26 +111,6 @@ fun StatelessWithDrawNoticeScreen(
             )
         },
     ) { innerPadding ->
-        if (showSuggestDialog) {
-            ConfirmWithdrawModal(
-                onDismissRequest = onSuggestDismiss,
-                onChangeNotification = onKeepClick,
-                onWithDraw = onWithDrawClick,
-            )
-        }
-
-        if (showFinalConfirmDialog) {
-            Modal(
-                title = "회원 탈퇴가\n완료되었습니다.",
-                confirmLabel = "확인",
-                onDismissRequest = {
-                    // cannot dismiss manually
-                },
-                onConfirm = onFinalConfirmClick,
-                topDescription = null,
-            )
-        }
-
         Box(
             Modifier
                 .fillMaxSize()
@@ -154,7 +128,9 @@ fun StatelessWithDrawNoticeScreen(
                         .padding(start = 16.dp, end = 16.dp, bottom = 28.dp),
                 type = CtaButtonType.OUTLINED,
                 labelString = "MOOI 서비스 탈퇴하기",
-                onClick = onWithDrawButtonClick,
+                onClick = {
+                    setModalState(WithdrawNoticeModalState.CONFIRM_WITHDRAW)
+                },
                 isDefaultWidth = false,
                 textStyle =
                     MooiTheme.typography.body7.copy(
@@ -170,14 +146,8 @@ fun StatelessWithDrawNoticeScreen(
 private fun WithDrawNoticeScreenPreview() {
     MooiTheme {
         StatelessWithDrawNoticeScreen(
-            showSuggestDialog = true,
-            showFinalConfirmDialog = false,
-            onSuggestDismiss = {},
-            onWithDrawButtonClick = {},
             onBackClick = {},
-            onKeepClick = {},
-            onWithDrawClick = {},
-            onFinalConfirmClick = {},
+            setModalState = {},
         )
     }
 }

--- a/feat/my/src/main/java/com/emotionstorage/my/ui/withdraw/WithDrawNoticeScreen.kt
+++ b/feat/my/src/main/java/com/emotionstorage/my/ui/withdraw/WithDrawNoticeScreen.kt
@@ -79,9 +79,10 @@ fun WithDrawNoticeScreen(
         }
     }
 
-    if(state.isLoading){
-        LoadingOverlay()
-    }
+    if (state.isLoading)
+        {
+            LoadingOverlay()
+        }
 
     StatelessWithDrawNoticeScreen(
         onBackClick = navToBack,


### PR DESCRIPTION
## Related Issue
- Issue #163 

## 작업 상세 내용
- 마이페이지 & 회원탈퇴 화면 리팩토링
  - 마이페이지 뷰모델 회원탈퇴 로직 -> 회원탈퇴 화면 뷰모델로 코드 분리
  - 로그아웃 확인(logout_confirm), 회원탈퇴 확인(withdraw_confirm), 회원탈퇴 성공(withdraw_success) 모달 파일 분리
- 로그아웃 실패 팝업(logout_failed) 추가
- 회원가입 실패 문의 팝업(withdraw_failed) 추가
  - 문의 메일 본문 - 유저 이메일 & 닉네임 자동 완성 
- 기타
  - 유저 정보 스냅샷 반환 레포지토리 함수 추가
  - 유저 이메일 & 닉네임 반환 유즈케이스 추가



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 탈퇴 전용 화면과 확인/오류/성공/로그아웃 모달 일괄 추가
  * 사용자 스냅샷 조회 API 및 이메일·닉네임 조회 유스케이스 추가
  * 탈퇴 흐름용 ViewModel과 모달 기반 상태 관리 도입

* **버그 수정**
  * 계정 삭제 성공 판단을 HTTP 204 No Content로 개선

* **리팩토링**
  * 모달 배경 오버레이 제거 및 콘텐츠 너비 소폭 조정
  * 마이페이지·탈퇴 및 로그아웃 흐름을 중앙화된 모달 상태로 재구성, 로그아웃 로직 간소화

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->