### PR TITLE
Fix/auto login JWT 토큰 리프레시 로직 추가 (Token Authenticator + 세션 재확인 로직)

### DIFF
--- a/core/local/src/main/java/com/emotionstorage/local/dataSourceImpl/NotificationPermissionLocalLocalDataSourceImpl.kt
+++ b/core/local/src/main/java/com/emotionstorage/local/dataSourceImpl/NotificationPermissionLocalLocalDataSourceImpl.kt
@@ -1,12 +1,13 @@
 package com.emotionstorage.local.dataSourceImpl
 
 import android.content.Context
+import androidx.datastore.core.IOException
 import androidx.datastore.preferences.core.booleanPreferencesKey
 import androidx.datastore.preferences.core.edit
 import androidx.datastore.preferences.core.emptyPreferences
 import androidx.datastore.preferences.core.stringPreferencesKey
 import androidx.datastore.preferences.preferencesDataStore
-import com.emotionstorage.data.dataSource.local.NotificationPermissionDataSource
+import com.emotionstorage.data.dataSource.local.NotificationPermissionLocalDataSource
 import com.emotionstorage.domain.model.NotificationPermissionInfo
 import com.emotionstorage.domain.model.NotificationPermissionStatus
 import com.orhanobut.logger.Logger
@@ -14,12 +15,11 @@ import dagger.hilt.android.qualifiers.ApplicationContext
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.catch
 import kotlinx.coroutines.flow.map
-import okio.IOException
 import javax.inject.Inject
 
-class NotificationPermissionDataSourceImpl @Inject constructor(
+class NotificationPermissionLocalLocalDataSourceImpl @Inject constructor(
     @ApplicationContext private val context: Context,
-) : NotificationPermissionDataSource {
+) : NotificationPermissionLocalDataSource {
     private val Context.dataStore by preferencesDataStore("permission_prefs")
 
     private object Keys {

--- a/core/local/src/main/java/com/emotionstorage/local/dataSourceImpl/SessionLocalDataSourceImpl.kt
+++ b/core/local/src/main/java/com/emotionstorage/local/dataSourceImpl/SessionLocalDataSourceImpl.kt
@@ -58,23 +58,23 @@ class SessionLocalDataSourceImpl
                 false
             }
 
-    override suspend fun saveRefreshToken(refreshToken: String): Boolean {
-        dataStore.edit { preferences ->
-            preferences[REFRESH_KEY] = refreshToken
+        override suspend fun saveRefreshToken(refreshToken: String): Boolean {
+            dataStore.edit { preferences ->
+                preferences[REFRESH_KEY] = refreshToken
+            }
+            return true
         }
-        return true
-    }
 
-    override suspend fun getRefreshToken(): String? =
-        dataStore
-            .data
-            .catch { exception ->
-                if (exception is IOException) {
-                    emit(emptyPreferences())
-                } else {
-                    throw exception
-                }
-            }.map { preferences ->
-                preferences[REFRESH_KEY]
-            }.firstOrNull()
-}
+        override suspend fun getRefreshToken(): String? =
+            dataStore
+                .data
+                .catch { exception ->
+                    if (exception is IOException) {
+                        emit(emptyPreferences())
+                    } else {
+                        throw exception
+                    }
+                }.map { preferences ->
+                    preferences[REFRESH_KEY]
+                }.firstOrNull()
+    }

--- a/core/local/src/main/java/com/emotionstorage/local/dataSourceImpl/SessionLocalDataSourceImpl.kt
+++ b/core/local/src/main/java/com/emotionstorage/local/dataSourceImpl/SessionLocalDataSourceImpl.kt
@@ -58,12 +58,16 @@ class SessionLocalDataSourceImpl
                 false
             }
 
-        override suspend fun saveRefreshToken(refreshToken: String): Boolean {
-            dataStore.edit { preferences ->
-                preferences[REFRESH_KEY] = refreshToken
+        override suspend fun saveRefreshToken(refreshToken: String): Boolean =
+            try {
+                dataStore.edit { preferences ->
+                    preferences[REFRESH_KEY] = refreshToken
+                }
+                true
+            } catch (e: Exception) {
+                Logger.e("saveRefreshToken error: $e")
+                false
             }
-            return true
-        }
 
         override suspend fun getRefreshToken(): String? =
             dataStore

--- a/core/local/src/main/java/com/emotionstorage/local/dataSourceImpl/SessionLocalDataSourceImpl.kt
+++ b/core/local/src/main/java/com/emotionstorage/local/dataSourceImpl/SessionLocalDataSourceImpl.kt
@@ -1,17 +1,32 @@
 package com.emotionstorage.local.dataSourceImpl
 
+import androidx.datastore.core.DataStore
+import androidx.datastore.core.IOException
+import androidx.datastore.preferences.core.Preferences
+import androidx.datastore.preferences.core.edit
+import androidx.datastore.preferences.core.emptyPreferences
+import androidx.datastore.preferences.core.stringPreferencesKey
 import com.emotionstorage.data.dataSource.local.SessionLocalDataSource
 import com.emotionstorage.data.model.SessionEntity
 import com.emotionstorage.local.modelMapper.SessionMapper
 import com.emotionstorage.local.room.dao.SessionDao
 import com.orhanobut.logger.Logger
+import kotlinx.coroutines.flow.catch
+import kotlinx.coroutines.flow.firstOrNull
+import kotlinx.coroutines.flow.map
 import javax.inject.Inject
 
+// todo: save access token in data store
 class SessionLocalDataSourceImpl
     @Inject
     constructor(
         private val sessionDao: SessionDao,
+        private val dataStore: DataStore<Preferences>,
     ) : SessionLocalDataSource {
+        companion object {
+            private val REFRESH_KEY = stringPreferencesKey("refresh_token")
+        }
+
         override suspend fun saveSession(session: SessionEntity): Boolean =
             try {
                 sessionDao.insertSession(SessionMapper.toLocal(session))
@@ -34,9 +49,32 @@ class SessionLocalDataSourceImpl
         override suspend fun deleteSession(): Boolean =
             try {
                 sessionDao.deleteSession()
+                dataStore.edit { preferences ->
+                    preferences.remove(REFRESH_KEY)
+                }
                 true
             } catch (e: Exception) {
                 Logger.e("deleteSession error: $e")
                 false
             }
+
+    override suspend fun saveRefreshToken(refreshToken: String): Boolean {
+        dataStore.edit { preferences ->
+            preferences[REFRESH_KEY] = refreshToken
+        }
+        return true
     }
+
+    override suspend fun getRefreshToken(): String? =
+        dataStore
+            .data
+            .catch { exception ->
+                if (exception is IOException) {
+                    emit(emptyPreferences())
+                } else {
+                    throw exception
+                }
+            }.map { preferences ->
+                preferences[REFRESH_KEY]
+            }.firstOrNull()
+}

--- a/core/local/src/main/java/com/emotionstorage/local/di/LocalDataSourceModule.kt
+++ b/core/local/src/main/java/com/emotionstorage/local/di/LocalDataSourceModule.kt
@@ -1,12 +1,12 @@
 package com.emotionstorage.local.di
 
 import com.emotionstorage.data.dataSource.local.FcmLocalDataSource
-import com.emotionstorage.data.dataSource.local.NotificationPermissionDataSource
+import com.emotionstorage.data.dataSource.local.NotificationPermissionLocalDataSource
 import com.emotionstorage.data.dataSource.local.SessionLocalDataSource
 import com.emotionstorage.data.dataSource.local.TimeCapsuleLocalDataSource
 import com.emotionstorage.data.dataSource.local.UserLocalDataSource
 import com.emotionstorage.local.dataSourceImpl.FcmLocalDataSourceImpl
-import com.emotionstorage.local.dataSourceImpl.NotificationPermissionDataSourceImpl
+import com.emotionstorage.local.dataSourceImpl.NotificationPermissionLocalLocalDataSourceImpl
 import com.emotionstorage.local.dataSourceImpl.SessionLocalDataSourceImpl
 import com.emotionstorage.local.dataSourceImpl.TimeCapsuleLocalDataSourceImpl
 import com.emotionstorage.local.dataSourceImpl.UserLocalDataSourceImpl
@@ -38,6 +38,6 @@ abstract class LocalDataSourceModule {
     @Binds
     @Singleton
     abstract fun bindNotificationPermissionDataSource(
-        impl: NotificationPermissionDataSourceImpl,
-    ): NotificationPermissionDataSource
+        impl: NotificationPermissionLocalLocalDataSourceImpl,
+    ): NotificationPermissionLocalDataSource
 }

--- a/core/presentation/src/main/java/com/emotionstorage/presentation/BaseViewModel.kt
+++ b/core/presentation/src/main/java/com/emotionstorage/presentation/BaseViewModel.kt
@@ -61,7 +61,6 @@ open class BaseViewModel<STATE : Any>(
                     postSideEffect(BaseSideEffect.NetworkError)
                 } else if (code.isAuthError()) {
                     // handle auth expiration error
-                    // todo: refresh token here? or in remote interceptor?
                     postSideEffect(BaseSideEffect.SessionExpired)
                 } else {
                     // handle internal server error / unknown error / etc

--- a/core/remote/src/main/java/com/emotionstorage/remote/api/AuthApiService.kt
+++ b/core/remote/src/main/java/com/emotionstorage/remote/api/AuthApiService.kt
@@ -37,13 +37,6 @@ interface AuthApiService {
     @GET("/auth/session")
     suspend fun getAuthSession(): ResponseDto<Unit>
 
-    /**
-     * send refresh token via HttpOnly Cookie
-     */
-    @POST("/auth/reissue")
-    suspend fun postReissue(
-    ): ResponseDto<ReissueResponseData>
-
     @DELETE("/api/v1/mypage/logout")
     suspend fun postLogout(): ResponseDto<Unit>
 

--- a/core/remote/src/main/java/com/emotionstorage/remote/api/AuthApiService.kt
+++ b/core/remote/src/main/java/com/emotionstorage/remote/api/AuthApiService.kt
@@ -6,7 +6,6 @@ import com.emotionstorage.remote.request.auth.KakaoLoginRequestBody
 import com.emotionstorage.remote.request.auth.KakaoSignupRequestBody
 import com.emotionstorage.remote.response.ResponseDto
 import com.emotionstorage.remote.response.auth.LoginResponseData
-import com.emotionstorage.remote.response.auth.ReissueResponseData
 import com.emotionstorage.remote.response.auth.SignupResponseData
 import retrofit2.http.Body
 import retrofit2.http.DELETE

--- a/core/remote/src/main/java/com/emotionstorage/remote/api/AuthApiService.kt
+++ b/core/remote/src/main/java/com/emotionstorage/remote/api/AuthApiService.kt
@@ -1,6 +1,5 @@
 package com.emotionstorage.remote.api
 
-import com.emotionstorage.remote.interceptor.AuthRequest
 import com.emotionstorage.remote.request.auth.GoogleLoginRequestBody
 import com.emotionstorage.remote.request.auth.GoogleSignupRequestBody
 import com.emotionstorage.remote.request.auth.KakaoLoginRequestBody
@@ -35,7 +34,6 @@ interface AuthApiService {
         @Body signupRequestBody: KakaoSignupRequestBody,
     ): ResponseDto<SignupResponseData>
 
-    @AuthRequest
     @GET("/auth/session")
     suspend fun getAuthSession(): ResponseDto<Unit>
 
@@ -46,11 +44,9 @@ interface AuthApiService {
     suspend fun postReissue(
     ): ResponseDto<ReissueResponseData>
 
-    @AuthRequest
     @DELETE("/api/v1/mypage/logout")
     suspend fun postLogout(): ResponseDto<Unit>
 
-    @AuthRequest
     @DELETE("/api/v1/mypage/account")
     suspend fun deleteAccount(): ResponseDto<Unit>
 }

--- a/core/remote/src/main/java/com/emotionstorage/remote/api/AuthApiService.kt
+++ b/core/remote/src/main/java/com/emotionstorage/remote/api/AuthApiService.kt
@@ -7,6 +7,7 @@ import com.emotionstorage.remote.request.auth.KakaoLoginRequestBody
 import com.emotionstorage.remote.request.auth.KakaoSignupRequestBody
 import com.emotionstorage.remote.response.ResponseDto
 import com.emotionstorage.remote.response.auth.LoginResponseData
+import com.emotionstorage.remote.response.auth.ReissueResponseData
 import com.emotionstorage.remote.response.auth.SignupResponseData
 import retrofit2.http.Body
 import retrofit2.http.DELETE
@@ -37,6 +38,13 @@ interface AuthApiService {
     @AuthRequest
     @GET("/auth/session")
     suspend fun getAuthSession(): ResponseDto<Unit>
+
+    /**
+     * send refresh token via HttpOnly Cookie
+     */
+    @POST("/auth/reissue")
+    suspend fun postReissue(
+    ): ResponseDto<ReissueResponseData>
 
     @AuthRequest
     @DELETE("/api/v1/mypage/logout")

--- a/core/remote/src/main/java/com/emotionstorage/remote/api/HomeApiService.kt
+++ b/core/remote/src/main/java/com/emotionstorage/remote/api/HomeApiService.kt
@@ -1,12 +1,10 @@
 package com.emotionstorage.remote.api
 
-import com.emotionstorage.remote.interceptor.AuthRequest
 import com.emotionstorage.remote.response.home.HomeResponse
 import com.emotionstorage.remote.response.ResponseDto
 import retrofit2.http.GET
 
 interface HomeApiService {
-    @AuthRequest
     @GET("/api/v1/home")
     suspend fun getHome(): ResponseDto<HomeResponse>
 }

--- a/core/remote/src/main/java/com/emotionstorage/remote/api/ReissueApiService.kt
+++ b/core/remote/src/main/java/com/emotionstorage/remote/api/ReissueApiService.kt
@@ -1,0 +1,14 @@
+package com.emotionstorage.remote.api
+
+import com.emotionstorage.remote.response.ResponseDto
+import com.emotionstorage.remote.response.auth.ReissueResponseData
+import retrofit2.http.POST
+
+interface ReissueApiService {
+    /**
+     * send refresh token via HttpOnly Cookie
+     */
+    @POST("/auth/reissue")
+    suspend fun postReissue(
+    ): ResponseDto<ReissueResponseData>
+}

--- a/core/remote/src/main/java/com/emotionstorage/remote/api/ReissueApiService.kt
+++ b/core/remote/src/main/java/com/emotionstorage/remote/api/ReissueApiService.kt
@@ -9,6 +9,5 @@ interface ReissueApiService {
      * send refresh token via HttpOnly Cookie
      */
     @POST("/auth/reissue")
-    suspend fun postReissue(
-    ): ResponseDto<ReissueResponseData>
+    suspend fun postReissue(): ResponseDto<ReissueResponseData>
 }

--- a/core/remote/src/main/java/com/emotionstorage/remote/cookieJar/AppCookieJar.kt
+++ b/core/remote/src/main/java/com/emotionstorage/remote/cookieJar/AppCookieJar.kt
@@ -10,9 +10,12 @@ import okhttp3.Cookie
 import okhttp3.CookieJar
 import okhttp3.HttpUrl
 
+private const val REFRESH_TOKEN_NAME = "refreshToken"
+
 class AppCookieJar(
     private val sessionLocalDataSource: SessionLocalDataSource,
 ) : CookieJar {
+
     private val scope = CoroutineScope(Dispatchers.IO)
     private val cookieStore = mutableMapOf<String, List<Cookie>>()
 
@@ -23,7 +26,7 @@ class AppCookieJar(
             return listOf(
                 Cookie
                     .Builder()
-                    .name("refresh_token")
+                    .name(REFRESH_TOKEN_NAME)
                     .value(refreshToken)
                     .domain(url.host)
                     .path("/")
@@ -44,7 +47,7 @@ class AppCookieJar(
         cookieStore[url.host] = cookies
 
         // save refresh token to data store
-        cookies.find { it.name == "refreshToken" }?.let { cookie ->
+        cookies.find { it.name == REFRESH_TOKEN_NAME }?.let { cookie ->
             scope.launch {
                 sessionLocalDataSource.saveRefreshToken(cookie.value)
             }

--- a/core/remote/src/main/java/com/emotionstorage/remote/cookieJar/AppCookieJar.kt
+++ b/core/remote/src/main/java/com/emotionstorage/remote/cookieJar/AppCookieJar.kt
@@ -2,10 +2,8 @@ package com.emotionstorage.remote.cookieJar
 
 import com.emotionstorage.data.dataSource.local.SessionLocalDataSource
 import com.orhanobut.logger.Logger
-import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.async
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.runBlocking
 import okhttp3.Cookie
@@ -13,9 +11,8 @@ import okhttp3.CookieJar
 import okhttp3.HttpUrl
 
 class AppCookieJar(
-    private val sessionLocalDataSource: SessionLocalDataSource
+    private val sessionLocalDataSource: SessionLocalDataSource,
 ) : CookieJar {
-
     private val scope = CoroutineScope(Dispatchers.IO)
     private val cookieStore = mutableMapOf<String, List<Cookie>>()
 
@@ -24,21 +21,25 @@ class AppCookieJar(
             // get refresh token from data store if reissue
             val refreshToken = runBlocking { sessionLocalDataSource.getRefreshToken() ?: "" }
             return listOf(
-                Cookie.Builder()
+                Cookie
+                    .Builder()
                     .name("refresh_token")
                     .value(refreshToken)
                     .domain(url.host)
                     .path("/")
                     .httpOnly()
                     .secure()
-                    .build()
+                    .build(),
             )
         } else {
             return cookieStore[url.host] ?: emptyList()
         }
     }
 
-    override fun saveFromResponse(url: HttpUrl, cookies: List<Cookie>) {
+    override fun saveFromResponse(
+        url: HttpUrl,
+        cookies: List<Cookie>,
+    ) {
         Logger.d("save cookies from response: $cookies")
         cookieStore[url.host] = cookies
 
@@ -50,4 +51,3 @@ class AppCookieJar(
         }
     }
 }
-

--- a/core/remote/src/main/java/com/emotionstorage/remote/cookieJar/AppCookieJar.kt
+++ b/core/remote/src/main/java/com/emotionstorage/remote/cookieJar/AppCookieJar.kt
@@ -15,7 +15,6 @@ private const val REFRESH_TOKEN_NAME = "refreshToken"
 class AppCookieJar(
     private val sessionLocalDataSource: SessionLocalDataSource,
 ) : CookieJar {
-
     private val scope = CoroutineScope(Dispatchers.IO)
     private val cookieStore = mutableMapOf<String, List<Cookie>>()
 

--- a/core/remote/src/main/java/com/emotionstorage/remote/cookieJar/AppCookieJar.kt
+++ b/core/remote/src/main/java/com/emotionstorage/remote/cookieJar/AppCookieJar.kt
@@ -1,0 +1,24 @@
+package com.emotionstorage.remote.cookieJar
+
+import com.emotionstorage.data.dataSource.local.SessionLocalDataSource
+import okhttp3.Cookie
+import okhttp3.CookieJar
+import okhttp3.HttpUrl
+
+class AppCookieJar(
+    private val sessionLocalDataSource: SessionLocalDataSource
+) : CookieJar {
+
+    private val cookieStore = mutableMapOf<String, List<Cookie>>()
+
+    override fun loadForRequest(url: HttpUrl): List<Cookie> {
+        return cookieStore[url.host] ?: emptyList()
+        // todo: add refresh token to cookie
+    }
+
+    override fun saveFromResponse(url: HttpUrl, cookies: List<Cookie>) {
+        cookieStore[url.host] = cookies
+        // todo: save refresh token to data store
+    }
+}
+

--- a/core/remote/src/main/java/com/emotionstorage/remote/cookieJar/AppCookieJar.kt
+++ b/core/remote/src/main/java/com/emotionstorage/remote/cookieJar/AppCookieJar.kt
@@ -2,6 +2,12 @@ package com.emotionstorage.remote.cookieJar
 
 import com.emotionstorage.data.dataSource.local.SessionLocalDataSource
 import com.orhanobut.logger.Logger
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.async
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.runBlocking
 import okhttp3.Cookie
 import okhttp3.CookieJar
 import okhttp3.HttpUrl
@@ -10,17 +16,38 @@ class AppCookieJar(
     private val sessionLocalDataSource: SessionLocalDataSource
 ) : CookieJar {
 
+    private val scope = CoroutineScope(Dispatchers.IO)
     private val cookieStore = mutableMapOf<String, List<Cookie>>()
 
     override fun loadForRequest(url: HttpUrl): List<Cookie> {
-        return cookieStore[url.host] ?: emptyList()
-        // todo: add refresh token to cookie
+        if (url.encodedPath.contains("/auth/reissue")) {
+            // get refresh token from data store if reissue
+            val refreshToken = runBlocking { sessionLocalDataSource.getRefreshToken() ?: "" }
+            return listOf(
+                Cookie.Builder()
+                    .name("refresh_token")
+                    .value(refreshToken)
+                    .domain(url.host)
+                    .path("/")
+                    .httpOnly()
+                    .secure()
+                    .build()
+            )
+        } else {
+            return cookieStore[url.host] ?: emptyList()
+        }
     }
 
     override fun saveFromResponse(url: HttpUrl, cookies: List<Cookie>) {
+        Logger.d("save cookies from response: $cookies")
         cookieStore[url.host] = cookies
-        Logger.d("saveFromResponse: $cookies")
-        // todo: save refresh token to data store
+
+        // save refresh token to data store
+        cookies.find { it.name == "refreshToken" }?.let { cookie ->
+            scope.launch {
+                sessionLocalDataSource.saveRefreshToken(cookie.value)
+            }
+        }
     }
 }
 

--- a/core/remote/src/main/java/com/emotionstorage/remote/cookieJar/AppCookieJar.kt
+++ b/core/remote/src/main/java/com/emotionstorage/remote/cookieJar/AppCookieJar.kt
@@ -1,6 +1,7 @@
 package com.emotionstorage.remote.cookieJar
 
 import com.emotionstorage.data.dataSource.local.SessionLocalDataSource
+import com.orhanobut.logger.Logger
 import okhttp3.Cookie
 import okhttp3.CookieJar
 import okhttp3.HttpUrl
@@ -18,6 +19,7 @@ class AppCookieJar(
 
     override fun saveFromResponse(url: HttpUrl, cookies: List<Cookie>) {
         cookieStore[url.host] = cookies
+        Logger.d("saveFromResponse: $cookies")
         // todo: save refresh token to data store
     }
 }

--- a/core/remote/src/main/java/com/emotionstorage/remote/dataSourceImpl/AuthRemoteDataSourceImpl.kt
+++ b/core/remote/src/main/java/com/emotionstorage/remote/dataSourceImpl/AuthRemoteDataSourceImpl.kt
@@ -17,122 +17,121 @@ import java.io.IOException
 import javax.inject.Inject
 
 class AuthRemoteDataSourceImpl
-@Inject
-constructor(
-    private val authApiService: AuthApiService,
-) : AuthRemoteDataSource {
-    override suspend fun login(
-        provider: User.AuthProvider,
-        idToken: String,
-    ): DataState<String> =
-        try {
-            val response =
-                when (provider) {
-                    User.AuthProvider.KAKAO -> {
-                        authApiService.postKakaoLogin(
-                            KakaoLoginRequestBody(idToken),
-                        )
+    @Inject
+    constructor(
+        private val authApiService: AuthApiService,
+    ) : AuthRemoteDataSource {
+        override suspend fun login(
+            provider: User.AuthProvider,
+            idToken: String,
+        ): DataState<String> =
+            try {
+                val response =
+                    when (provider) {
+                        User.AuthProvider.KAKAO -> {
+                            authApiService.postKakaoLogin(
+                                KakaoLoginRequestBody(idToken),
+                            )
+                        }
+
+                        User.AuthProvider.GOOGLE -> {
+                            authApiService.postGoogleLogin(
+                                GoogleLoginRequestBody(idToken),
+                            )
+                        }
                     }
 
-                    User.AuthProvider.GOOGLE -> {
-                        authApiService.postGoogleLogin(
-                            GoogleLoginRequestBody(idToken),
-                        )
-                    }
+                response.data?.accessToken?.run {
+                    DataState.Success(this)
+                } ?: DataState.Error(Throwable("No access token received"))
+            } catch (e: IOException) {
+                if (e !is CustomHttpException) {
+                    // handle network error
+                    Logger.e("Login network exception, $e")
+                    DataState.Error(e, ErrorCode.NETWORK_ERROR, data = idToken)
+                } else {
+                    // handle http response error
+                    Logger.e("Login http exception, $e")
+                    DataState.Error(e, ErrorCode.toErrorCode(e.code ?: ""), data = idToken)
                 }
-
-            response.data?.accessToken?.run {
-                DataState.Success(this)
-            } ?: DataState.Error(Throwable("No access token received"))
-        } catch (e: IOException) {
-            if (e !is CustomHttpException) {
-                // handle network error
-                Logger.e("Login network exception, $e")
-                DataState.Error(e, ErrorCode.NETWORK_ERROR, data = idToken)
-            } else {
-                // handle http response error
-                Logger.e("Login http exception, $e")
-                DataState.Error(e, ErrorCode.toErrorCode(e.code ?: ""), data = idToken)
+            } catch (e: Exception) {
+                // handle unknown error
+                Logger.e("Login exception, $e")
+                DataState.Error(Throwable("Login api failed", e), data = idToken)
             }
-        } catch (e: Exception) {
-            // handle unknown error
-            Logger.e("Login exception, $e")
-            DataState.Error(Throwable("Login api failed", e), data = idToken)
-        }
 
-    override suspend fun signup(
-        provider: User.AuthProvider,
-        signupFormEntity: SignupFormEntity,
-    ): DataState<Unit> =
-        try {
-            val response =
-                when (provider) {
-                    User.AuthProvider.KAKAO -> {
-                        authApiService.postKakaoSignup(
-                            KakaoSignupFormMapper.toRemote(signupFormEntity),
-                        )
+        override suspend fun signup(
+            provider: User.AuthProvider,
+            signupFormEntity: SignupFormEntity,
+        ): DataState<Unit> =
+            try {
+                val response =
+                    when (provider) {
+                        User.AuthProvider.KAKAO -> {
+                            authApiService.postKakaoSignup(
+                                KakaoSignupFormMapper.toRemote(signupFormEntity),
+                            )
+                        }
+
+                        User.AuthProvider.GOOGLE -> {
+                            authApiService.postGoogleSignup(
+                                GoogleSignupFormMapper.toRemote(signupFormEntity),
+                            )
+                        }
                     }
 
-                    User.AuthProvider.GOOGLE -> {
-                        authApiService.postGoogleSignup(
-                            GoogleSignupFormMapper.toRemote(signupFormEntity),
-                        )
-                    }
+                if (response.status == ResponseStatus.Created.code) {
+                    DataState.Success(Unit)
+                } else {
+                    throw Exception(response.code + "" + response.message)
                 }
+            } catch (e: IOException) {
+                if (e !is CustomHttpException) {
+                    // handle network error
+                    Logger.e("Signup network exception, $e")
+                    DataState.Error(e, ErrorCode.NETWORK_ERROR)
+                } else {
+                    // handle http response error
+                    Logger.e("Signup http exception, $e")
+                    DataState.Error(e, ErrorCode.toErrorCode(e.code ?: ""))
+                }
+            } catch (e: Exception) {
+                // handle unknown error
+                Logger.e("Signup api failed", e)
+                DataState.Error(e)
+            }
 
-            if (response.status == ResponseStatus.Created.code) {
-                DataState.Success(Unit)
-            } else {
-                throw Exception(response.code + "" + response.message)
+        override suspend fun checkSession(): DataState<Unit> =
+            try {
+                val response = authApiService.getAuthSession()
+                if (response.status == ResponseStatus.OK.code) {
+                    DataState.Success(Unit)
+                } else {
+                    throw Exception(response.code + "" + response.message)
+                }
+            } catch (e: IOException) {
+                if (e !is CustomHttpException) {
+                    // handle network error
+                    Logger.e("check session network exception, $e")
+                    DataState.Error(e, ErrorCode.NETWORK_ERROR)
+                } else {
+                    // handle http response error
+                    Logger.e("check session http exception, $e")
+                    DataState.Error(e, ErrorCode.toErrorCode(e.code ?: ""))
+                }
+            } catch (e: Exception) {
+                // handle unknown error
+                Logger.e("check session api failed", e)
+                DataState.Error(e)
             }
-        } catch (e: IOException) {
-            if (e !is CustomHttpException) {
-                // handle network error
-                Logger.e("Signup network exception, $e")
-                DataState.Error(e, ErrorCode.NETWORK_ERROR)
-            } else {
-                // handle http response error
-                Logger.e("Signup http exception, $e")
-                DataState.Error(e, ErrorCode.toErrorCode(e.code ?: ""))
-            }
-        } catch (e: Exception) {
-            // handle unknown error
-            Logger.e("Signup api failed", e)
-            DataState.Error(e)
+
+        override suspend fun logout(): Boolean {
+            val response = authApiService.postLogout()
+            return response.status == ResponseStatus.OK.code
         }
 
-    override suspend fun checkSession(): DataState<Unit> =
-        try {
-            val response = authApiService.getAuthSession()
-            if (response.status == ResponseStatus.OK.code) {
-                DataState.Success(Unit)
-            } else {
-                throw Exception(response.code + "" + response.message)
-            }
-        } catch (e: IOException) {
-            if (e !is CustomHttpException) {
-                // handle network error
-                Logger.e("check session network exception, $e")
-                DataState.Error(e, ErrorCode.NETWORK_ERROR)
-            } else {
-                // handle http response error
-                Logger.e("check session http exception, $e")
-                DataState.Error(e, ErrorCode.toErrorCode(e.code ?: ""))
-            }
-        } catch (e: Exception) {
-            // handle unknown error
-            Logger.e("check session api failed", e)
-            DataState.Error(e)
+        override suspend fun deleteAccount(): Boolean {
+            val response = authApiService.deleteAccount()
+            return response.status == ResponseStatus.NoContent.code
         }
-
-
-    override suspend fun logout(): Boolean {
-        val response = authApiService.postLogout()
-        return response.status == ResponseStatus.OK.code
     }
-
-    override suspend fun deleteAccount(): Boolean {
-        val response = authApiService.deleteAccount()
-        return response.status == ResponseStatus.NoContent.code
-    }
-}

--- a/core/remote/src/main/java/com/emotionstorage/remote/dataSourceImpl/AuthRemoteDataSourceImpl.kt
+++ b/core/remote/src/main/java/com/emotionstorage/remote/dataSourceImpl/AuthRemoteDataSourceImpl.kt
@@ -17,110 +17,122 @@ import java.io.IOException
 import javax.inject.Inject
 
 class AuthRemoteDataSourceImpl
-    @Inject
-    constructor(
-        private val authApiService: AuthApiService,
-    ) : AuthRemoteDataSource {
-        override suspend fun login(
-            provider: User.AuthProvider,
-            idToken: String,
-        ): DataState<String> =
-            try {
-                val response =
-                    when (provider) {
-                        User.AuthProvider.KAKAO -> {
-                            authApiService.postKakaoLogin(
-                                KakaoLoginRequestBody(idToken),
-                            )
-                        }
-
-                        User.AuthProvider.GOOGLE -> {
-                            authApiService.postGoogleLogin(
-                                GoogleLoginRequestBody(idToken),
-                            )
-                        }
+@Inject
+constructor(
+    private val authApiService: AuthApiService,
+) : AuthRemoteDataSource {
+    override suspend fun login(
+        provider: User.AuthProvider,
+        idToken: String,
+    ): DataState<String> =
+        try {
+            val response =
+                when (provider) {
+                    User.AuthProvider.KAKAO -> {
+                        authApiService.postKakaoLogin(
+                            KakaoLoginRequestBody(idToken),
+                        )
                     }
 
-                response.data?.accessToken?.run {
-                    DataState.Success(this)
-                } ?: DataState.Error(Throwable("No access token received"))
-            } catch (e: IOException) {
-                if (e !is CustomHttpException) {
-                    // handle network error
-                    Logger.e("Login network exception, $e")
-                    DataState.Error(e, ErrorCode.NETWORK_ERROR, data = idToken)
-                } else {
-                    // handle http response error
-                    Logger.e("Login http exception, $e")
-                    DataState.Error(e, ErrorCode.toErrorCode(e.code ?: ""), data = idToken)
+                    User.AuthProvider.GOOGLE -> {
+                        authApiService.postGoogleLogin(
+                            GoogleLoginRequestBody(idToken),
+                        )
+                    }
                 }
-            } catch (e: Exception) {
-                // handle unknown error
-                Logger.e("Login exception, $e")
-                DataState.Error(Throwable("Login api failed", e), data = idToken)
+
+            response.data?.accessToken?.run {
+                DataState.Success(this)
+            } ?: DataState.Error(Throwable("No access token received"))
+        } catch (e: IOException) {
+            if (e !is CustomHttpException) {
+                // handle network error
+                Logger.e("Login network exception, $e")
+                DataState.Error(e, ErrorCode.NETWORK_ERROR, data = idToken)
+            } else {
+                // handle http response error
+                Logger.e("Login http exception, $e")
+                DataState.Error(e, ErrorCode.toErrorCode(e.code ?: ""), data = idToken)
             }
+        } catch (e: Exception) {
+            // handle unknown error
+            Logger.e("Login exception, $e")
+            DataState.Error(Throwable("Login api failed", e), data = idToken)
+        }
 
-        override suspend fun signup(
-            provider: User.AuthProvider,
-            signupFormEntity: SignupFormEntity,
-        ): DataState<Unit> =
-            try {
-                val response =
-                    when (provider) {
-                        User.AuthProvider.KAKAO -> {
-                            authApiService.postKakaoSignup(
-                                KakaoSignupFormMapper.toRemote(signupFormEntity),
-                            )
-                        }
-
-                        User.AuthProvider.GOOGLE -> {
-                            authApiService.postGoogleSignup(
-                                GoogleSignupFormMapper.toRemote(signupFormEntity),
-                            )
-                        }
+    override suspend fun signup(
+        provider: User.AuthProvider,
+        signupFormEntity: SignupFormEntity,
+    ): DataState<Unit> =
+        try {
+            val response =
+                when (provider) {
+                    User.AuthProvider.KAKAO -> {
+                        authApiService.postKakaoSignup(
+                            KakaoSignupFormMapper.toRemote(signupFormEntity),
+                        )
                     }
 
-                if (response.status == ResponseStatus.Created.code) {
-                    DataState.Success(Unit)
-                } else {
-                    throw Exception(response.code + "" + response.message)
+                    User.AuthProvider.GOOGLE -> {
+                        authApiService.postGoogleSignup(
+                            GoogleSignupFormMapper.toRemote(signupFormEntity),
+                        )
+                    }
                 }
-            } catch (e: IOException) {
-                if (e !is CustomHttpException) {
-                    // handle network error
-                    Logger.e("Signup network exception, $e")
-                    DataState.Error(e, ErrorCode.NETWORK_ERROR)
-                } else {
-                    // handle http response error
-                    Logger.e("Signup http exception, $e")
-                    DataState.Error(e, ErrorCode.toErrorCode(e.code ?: ""))
-                }
-            } catch (e: Exception) {
-                // handle unknown error
-                Logger.e("Signup api failed", e)
-                DataState.Error(e)
+
+            if (response.status == ResponseStatus.Created.code) {
+                DataState.Success(Unit)
+            } else {
+                throw Exception(response.code + "" + response.message)
             }
-
-        override suspend fun checkSession(): Boolean {
-            try {
-                val response = authApiService.getAuthSession()
-                if (response.status == ResponseStatus.OK.code) {
-                    return true
-                } else {
-                    throw Exception(response.code + "" + response.message)
-                }
-            } catch (e: Exception) {
-                throw Exception("Check session api failed", e)
+        } catch (e: IOException) {
+            if (e !is CustomHttpException) {
+                // handle network error
+                Logger.e("Signup network exception, $e")
+                DataState.Error(e, ErrorCode.NETWORK_ERROR)
+            } else {
+                // handle http response error
+                Logger.e("Signup http exception, $e")
+                DataState.Error(e, ErrorCode.toErrorCode(e.code ?: ""))
             }
+        } catch (e: Exception) {
+            // handle unknown error
+            Logger.e("Signup api failed", e)
+            DataState.Error(e)
         }
 
-        override suspend fun logout(): Boolean {
-            val response = authApiService.postLogout()
-            return response.status == ResponseStatus.OK.code
+    override suspend fun checkSession(): DataState<Unit> =
+        try {
+            val response = authApiService.getAuthSession()
+            if (response.status == ResponseStatus.OK.code) {
+                DataState.Success(Unit)
+            } else {
+                throw Exception(response.code + "" + response.message)
+            }
+        } catch (e: IOException) {
+            if (e !is CustomHttpException) {
+                // handle network error
+                Logger.e("check session network exception, $e")
+                DataState.Error(e, ErrorCode.NETWORK_ERROR)
+            } else {
+                // handle http response error
+                Logger.e("check session http exception, $e")
+                DataState.Error(e, ErrorCode.toErrorCode(e.code ?: ""))
+            }
+        } catch (e: Exception) {
+            // handle unknown error
+            Logger.e("check session api failed", e)
+            DataState.Error(e)
         }
 
-        override suspend fun deleteAccount(): Boolean {
-            val response = authApiService.deleteAccount()
-            return response.status == ResponseStatus.NoContent.code
-        }
+
+    override suspend fun logout(): Boolean {
+        val response = authApiService.postLogout()
+        return response.status == ResponseStatus.OK.code
     }
+
+    override suspend fun deleteAccount(): Boolean {
+        val response = authApiService.deleteAccount()
+        return response.status == ResponseStatus.NoContent.code
+    }
+}

--- a/core/remote/src/main/java/com/emotionstorage/remote/dataSourceImpl/ReissueRemoteDataSourceImpl.kt
+++ b/core/remote/src/main/java/com/emotionstorage/remote/dataSourceImpl/ReissueRemoteDataSourceImpl.kt
@@ -8,15 +8,16 @@ import javax.inject.Inject
 
 class ReissueRemoteDataSourceImpl @Inject constructor(
     private val reissueApiService: ReissueApiService,
-): ReissueRemoteDataSource {
-    override suspend fun reissueAccessToken(): DataState<String> = try{
-        reissueApiService.postReissue().data?.accessToken?.run{
-            DataState.Success(this)
-        }?: DataState.Error(
-            Throwable("No access token received")
-        )
-    }catch(e: Exception){
-        Logger.e("Reissue api failed", e)
-        DataState.Error(e)
-    }
+) : ReissueRemoteDataSource {
+    override suspend fun reissueAccessToken(): DataState<String> =
+        try {
+            reissueApiService.postReissue().data?.accessToken?.run {
+                DataState.Success(this)
+            } ?: DataState.Error(
+                Throwable("No access token received"),
+            )
+        } catch (e: Exception) {
+            Logger.e("Reissue api failed", e)
+            DataState.Error(e)
+        }
 }

--- a/core/remote/src/main/java/com/emotionstorage/remote/dataSourceImpl/ReissueRemoteDataSourceImpl.kt
+++ b/core/remote/src/main/java/com/emotionstorage/remote/dataSourceImpl/ReissueRemoteDataSourceImpl.kt
@@ -6,7 +6,7 @@ import com.emotionstorage.domain.common.ErrorCode
 import com.emotionstorage.remote.api.ReissueApiService
 import com.emotionstorage.remote.response.CustomHttpException
 import com.orhanobut.logger.Logger
-import okio.IOException
+import java.io.IOException
 import javax.inject.Inject
 
 class ReissueRemoteDataSourceImpl @Inject constructor(

--- a/core/remote/src/main/java/com/emotionstorage/remote/dataSourceImpl/ReissueRemoteDataSourceImpl.kt
+++ b/core/remote/src/main/java/com/emotionstorage/remote/dataSourceImpl/ReissueRemoteDataSourceImpl.kt
@@ -1,0 +1,22 @@
+package com.emotionstorage.remote.dataSourceImpl
+
+import com.emotionstorage.data.dataSource.remote.ReissueRemoteDataSource
+import com.emotionstorage.domain.common.DataState
+import com.emotionstorage.remote.api.ReissueApiService
+import com.orhanobut.logger.Logger
+import javax.inject.Inject
+
+class ReissueRemoteDataSourceImpl @Inject constructor(
+    private val reissueApiService: ReissueApiService,
+): ReissueRemoteDataSource {
+    override suspend fun reissueAccessToken(): DataState<String> = try{
+        reissueApiService.postReissue().data?.accessToken?.run{
+            DataState.Success(this)
+        }?: DataState.Error(
+            Throwable("No access token received")
+        )
+    }catch(e: Exception){
+        Logger.e("Reissue api failed", e)
+        DataState.Error(e)
+    }
+}

--- a/core/remote/src/main/java/com/emotionstorage/remote/dataSourceImpl/ReissueRemoteDataSourceImpl.kt
+++ b/core/remote/src/main/java/com/emotionstorage/remote/dataSourceImpl/ReissueRemoteDataSourceImpl.kt
@@ -2,8 +2,11 @@ package com.emotionstorage.remote.dataSourceImpl
 
 import com.emotionstorage.data.dataSource.remote.ReissueRemoteDataSource
 import com.emotionstorage.domain.common.DataState
+import com.emotionstorage.domain.common.ErrorCode
 import com.emotionstorage.remote.api.ReissueApiService
+import com.emotionstorage.remote.response.CustomHttpException
 import com.orhanobut.logger.Logger
+import okio.IOException
 import javax.inject.Inject
 
 class ReissueRemoteDataSourceImpl @Inject constructor(
@@ -16,6 +19,14 @@ class ReissueRemoteDataSourceImpl @Inject constructor(
             } ?: DataState.Error(
                 Throwable("No access token received"),
             )
+        } catch (e: IOException) {
+            if (e !is CustomHttpException) {
+                Logger.e("Reissue network exception, $e")
+                DataState.Error(e, ErrorCode.NETWORK_ERROR)
+            } else {
+                Logger.e("Reissue http exception, $e")
+                DataState.Error(e, ErrorCode.toErrorCode(e.code ?: ""))
+            }
         } catch (e: Exception) {
             Logger.e("Reissue api failed", e)
             DataState.Error(e)

--- a/core/remote/src/main/java/com/emotionstorage/remote/di/ApiServiceModule.kt
+++ b/core/remote/src/main/java/com/emotionstorage/remote/di/ApiServiceModule.kt
@@ -20,6 +20,10 @@ import javax.inject.Singleton
 object ApiServiceModule {
     @Singleton
     @Provides
+    fun provideAuthApiService(retrofit: Retrofit): AuthApiService = retrofit.create(AuthApiService::class.java)
+
+    @Singleton
+    @Provides
     fun provideHomeApiService(retrofit: Retrofit): HomeApiService = retrofit.create(HomeApiService::class.java)
 
     @Singleton

--- a/core/remote/src/main/java/com/emotionstorage/remote/di/ApiServiceModule.kt
+++ b/core/remote/src/main/java/com/emotionstorage/remote/di/ApiServiceModule.kt
@@ -20,10 +20,6 @@ import javax.inject.Singleton
 object ApiServiceModule {
     @Singleton
     @Provides
-    fun provideAuthApiService(retrofit: Retrofit): AuthApiService = retrofit.create(AuthApiService::class.java)
-
-    @Singleton
-    @Provides
     fun provideHomeApiService(retrofit: Retrofit): HomeApiService = retrofit.create(HomeApiService::class.java)
 
     @Singleton

--- a/core/remote/src/main/java/com/emotionstorage/remote/di/AppCookieJarModule.kt
+++ b/core/remote/src/main/java/com/emotionstorage/remote/di/AppCookieJarModule.kt
@@ -1,0 +1,17 @@
+package com.emotionstorage.remote.di
+
+import com.emotionstorage.data.dataSource.local.SessionLocalDataSource
+import com.emotionstorage.remote.cookieJar.AppCookieJar
+import dagger.Module
+import dagger.Provides
+import dagger.hilt.InstallIn
+import dagger.hilt.components.SingletonComponent
+import javax.inject.Singleton
+
+@Module
+@InstallIn(SingletonComponent::class)
+object AppCookieJarModule {
+    @Singleton
+    @Provides
+    fun provideAppCookieJar(sessionLocalDataSource: SessionLocalDataSource) = AppCookieJar(sessionLocalDataSource)
+}

--- a/core/remote/src/main/java/com/emotionstorage/remote/di/AuthApiModule.kt
+++ b/core/remote/src/main/java/com/emotionstorage/remote/di/AuthApiModule.kt
@@ -1,0 +1,55 @@
+package com.emotionstorage.remote.di
+
+import com.emotionstorage.remote.BuildConfig
+import com.emotionstorage.remote.api.AuthApiService
+import com.jakewharton.retrofit2.converter.kotlinx.serialization.asConverterFactory
+import dagger.Module
+import dagger.Provides
+import dagger.hilt.InstallIn
+import dagger.hilt.components.SingletonComponent
+import kotlinx.serialization.json.Json
+import okhttp3.MediaType.Companion.toMediaType
+import okhttp3.OkHttpClient
+import retrofit2.Retrofit
+import java.util.concurrent.TimeUnit
+import javax.inject.Named
+import javax.inject.Singleton
+
+@Module
+@InstallIn(SingletonComponent::class)
+object AuthApiModule {
+    private const val BASE_URL = "http://${BuildConfig.MOOI_DEV_SERVER_URL}"
+    private const val TIMEOUT = 20L
+
+    private val json =
+        Json {
+            ignoreUnknownKeys = true // Common configuration
+            isLenient = true
+            prettyPrint = true // For debugging, optional
+        }
+
+    /**
+     * auth retrofit to prevent dependency cycle
+     */
+    @Provides
+    @Singleton
+    @Named("AuthRetrofit")
+    fun provideAuthRetrofit(
+    ): Retrofit {
+        return Retrofit.Builder()
+            .baseUrl(BASE_URL)
+            .addConverterFactory(json.asConverterFactory("application/json".toMediaType()))
+            .client(
+                OkHttpClient.Builder()
+                    .connectTimeout(TIMEOUT, TimeUnit.SECONDS)
+                    .readTimeout(TIMEOUT, TimeUnit.SECONDS)
+                    .build())
+            .build()
+    }
+
+    @Provides
+    @Singleton
+    fun provideAuthApi(
+        @Named("AuthRetrofit") retrofit: Retrofit
+    ): AuthApiService = retrofit.create(AuthApiService::class.java)
+}

--- a/core/remote/src/main/java/com/emotionstorage/remote/di/NetworkJsonModule.kt
+++ b/core/remote/src/main/java/com/emotionstorage/remote/di/NetworkJsonModule.kt
@@ -12,9 +12,10 @@ import javax.inject.Singleton
 object NetworkJsonModule {
     @Provides
     @Singleton
-    fun provideJson() = Json {
-        ignoreUnknownKeys = true // Common configuration
-        isLenient = true
-        prettyPrint = true // For debugging, optional
-    }
+    fun provideJson() =
+        Json {
+            ignoreUnknownKeys = true // Common configuration
+            isLenient = true
+            prettyPrint = true // For debugging, optional
+        }
 }

--- a/core/remote/src/main/java/com/emotionstorage/remote/di/NetworkJsonModule.kt
+++ b/core/remote/src/main/java/com/emotionstorage/remote/di/NetworkJsonModule.kt
@@ -1,0 +1,20 @@
+package com.emotionstorage.remote.di
+
+import dagger.Module
+import dagger.Provides
+import dagger.hilt.InstallIn
+import dagger.hilt.components.SingletonComponent
+import kotlinx.serialization.json.Json
+import javax.inject.Singleton
+
+@Module
+@InstallIn(SingletonComponent::class)
+object NetworkJsonModule {
+    @Provides
+    @Singleton
+    fun provideJson() = Json {
+        ignoreUnknownKeys = true // Common configuration
+        isLenient = true
+        prettyPrint = true // For debugging, optional
+    }
+}

--- a/core/remote/src/main/java/com/emotionstorage/remote/di/ReissueApiServiceModule.kt
+++ b/core/remote/src/main/java/com/emotionstorage/remote/di/ReissueApiServiceModule.kt
@@ -31,7 +31,7 @@ object ReissueApiServiceModule {
     fun provideAuthRetrofit(
         json: Json,
         appCookieJar: AppCookieJar,
-        ): Retrofit =
+    ): Retrofit =
         Retrofit
             .Builder()
             .baseUrl(BASE_URL)

--- a/core/remote/src/main/java/com/emotionstorage/remote/di/ReissueApiServiceModule.kt
+++ b/core/remote/src/main/java/com/emotionstorage/remote/di/ReissueApiServiceModule.kt
@@ -2,6 +2,7 @@ package com.emotionstorage.remote.di
 
 import com.emotionstorage.remote.BuildConfig
 import com.emotionstorage.remote.api.ReissueApiService
+import com.emotionstorage.remote.cookieJar.AppCookieJar
 import com.jakewharton.retrofit2.converter.kotlinx.serialization.asConverterFactory
 import dagger.Module
 import dagger.Provides
@@ -34,7 +35,9 @@ object ReissueApiServiceModule {
     @Provides
     @Singleton
     @Named("AuthRetrofit")
-    fun provideAuthRetrofit(): Retrofit =
+    fun provideAuthRetrofit(
+        appCookieJar: AppCookieJar,
+    ): Retrofit =
         Retrofit
             .Builder()
             .baseUrl(BASE_URL)
@@ -44,6 +47,7 @@ object ReissueApiServiceModule {
                     .Builder()
                     .connectTimeout(TIMEOUT, TimeUnit.SECONDS)
                     .readTimeout(TIMEOUT, TimeUnit.SECONDS)
+                    .cookieJar(appCookieJar)
                     .build(),
             ).build()
 

--- a/core/remote/src/main/java/com/emotionstorage/remote/di/ReissueApiServiceModule.kt
+++ b/core/remote/src/main/java/com/emotionstorage/remote/di/ReissueApiServiceModule.kt
@@ -22,20 +22,16 @@ object ReissueApiServiceModule {
     private const val BASE_URL = "http://${BuildConfig.MOOI_DEV_SERVER_URL}"
     private const val TIMEOUT = 20L
 
-    private val json =
-        Json {
-            ignoreUnknownKeys = true // Common configuration
-            isLenient = true
-            prettyPrint = true // For debugging, optional
-        }
-
     /**
      * auth retrofit to prevent dependency cycle
      */
     @Provides
     @Singleton
     @Named("AuthRetrofit")
-    fun provideAuthRetrofit(appCookieJar: AppCookieJar): Retrofit =
+    fun provideAuthRetrofit(
+        json: Json,
+        appCookieJar: AppCookieJar,
+        ): Retrofit =
         Retrofit
             .Builder()
             .baseUrl(BASE_URL)

--- a/core/remote/src/main/java/com/emotionstorage/remote/di/ReissueApiServiceModule.kt
+++ b/core/remote/src/main/java/com/emotionstorage/remote/di/ReissueApiServiceModule.kt
@@ -35,9 +35,7 @@ object ReissueApiServiceModule {
     @Provides
     @Singleton
     @Named("AuthRetrofit")
-    fun provideAuthRetrofit(
-        appCookieJar: AppCookieJar,
-    ): Retrofit =
+    fun provideAuthRetrofit(appCookieJar: AppCookieJar): Retrofit =
         Retrofit
             .Builder()
             .baseUrl(BASE_URL)

--- a/core/remote/src/main/java/com/emotionstorage/remote/di/ReissueApiServiceModule.kt
+++ b/core/remote/src/main/java/com/emotionstorage/remote/di/ReissueApiServiceModule.kt
@@ -1,7 +1,6 @@
 package com.emotionstorage.remote.di
 
 import com.emotionstorage.remote.BuildConfig
-import com.emotionstorage.remote.api.AuthApiService
 import com.emotionstorage.remote.api.ReissueApiService
 import com.jakewharton.retrofit2.converter.kotlinx.serialization.asConverterFactory
 import dagger.Module
@@ -35,22 +34,22 @@ object ReissueApiServiceModule {
     @Provides
     @Singleton
     @Named("AuthRetrofit")
-    fun provideAuthRetrofit(
-    ): Retrofit {
-        return Retrofit.Builder()
+    fun provideAuthRetrofit(): Retrofit =
+        Retrofit
+            .Builder()
             .baseUrl(BASE_URL)
             .addConverterFactory(json.asConverterFactory("application/json".toMediaType()))
             .client(
-                OkHttpClient.Builder()
+                OkHttpClient
+                    .Builder()
                     .connectTimeout(TIMEOUT, TimeUnit.SECONDS)
                     .readTimeout(TIMEOUT, TimeUnit.SECONDS)
-                    .build())
-            .build()
-    }
+                    .build(),
+            ).build()
 
     @Provides
     @Singleton
     fun provideReissueApi(
-        @Named("AuthRetrofit") retrofit: Retrofit
+        @Named("AuthRetrofit") retrofit: Retrofit,
     ): ReissueApiService = retrofit.create(ReissueApiService::class.java)
 }

--- a/core/remote/src/main/java/com/emotionstorage/remote/di/ReissueApiServiceModule.kt
+++ b/core/remote/src/main/java/com/emotionstorage/remote/di/ReissueApiServiceModule.kt
@@ -2,6 +2,7 @@ package com.emotionstorage.remote.di
 
 import com.emotionstorage.remote.BuildConfig
 import com.emotionstorage.remote.api.AuthApiService
+import com.emotionstorage.remote.api.ReissueApiService
 import com.jakewharton.retrofit2.converter.kotlinx.serialization.asConverterFactory
 import dagger.Module
 import dagger.Provides
@@ -17,7 +18,7 @@ import javax.inject.Singleton
 
 @Module
 @InstallIn(SingletonComponent::class)
-object AuthApiModule {
+object ReissueApiServiceModule {
     private const val BASE_URL = "http://${BuildConfig.MOOI_DEV_SERVER_URL}"
     private const val TIMEOUT = 20L
 
@@ -49,7 +50,7 @@ object AuthApiModule {
 
     @Provides
     @Singleton
-    fun provideAuthApi(
+    fun provideReissueApi(
         @Named("AuthRetrofit") retrofit: Retrofit
-    ): AuthApiService = retrofit.create(AuthApiService::class.java)
+    ): ReissueApiService = retrofit.create(ReissueApiService::class.java)
 }

--- a/core/remote/src/main/java/com/emotionstorage/remote/di/ReissueApiServiceModule.kt
+++ b/core/remote/src/main/java/com/emotionstorage/remote/di/ReissueApiServiceModule.kt
@@ -45,6 +45,7 @@ object ReissueApiServiceModule {
                     .Builder()
                     .connectTimeout(TIMEOUT, TimeUnit.SECONDS)
                     .readTimeout(TIMEOUT, TimeUnit.SECONDS)
+                    .writeTimeout(TIMEOUT, TimeUnit.SECONDS)
                     .cookieJar(appCookieJar)
                     .build(),
             ).build()

--- a/core/remote/src/main/java/com/emotionstorage/remote/di/RemoteDataSourceModule.kt
+++ b/core/remote/src/main/java/com/emotionstorage/remote/di/RemoteDataSourceModule.kt
@@ -9,6 +9,7 @@ import com.emotionstorage.data.dataSource.remote.HomeRemoteDataSource
 import com.emotionstorage.data.dataSource.remote.KakaoRemoteDataSource
 import com.emotionstorage.data.dataSource.remote.MyPageRemoteDataSource
 import com.emotionstorage.data.dataSource.remote.NotificationSettingRemoteDataSource
+import com.emotionstorage.data.dataSource.remote.ReissueRemoteDataSource
 import com.emotionstorage.data.dataSource.remote.TimeCapsuleRemoteDataSource
 import com.emotionstorage.data.dataSource.remote.UserRemoteDataSource
 import com.emotionstorage.remote.dataSourceImpl.AttendanceRemoteDataSourceImpl
@@ -20,6 +21,7 @@ import com.emotionstorage.remote.dataSourceImpl.HomeRemoteDataSourceImpl
 import com.emotionstorage.remote.dataSourceImpl.KakaoRemoteDataSourceImpl
 import com.emotionstorage.remote.dataSourceImpl.MyPageRemoteDataSourceImpl
 import com.emotionstorage.remote.dataSourceImpl.NotificationSettingRemoteDataSourceImpl
+import com.emotionstorage.remote.dataSourceImpl.ReissueRemoteDataSourceImpl
 import com.emotionstorage.remote.dataSourceImpl.TimeCapsuleRemoteDataSourceImpl
 import com.emotionstorage.remote.dataSourceImpl.UserRemoteDataSourceImpl
 import dagger.Binds
@@ -33,16 +35,20 @@ import javax.inject.Singleton
 abstract class RemoteDataSourceModule {
     @Binds
     @Singleton
-    abstract fun bindAuthRemoteDataSource(authRemoteDataSourceImpl: AuthRemoteDataSourceImpl): AuthRemoteDataSource
+    abstract fun bindAuthRemoteDataSource(impl: AuthRemoteDataSourceImpl): AuthRemoteDataSource
 
     @Binds
     @Singleton
-    abstract fun bindKakaoRemoteDataSource(kakaoRemoteDataSourceImpl: KakaoRemoteDataSourceImpl): KakaoRemoteDataSource
+    abstract fun bindReissueRemoteDataSource(impl: ReissueRemoteDataSourceImpl): ReissueRemoteDataSource
+
+    @Binds
+    @Singleton
+    abstract fun bindKakaoRemoteDataSource(impl: KakaoRemoteDataSourceImpl): KakaoRemoteDataSource
 
     @Binds
     @Singleton
     abstract fun bindGoogleRemoteDataSource(
-        googleRemoteDataSourceImpl: GoogleRemoteDataSourceImpl,
+        impl: GoogleRemoteDataSourceImpl,
     ): GoogleRemoteDataSource
 
     @Binds

--- a/core/remote/src/main/java/com/emotionstorage/remote/di/RemoteDataSourceModule.kt
+++ b/core/remote/src/main/java/com/emotionstorage/remote/di/RemoteDataSourceModule.kt
@@ -47,9 +47,7 @@ abstract class RemoteDataSourceModule {
 
     @Binds
     @Singleton
-    abstract fun bindGoogleRemoteDataSource(
-        impl: GoogleRemoteDataSourceImpl,
-    ): GoogleRemoteDataSource
+    abstract fun bindGoogleRemoteDataSource(impl: GoogleRemoteDataSourceImpl): GoogleRemoteDataSource
 
     @Binds
     @Singleton

--- a/core/remote/src/main/java/com/emotionstorage/remote/di/RetrofitModule.kt
+++ b/core/remote/src/main/java/com/emotionstorage/remote/di/RetrofitModule.kt
@@ -26,16 +26,10 @@ object RetrofitModule {
     private const val BASE_URL = "http://${BuildConfig.MOOI_DEV_SERVER_URL}"
     private const val TIMEOUT = 20L
 
-    private val json =
-        Json {
-            ignoreUnknownKeys = true // Common configuration
-            isLenient = true
-            prettyPrint = true // For debugging, optional
-        }
-
     @Singleton
     @Provides
     fun provideRetrofit(
+        json: Json,
         appCookieJar: AppCookieJar,
         requestHeaderInterceptor: RequestHeaderInterceptor,
         failResponseInterceptor: FailResponseInterceptor,

--- a/core/remote/src/main/java/com/emotionstorage/remote/di/RetrofitModule.kt
+++ b/core/remote/src/main/java/com/emotionstorage/remote/di/RetrofitModule.kt
@@ -2,9 +2,12 @@ package com.emotionstorage.remote.di
 
 import com.emotionstorage.data.dataSource.local.SessionLocalDataSource
 import com.emotionstorage.remote.BuildConfig
+import com.emotionstorage.remote.api.AuthApiService
+import com.emotionstorage.remote.api.ReissueApiService
 import com.emotionstorage.remote.cookieJar.AppCookieJar
 import com.emotionstorage.remote.interceptor.FailResponseInterceptor
 import com.emotionstorage.remote.interceptor.RequestHeaderInterceptor
+import com.emotionstorage.remote.interceptor.TokenAuthenticator
 import com.jakewharton.retrofit2.converter.kotlinx.serialization.asConverterFactory
 import dagger.Module
 import dagger.Provides
@@ -34,9 +37,10 @@ object RetrofitModule {
     @Singleton
     @Provides
     fun provideRetrofit(
+        appCookieJar: AppCookieJar,
         requestHeaderInterceptor: RequestHeaderInterceptor,
         failResponseInterceptor: FailResponseInterceptor,
-        appCookieJar: AppCookieJar,
+        tokenAuthenticator: TokenAuthenticator,
     ): Retrofit {
         val loggingInterceptor =
             HttpLoggingInterceptor().apply {
@@ -62,9 +66,15 @@ object RetrofitModule {
                     .addNetworkInterceptor(loggingInterceptor)
                     .addInterceptor(requestHeaderInterceptor)
                     .addInterceptor(failResponseInterceptor)
+                    .authenticator(tokenAuthenticator)
                     .build(),
             ).build()
     }
+
+    @Singleton
+    @Provides
+    fun provideAppCookieJar(sessionLocalDataSource: SessionLocalDataSource) =
+        AppCookieJar(sessionLocalDataSource)
 
     @Singleton
     @Provides
@@ -73,12 +83,13 @@ object RetrofitModule {
 
     @Singleton
     @Provides
-    fun provideFailResponseHeaderInterceptor(sessionLocalDataSource: SessionLocalDataSource) =
-        FailResponseInterceptor(sessionLocalDataSource)
+    fun provideFailResponseHeaderInterceptor() =
+        FailResponseInterceptor()
 
 
     @Singleton
     @Provides
-    fun provideAppCookieJar(sessionLocalDataSource: SessionLocalDataSource) =
-        AppCookieJar(sessionLocalDataSource)
+    fun provideTokenAuthenticator(reissueApiService: ReissueApiService) =
+        TokenAuthenticator(reissueApiService)
+
 }

--- a/core/remote/src/main/java/com/emotionstorage/remote/di/RetrofitModule.kt
+++ b/core/remote/src/main/java/com/emotionstorage/remote/di/RetrofitModule.kt
@@ -72,10 +72,6 @@ object RetrofitModule {
 
     @Singleton
     @Provides
-    fun provideAppCookieJar(sessionLocalDataSource: SessionLocalDataSource) = AppCookieJar(sessionLocalDataSource)
-
-    @Singleton
-    @Provides
     fun provideRequestHeaderInterceptor(sessionLocalDataSource: SessionLocalDataSource) =
         RequestHeaderInterceptor(sessionLocalDataSource)
 

--- a/core/remote/src/main/java/com/emotionstorage/remote/di/RetrofitModule.kt
+++ b/core/remote/src/main/java/com/emotionstorage/remote/di/RetrofitModule.kt
@@ -2,6 +2,7 @@ package com.emotionstorage.remote.di
 
 import com.emotionstorage.data.dataSource.local.SessionLocalDataSource
 import com.emotionstorage.remote.BuildConfig
+import com.emotionstorage.remote.cookieJar.AppCookieJar
 import com.emotionstorage.remote.interceptor.FailResponseInterceptor
 import com.emotionstorage.remote.interceptor.RequestHeaderInterceptor
 import com.jakewharton.retrofit2.converter.kotlinx.serialization.asConverterFactory
@@ -35,6 +36,7 @@ object RetrofitModule {
     fun provideRetrofit(
         requestHeaderInterceptor: RequestHeaderInterceptor,
         failResponseInterceptor: FailResponseInterceptor,
+        appCookieJar: AppCookieJar,
     ): Retrofit {
         val loggingInterceptor =
             HttpLoggingInterceptor().apply {
@@ -56,6 +58,7 @@ object RetrofitModule {
                     .connectTimeout(TIMEOUT, TimeUnit.SECONDS)
                     .readTimeout(TIMEOUT, TimeUnit.SECONDS)
                     .writeTimeout(TIMEOUT, TimeUnit.SECONDS)
+                    .cookieJar(appCookieJar)
                     .addNetworkInterceptor(loggingInterceptor)
                     .addInterceptor(requestHeaderInterceptor)
                     .addInterceptor(failResponseInterceptor)
@@ -72,4 +75,10 @@ object RetrofitModule {
     @Provides
     fun provideFailResponseHeaderInterceptor(sessionLocalDataSource: SessionLocalDataSource) =
         FailResponseInterceptor(sessionLocalDataSource)
+
+
+    @Singleton
+    @Provides
+    fun provideAppCookieJar(sessionLocalDataSource: SessionLocalDataSource) =
+        AppCookieJar(sessionLocalDataSource)
 }

--- a/core/remote/src/main/java/com/emotionstorage/remote/di/RetrofitModule.kt
+++ b/core/remote/src/main/java/com/emotionstorage/remote/di/RetrofitModule.kt
@@ -87,6 +87,6 @@ object RetrofitModule {
     @Provides
     fun provideTokenAuthenticator(
         reissueApiService: ReissueApiService,
-        sessionLocalDataSource: SessionLocalDataSource
+        sessionLocalDataSource: SessionLocalDataSource,
     ) = TokenAuthenticator(reissueApiService, sessionLocalDataSource)
 }

--- a/core/remote/src/main/java/com/emotionstorage/remote/di/RetrofitModule.kt
+++ b/core/remote/src/main/java/com/emotionstorage/remote/di/RetrofitModule.kt
@@ -85,5 +85,8 @@ object RetrofitModule {
 
     @Singleton
     @Provides
-    fun provideTokenAuthenticator(reissueApiService: ReissueApiService) = TokenAuthenticator(reissueApiService)
+    fun provideTokenAuthenticator(
+        reissueApiService: ReissueApiService,
+        sessionLocalDataSource: SessionLocalDataSource
+    ) = TokenAuthenticator(reissueApiService, sessionLocalDataSource)
 }

--- a/core/remote/src/main/java/com/emotionstorage/remote/di/RetrofitModule.kt
+++ b/core/remote/src/main/java/com/emotionstorage/remote/di/RetrofitModule.kt
@@ -2,7 +2,6 @@ package com.emotionstorage.remote.di
 
 import com.emotionstorage.data.dataSource.local.SessionLocalDataSource
 import com.emotionstorage.remote.BuildConfig
-import com.emotionstorage.remote.api.AuthApiService
 import com.emotionstorage.remote.api.ReissueApiService
 import com.emotionstorage.remote.cookieJar.AppCookieJar
 import com.emotionstorage.remote.interceptor.FailResponseInterceptor
@@ -73,8 +72,7 @@ object RetrofitModule {
 
     @Singleton
     @Provides
-    fun provideAppCookieJar(sessionLocalDataSource: SessionLocalDataSource) =
-        AppCookieJar(sessionLocalDataSource)
+    fun provideAppCookieJar(sessionLocalDataSource: SessionLocalDataSource) = AppCookieJar(sessionLocalDataSource)
 
     @Singleton
     @Provides
@@ -83,13 +81,9 @@ object RetrofitModule {
 
     @Singleton
     @Provides
-    fun provideFailResponseHeaderInterceptor() =
-        FailResponseInterceptor()
-
+    fun provideFailResponseHeaderInterceptor() = FailResponseInterceptor()
 
     @Singleton
     @Provides
-    fun provideTokenAuthenticator(reissueApiService: ReissueApiService) =
-        TokenAuthenticator(reissueApiService)
-
+    fun provideTokenAuthenticator(reissueApiService: ReissueApiService) = TokenAuthenticator(reissueApiService)
 }

--- a/core/remote/src/main/java/com/emotionstorage/remote/interceptor/FailResponseInterceptor.kt
+++ b/core/remote/src/main/java/com/emotionstorage/remote/interceptor/FailResponseInterceptor.kt
@@ -9,7 +9,7 @@ import okhttp3.Response
 import java.time.LocalDateTime
 import javax.inject.Inject
 
-class FailResponseInterceptor @Inject constructor( ) : Interceptor {
+class FailResponseInterceptor @Inject constructor() : Interceptor {
     private val json = Json { ignoreUnknownKeys = true }
 
     override fun intercept(chain: Interceptor.Chain): Response {

--- a/core/remote/src/main/java/com/emotionstorage/remote/interceptor/FailResponseInterceptor.kt
+++ b/core/remote/src/main/java/com/emotionstorage/remote/interceptor/FailResponseInterceptor.kt
@@ -1,6 +1,5 @@
 package com.emotionstorage.remote.interceptor
 
-import com.emotionstorage.data.dataSource.local.SessionLocalDataSource
 import com.emotionstorage.remote.response.CustomHttpException
 import com.emotionstorage.remote.response.ResponseDto
 import com.emotionstorage.remote.response.ResponseStatus
@@ -10,13 +9,7 @@ import okhttp3.Response
 import java.time.LocalDateTime
 import javax.inject.Inject
 
-private const val MAX_TRY_COUNT = 3
-
-// todo: refresh token & retry on UNAUTHORIZED error
-// todo: retry request for max 3 times on error
-class FailResponseInterceptor @Inject constructor(
-    private val sessionLocalDataSource: SessionLocalDataSource,
-) : Interceptor {
+class FailResponseInterceptor @Inject constructor( ) : Interceptor {
     private val json = Json { ignoreUnknownKeys = true }
 
     override fun intercept(chain: Interceptor.Chain): Response {

--- a/core/remote/src/main/java/com/emotionstorage/remote/interceptor/FailResponseInterceptor.kt
+++ b/core/remote/src/main/java/com/emotionstorage/remote/interceptor/FailResponseInterceptor.kt
@@ -17,6 +17,8 @@ class FailResponseInterceptor @Inject constructor( ) : Interceptor {
         val httpResponse = chain.proceed(httpRequest)
         // return successful response
         if (httpResponse.code in 200..226) return httpResponse
+        // return 401 error for token authenticator to handle
+        if (httpResponse.code == 401) return httpResponse
 
         // parse error response body & throw custom error
         val httpResponseBody = httpResponse.peekBody(Long.MAX_VALUE).string()

--- a/core/remote/src/main/java/com/emotionstorage/remote/interceptor/RequestHeaderInterceptor.kt
+++ b/core/remote/src/main/java/com/emotionstorage/remote/interceptor/RequestHeaderInterceptor.kt
@@ -5,7 +5,6 @@ import com.orhanobut.logger.Logger
 import kotlinx.coroutines.runBlocking
 import okhttp3.Interceptor
 import okhttp3.Response
-import retrofit2.Invocation
 import javax.inject.Inject
 
 class RequestHeaderInterceptor

--- a/core/remote/src/main/java/com/emotionstorage/remote/interceptor/RequestHeaderInterceptor.kt
+++ b/core/remote/src/main/java/com/emotionstorage/remote/interceptor/RequestHeaderInterceptor.kt
@@ -8,10 +8,6 @@ import okhttp3.Response
 import retrofit2.Invocation
 import javax.inject.Inject
 
-@Retention(AnnotationRetention.RUNTIME)
-@Target(AnnotationTarget.FUNCTION)
-annotation class AuthRequest
-
 class RequestHeaderInterceptor
     @Inject
     constructor(
@@ -36,28 +32,7 @@ class RequestHeaderInterceptor
                 requestBuilder.addHeader("Authorization", "Bearer " + this)
             }
 
-            // add authorization header if @AuthRequest annotation is added
-//        chain.request().tag(Invocation::class.java)?.let { invocation ->
-//            containedOnInvocation(invocation).forEach { annotation ->
-//                requestBuilder.apply {
-//                    when (annotation) {
-//                        is AuthRequest -> {
-//                            runBlocking {
-//                                sessionLocalDataSource.getSession()?.accessToken
-//                            }?.run {
-//                                Logger.d("add authorization header, $this")
-//                                addHeader("Authorization", "Bearer " + this)
-//                            }
-//                        }
-//                    }
-//                }
-//            }
-//        }
-
             Logger.d("request headers: ${requestBuilder.build().headers}")
             return chain.proceed(requestBuilder.build())
         }
-
-        private fun containedOnInvocation(invocation: Invocation): Set<Annotation> =
-            invocation.method().annotations.toSet()
     }

--- a/core/remote/src/main/java/com/emotionstorage/remote/interceptor/TokenAuthenticator.kt
+++ b/core/remote/src/main/java/com/emotionstorage/remote/interceptor/TokenAuthenticator.kt
@@ -32,12 +32,13 @@ class TokenAuthenticator @Inject constructor(
                 }.data?.accessToken
             if (newAccessToken == null) return null
 
-            // save new access token & retry request
-            CoroutineScope(Dispatchers.IO).launch {
+            // save new access token
+            runBlocking{
                 sessionLocalDataSource.saveSession(
                     SessionEntity(newAccessToken),
                 )
             }
+            // retry request with new access token
             return response
                 .request
                 .newBuilder()

--- a/core/remote/src/main/java/com/emotionstorage/remote/interceptor/TokenAuthenticator.kt
+++ b/core/remote/src/main/java/com/emotionstorage/remote/interceptor/TokenAuthenticator.kt
@@ -4,9 +4,6 @@ import com.emotionstorage.data.dataSource.local.SessionLocalDataSource
 import com.emotionstorage.data.model.SessionEntity
 import com.emotionstorage.remote.api.ReissueApiService
 import com.orhanobut.logger.Logger
-import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.launch
 import kotlinx.coroutines.runBlocking
 import okhttp3.Authenticator
 import okhttp3.Request
@@ -33,7 +30,7 @@ class TokenAuthenticator @Inject constructor(
             if (newAccessToken == null) return null
 
             // save new access token
-            runBlocking{
+            runBlocking {
                 sessionLocalDataSource.saveSession(
                     SessionEntity(newAccessToken),
                 )

--- a/core/remote/src/main/java/com/emotionstorage/remote/interceptor/TokenAuthenticator.kt
+++ b/core/remote/src/main/java/com/emotionstorage/remote/interceptor/TokenAuthenticator.kt
@@ -1,8 +1,13 @@
 package com.emotionstorage.remote.interceptor
 
+import com.emotionstorage.data.dataSource.local.SessionLocalDataSource
+import com.emotionstorage.data.model.SessionEntity
 import com.emotionstorage.remote.api.AuthApiService
 import com.emotionstorage.remote.api.ReissueApiService
 import com.orhanobut.logger.Logger
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
 import kotlinx.coroutines.runBlocking
 import okhttp3.Authenticator
 import okhttp3.Request
@@ -11,16 +16,26 @@ import okhttp3.Route
 import javax.inject.Inject
 
 class TokenAuthenticator @Inject constructor(
-    private val reissueApi: ReissueApiService
+    private val reissueApi: ReissueApiService,
+    private val sessionLocalDataSource: SessionLocalDataSource,
 ) : Authenticator {
 
     override fun authenticate(route: Route?, response: Response): Request? {
+        // prevent infinite loop
         if (responseCount(response) >= 2) return null
 
         try {
             val newAccessToken = runBlocking {
                 reissueApi.postReissue()
-            }.data?.accessToken ?: return null
+            }.data?.accessToken
+            if (newAccessToken == null) return null
+
+            // save new access token & retry request
+            CoroutineScope(Dispatchers.IO).launch {
+                sessionLocalDataSource.saveSession(
+                    SessionEntity(newAccessToken)
+                )
+            }
             return response.request.newBuilder()
                 .header("Authorization", "Bearer $newAccessToken")
                 .build()

--- a/core/remote/src/main/java/com/emotionstorage/remote/interceptor/TokenAuthenticator.kt
+++ b/core/remote/src/main/java/com/emotionstorage/remote/interceptor/TokenAuthenticator.kt
@@ -2,7 +2,6 @@ package com.emotionstorage.remote.interceptor
 
 import com.emotionstorage.data.dataSource.local.SessionLocalDataSource
 import com.emotionstorage.data.model.SessionEntity
-import com.emotionstorage.remote.api.AuthApiService
 import com.emotionstorage.remote.api.ReissueApiService
 import com.orhanobut.logger.Logger
 import kotlinx.coroutines.CoroutineScope
@@ -19,24 +18,29 @@ class TokenAuthenticator @Inject constructor(
     private val reissueApi: ReissueApiService,
     private val sessionLocalDataSource: SessionLocalDataSource,
 ) : Authenticator {
-
-    override fun authenticate(route: Route?, response: Response): Request? {
+    override fun authenticate(
+        route: Route?,
+        response: Response,
+    ): Request? {
         // prevent infinite loop
         if (responseCount(response) >= 2) return null
 
         try {
-            val newAccessToken = runBlocking {
-                reissueApi.postReissue()
-            }.data?.accessToken
+            val newAccessToken =
+                runBlocking {
+                    reissueApi.postReissue()
+                }.data?.accessToken
             if (newAccessToken == null) return null
 
             // save new access token & retry request
             CoroutineScope(Dispatchers.IO).launch {
                 sessionLocalDataSource.saveSession(
-                    SessionEntity(newAccessToken)
+                    SessionEntity(newAccessToken),
                 )
             }
-            return response.request.newBuilder()
+            return response
+                .request
+                .newBuilder()
                 .header("Authorization", "Bearer $newAccessToken")
                 .build()
         } catch (e: Exception) {

--- a/core/remote/src/main/java/com/emotionstorage/remote/interceptor/TokenAuthenticator.kt
+++ b/core/remote/src/main/java/com/emotionstorage/remote/interceptor/TokenAuthenticator.kt
@@ -1,0 +1,42 @@
+package com.emotionstorage.remote.interceptor
+
+import com.emotionstorage.remote.api.AuthApiService
+import com.emotionstorage.remote.api.ReissueApiService
+import com.orhanobut.logger.Logger
+import kotlinx.coroutines.runBlocking
+import okhttp3.Authenticator
+import okhttp3.Request
+import okhttp3.Response
+import okhttp3.Route
+import javax.inject.Inject
+
+class TokenAuthenticator @Inject constructor(
+    private val reissueApi: ReissueApiService
+) : Authenticator {
+
+    override fun authenticate(route: Route?, response: Response): Request? {
+        if (responseCount(response) >= 2) return null
+
+        try {
+            val newAccessToken = runBlocking {
+                reissueApi.postReissue()
+            }.data?.accessToken ?: return null
+            return response.request.newBuilder()
+                .header("Authorization", "Bearer $newAccessToken")
+                .build()
+        } catch (e: Exception) {
+            Logger.e("Token reissue error, $e")
+            return null
+        }
+    }
+
+    private fun responseCount(response: Response): Int {
+        var count = 1
+        var prior = response.priorResponse
+        while (prior != null) {
+            count++
+            prior = prior.priorResponse
+        }
+        return count
+    }
+}

--- a/core/remote/src/main/java/com/emotionstorage/remote/response/auth/ReissueResponseData.kt
+++ b/core/remote/src/main/java/com/emotionstorage/remote/response/auth/ReissueResponseData.kt
@@ -3,6 +3,6 @@ package com.emotionstorage.remote.response.auth
 import kotlinx.serialization.Serializable
 
 @Serializable
-data class ReissueResponseData (
-    val accessToken: String
+data class ReissueResponseData(
+    val accessToken: String,
 )

--- a/core/remote/src/main/java/com/emotionstorage/remote/response/auth/ReissueResponseData.kt
+++ b/core/remote/src/main/java/com/emotionstorage/remote/response/auth/ReissueResponseData.kt
@@ -1,0 +1,8 @@
+package com.emotionstorage.remote.response.auth
+
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class ReissueResponseData (
+    val accessToken: String
+)

--- a/data/src/main/java/com/emotionstorage/data/dataSource/local/NotificationPermissionLocalDataSource.kt
+++ b/data/src/main/java/com/emotionstorage/data/dataSource/local/NotificationPermissionLocalDataSource.kt
@@ -3,7 +3,7 @@ package com.emotionstorage.data.dataSource.local
 import com.emotionstorage.domain.model.NotificationPermissionInfo
 import com.emotionstorage.domain.model.NotificationPermissionStatus
 
-interface NotificationPermissionDataSource {
+interface NotificationPermissionLocalDataSource {
     fun observeInfo(): kotlinx.coroutines.flow.Flow<NotificationPermissionInfo>
 
     suspend fun updateStatus(status: NotificationPermissionStatus)

--- a/data/src/main/java/com/emotionstorage/data/dataSource/local/SessionLocalDataSource.kt
+++ b/data/src/main/java/com/emotionstorage/data/dataSource/local/SessionLocalDataSource.kt
@@ -8,4 +8,8 @@ interface SessionLocalDataSource {
     suspend fun getSession(): SessionEntity?
 
     suspend fun deleteSession(): Boolean
+
+    suspend fun saveRefreshToken(refreshToken: String): Boolean
+
+    suspend fun getRefreshToken(): String?
 }

--- a/data/src/main/java/com/emotionstorage/data/dataSource/remote/AuthRemoteDataSource.kt
+++ b/data/src/main/java/com/emotionstorage/data/dataSource/remote/AuthRemoteDataSource.kt
@@ -14,18 +14,11 @@ interface AuthRemoteDataSource {
         idToken: String,
     ): DataState<String>
 
-    /**
-     * Signup with id token
-     */
     suspend fun signup(
         provider: User.AuthProvider,
         signupFormEntity: SignupFormEntity,
     ): DataState<Unit>
 
-    /**
-     * Check session
-     * @return access token
-     */
     suspend fun checkSession(): DataState<Unit>
 
     suspend fun logout(): Boolean

--- a/data/src/main/java/com/emotionstorage/data/dataSource/remote/AuthRemoteDataSource.kt
+++ b/data/src/main/java/com/emotionstorage/data/dataSource/remote/AuthRemoteDataSource.kt
@@ -24,9 +24,9 @@ interface AuthRemoteDataSource {
 
     /**
      * Check session
-     * @return success
+     * @return access token
      */
-    suspend fun checkSession(): Boolean
+    suspend fun checkSession(): DataState<Unit>
 
     suspend fun logout(): Boolean
 

--- a/data/src/main/java/com/emotionstorage/data/dataSource/remote/ReissueRemoteDataSource.kt
+++ b/data/src/main/java/com/emotionstorage/data/dataSource/remote/ReissueRemoteDataSource.kt
@@ -1,0 +1,7 @@
+package com.emotionstorage.data.dataSource.remote
+
+import com.emotionstorage.domain.common.DataState
+
+interface ReissueRemoteDataSource {
+    suspend fun reissueAccessToken(): DataState<String>
+}

--- a/data/src/main/java/com/emotionstorage/data/repoImpl/AuthRepositoryImpl.kt
+++ b/data/src/main/java/com/emotionstorage/data/repoImpl/AuthRepositoryImpl.kt
@@ -71,38 +71,26 @@ class AuthRepositoryImpl @Inject constructor(
     override suspend fun checkSession(): DataState<Unit> {
         try {
             val result = authRemoteDataSource.checkSession()
-            when (result) {
-                is DataState.Success -> {
-                    return result
-                }
+            if (result !is DataState.Error) {
+                return result
+            }
+            if (result.code != ErrorCode.ACCESS_TOKEN_EXPIRED && result.code != ErrorCode.USER_NOT_FOUND) {
+                return result
+            }
 
-                is DataState.Error -> {
-                    if (result.code == ErrorCode.ACCESS_TOKEN_EXPIRED || result.code == ErrorCode.USER_NOT_FOUND) {
-                        // refresh access token
-                        val reissueResult = reissueRemoteDataSource.reissueAccessToken()
-                        return if (reissueResult is DataState.Success) {
-                            // save new access token
-                            if (sessionLocalDataSource.saveSession(SessionEntity(reissueResult.data))) {
-                                //  retry check session
-                                authRemoteDataSource.checkSession()
-                            } else {
-                                DataState.Error(Throwable("failed to save new access token"))
-                            }
-                        } else {
-                            DataState.Error(
-                                Throwable("failed to reissue access token"),
-                                ErrorCode.REFRESH_TOKEN_EXPIRED
-                            )
-                        }
-                    } else {
-                        return result
-                    }
-                }
-
-                else -> {
-                    // fallback
-                    return result
-                }
+            // refresh access token
+            val reissueResult = reissueRemoteDataSource.reissueAccessToken()
+            if (reissueResult !is DataState.Success) {
+                return DataState.Error(
+                    Throwable("failed to reissue access token"),
+                    ErrorCode.REFRESH_TOKEN_NOT_FOUND
+                )
+            }
+            // save new access token & retry check session
+            return if (sessionLocalDataSource.saveSession(SessionEntity(reissueResult.data))) {
+                authRemoteDataSource.checkSession()
+            }else{
+                DataState.Error(Throwable("failed to save new access token"))
             }
         } catch (e: Exception) {
             return DataState.Error(e)

--- a/data/src/main/java/com/emotionstorage/data/repoImpl/AuthRepositoryImpl.kt
+++ b/data/src/main/java/com/emotionstorage/data/repoImpl/AuthRepositoryImpl.kt
@@ -1,13 +1,16 @@
 package com.emotionstorage.data.repoImpl
 
+import com.emotionstorage.data.dataSource.local.SessionLocalDataSource
 import com.emotionstorage.data.dataSource.remote.AuthRemoteDataSource
 import com.emotionstorage.data.dataSource.remote.GoogleRemoteDataSource
 import com.emotionstorage.data.dataSource.remote.KakaoRemoteDataSource
+import com.emotionstorage.data.dataSource.remote.ReissueRemoteDataSource
+import com.emotionstorage.data.model.SessionEntity
 import com.emotionstorage.data.modelMapper.SignupFormMapper
 import com.emotionstorage.domain.common.DataState
 import com.emotionstorage.domain.common.ErrorCode
+import com.emotionstorage.domain.common.map
 import com.emotionstorage.domain.model.SignupForm
-import com.emotionstorage.domain.model.User
 import com.emotionstorage.domain.model.User.AuthProvider
 import com.emotionstorage.domain.repo.AuthRepository
 import io.github.aakira.napier.Napier
@@ -15,10 +18,13 @@ import javax.inject.Inject
 
 class AuthRepositoryImpl @Inject constructor(
     private val authRemoteDataSource: AuthRemoteDataSource,
+    private val sessionLocalDataSource: SessionLocalDataSource,
+    private val reissueRemoteDataSource: ReissueRemoteDataSource,
     private val kakaoRemoteDataSource: KakaoRemoteDataSource,
     private val googleRemoteDataSource: GoogleRemoteDataSource,
 ) : AuthRepository {
-    override suspend fun login(provider: User.AuthProvider): DataState<String> =
+
+    override suspend fun login(provider: AuthProvider): DataState<String> =
         try {
             // get id token from providers
             val idToken =
@@ -62,12 +68,46 @@ class AuthRepositoryImpl @Inject constructor(
             DataState.Error(e)
         }
 
-    override suspend fun checkSession(): DataState<Boolean> =
+    override suspend fun checkSession(): DataState<Unit> {
         try {
-            DataState.Success(authRemoteDataSource.checkSession())
+            val result = authRemoteDataSource.checkSession()
+            when (result) {
+                is DataState.Success -> {
+                    return result
+                }
+
+                is DataState.Error -> {
+                    if (result.code == ErrorCode.ACCESS_TOKEN_EXPIRED || result.code == ErrorCode.USER_NOT_FOUND) {
+                        // refresh access token
+                        val reissueResult = reissueRemoteDataSource.reissueAccessToken()
+                        return if (reissueResult is DataState.Success) {
+                            // save new access token
+                            if (sessionLocalDataSource.saveSession(SessionEntity(reissueResult.data))) {
+                                //  retry check session
+                                authRemoteDataSource.checkSession()
+                            } else {
+                                DataState.Error(Throwable("failed to save new access token"))
+                            }
+                        } else {
+                            DataState.Error(
+                                Throwable("failed to reissue access token"),
+                                ErrorCode.REFRESH_TOKEN_EXPIRED
+                            )
+                        }
+                    } else {
+                        return result
+                    }
+                }
+
+                else -> {
+                    // fallback
+                    return result
+                }
+            }
         } catch (e: Exception) {
-            DataState.Error(e)
+            return DataState.Error(e)
         }
+    }
 
     override suspend fun logout(): Boolean = authRemoteDataSource.logout()
 

--- a/data/src/main/java/com/emotionstorage/data/repoImpl/AuthRepositoryImpl.kt
+++ b/data/src/main/java/com/emotionstorage/data/repoImpl/AuthRepositoryImpl.kt
@@ -88,7 +88,7 @@ class AuthRepositoryImpl @Inject constructor(
             return if (sessionLocalDataSource.saveSession(SessionEntity(reissueResult.data))) {
                 authRemoteDataSource.checkSession()
             } else {
-                    DataState.Error(Throwable("failed to save new access token"))
+                DataState.Error(Throwable("failed to save new access token"))
             }
         } catch (e: Exception) {
             return DataState.Error(e)

--- a/data/src/main/java/com/emotionstorage/data/repoImpl/AuthRepositoryImpl.kt
+++ b/data/src/main/java/com/emotionstorage/data/repoImpl/AuthRepositoryImpl.kt
@@ -87,10 +87,9 @@ class AuthRepositoryImpl @Inject constructor(
             // save new access token & retry check session
             return if (sessionLocalDataSource.saveSession(SessionEntity(reissueResult.data))) {
                 authRemoteDataSource.checkSession()
-            } else
-                {
+            } else {
                     DataState.Error(Throwable("failed to save new access token"))
-                }
+            }
         } catch (e: Exception) {
             return DataState.Error(e)
         }

--- a/data/src/main/java/com/emotionstorage/data/repoImpl/AuthRepositoryImpl.kt
+++ b/data/src/main/java/com/emotionstorage/data/repoImpl/AuthRepositoryImpl.kt
@@ -81,8 +81,11 @@ class AuthRepositoryImpl @Inject constructor(
             if (reissueResult !is DataState.Success) {
                 return DataState.Error(
                     Throwable("failed to reissue access token"),
-                    if (reissueResult is DataState.Error) reissueResult.code
-                    else ErrorCode.UNKNOWN,
+                    if (reissueResult is DataState.Error) {
+                        reissueResult.code
+                    } else {
+                        ErrorCode.UNKNOWN
+                    },
                 )
             }
             // save new access token & retry check session

--- a/data/src/main/java/com/emotionstorage/data/repoImpl/AuthRepositoryImpl.kt
+++ b/data/src/main/java/com/emotionstorage/data/repoImpl/AuthRepositoryImpl.kt
@@ -9,7 +9,6 @@ import com.emotionstorage.data.model.SessionEntity
 import com.emotionstorage.data.modelMapper.SignupFormMapper
 import com.emotionstorage.domain.common.DataState
 import com.emotionstorage.domain.common.ErrorCode
-import com.emotionstorage.domain.common.map
 import com.emotionstorage.domain.model.SignupForm
 import com.emotionstorage.domain.model.User.AuthProvider
 import com.emotionstorage.domain.repo.AuthRepository
@@ -23,7 +22,6 @@ class AuthRepositoryImpl @Inject constructor(
     private val kakaoRemoteDataSource: KakaoRemoteDataSource,
     private val googleRemoteDataSource: GoogleRemoteDataSource,
 ) : AuthRepository {
-
     override suspend fun login(provider: AuthProvider): DataState<String> =
         try {
             // get id token from providers
@@ -83,15 +81,16 @@ class AuthRepositoryImpl @Inject constructor(
             if (reissueResult !is DataState.Success) {
                 return DataState.Error(
                     Throwable("failed to reissue access token"),
-                    ErrorCode.REFRESH_TOKEN_NOT_FOUND
+                    ErrorCode.REFRESH_TOKEN_NOT_FOUND,
                 )
             }
             // save new access token & retry check session
             return if (sessionLocalDataSource.saveSession(SessionEntity(reissueResult.data))) {
                 authRemoteDataSource.checkSession()
-            }else{
-                DataState.Error(Throwable("failed to save new access token"))
-            }
+            } else
+                {
+                    DataState.Error(Throwable("failed to save new access token"))
+                }
         } catch (e: Exception) {
             return DataState.Error(e)
         }

--- a/data/src/main/java/com/emotionstorage/data/repoImpl/AuthRepositoryImpl.kt
+++ b/data/src/main/java/com/emotionstorage/data/repoImpl/AuthRepositoryImpl.kt
@@ -81,7 +81,8 @@ class AuthRepositoryImpl @Inject constructor(
             if (reissueResult !is DataState.Success) {
                 return DataState.Error(
                     Throwable("failed to reissue access token"),
-                    ErrorCode.REFRESH_TOKEN_NOT_FOUND,
+                    if (reissueResult is DataState.Error) reissueResult.code
+                    else ErrorCode.UNKNOWN,
                 )
             }
             // save new access token & retry check session

--- a/data/src/main/java/com/emotionstorage/data/repoImpl/NotificationPermissionRepositoryImpl.kt
+++ b/data/src/main/java/com/emotionstorage/data/repoImpl/NotificationPermissionRepositoryImpl.kt
@@ -1,12 +1,12 @@
 package com.emotionstorage.data.repoImpl
 
-import com.emotionstorage.data.dataSource.local.NotificationPermissionDataSource
+import com.emotionstorage.data.dataSource.local.NotificationPermissionLocalDataSource
 import com.emotionstorage.domain.model.NotificationPermissionStatus
 import com.emotionstorage.domain.repo.NotificationPermissionRepository
 import javax.inject.Inject
 
 class NotificationPermissionRepositoryImpl @Inject constructor(
-    private val datsSource: NotificationPermissionDataSource,
+    private val datsSource: NotificationPermissionLocalDataSource,
 ) : NotificationPermissionRepository {
     override fun observeInfo() = datsSource.observeInfo()
 

--- a/domain/src/main/java/com/emotionstorage/domain/repo/AuthRepository.kt
+++ b/domain/src/main/java/com/emotionstorage/domain/repo/AuthRepository.kt
@@ -14,7 +14,7 @@ interface AuthRepository {
 
     suspend fun signup(signupForm: SignupForm): DataState<Unit>
 
-    suspend fun checkSession(): DataState<Boolean>
+    suspend fun checkSession(): DataState<Unit>
 
     suspend fun logout(): Boolean
 

--- a/domain/src/main/java/com/emotionstorage/domain/useCase/auth/AutomaticLoginUseCase.kt
+++ b/domain/src/main/java/com/emotionstorage/domain/useCase/auth/AutomaticLoginUseCase.kt
@@ -12,7 +12,7 @@ class AutomaticLoginUseCase
         private val fcmRepository: FcmRepository,
         private val handleLogout: HandleLogoutUseCase,
     ) {
-        suspend operator fun invoke(): DataState<Boolean> {
+        suspend operator fun invoke(): DataState<Unit> {
             val checkSessionResult = authRepository.checkSession()
 
             if (checkSessionResult is DataState.Success) {

--- a/feat/ai-chat/src/main/java/com/emotionstorage/ai_chat/remote/api/ChatApiService.kt
+++ b/feat/ai-chat/src/main/java/com/emotionstorage/ai_chat/remote/api/ChatApiService.kt
@@ -2,18 +2,15 @@ package com.emotionstorage.ai_chat.remote.api
 
 import com.emotionstorage.ai_chat.remote.response.ExitChatRoomResponse
 import com.emotionstorage.ai_chat.remote.response.StartEmotionConversationResponse
-import com.emotionstorage.remote.interceptor.AuthRequest
 import com.emotionstorage.remote.response.ResponseDto
 import retrofit2.http.DELETE
 import retrofit2.http.POST
 import retrofit2.http.Path
 
 interface ChatApiService {
-    @AuthRequest
     @POST("/api/v1/home/emotion-conversation")
     suspend fun postEmotionConversationStart(): ResponseDto<StartEmotionConversationResponse>
 
-    @AuthRequest
     @DELETE("/api/v1/home/emotion-conversation/{roomId}")
     suspend fun exitEmotionConversation(
         @Path("roomId") roomId: Long,


### PR DESCRIPTION
## Related Issue
- Closes #192 

## 작업 상세 내용
- Refresh 토큰은 Access 토큰과 달리, **HttpOnly 쿠키**로 관리
  - 쿠키 관리를 위해 `AppCookieJar` 클래스 추가
  - Refresh 토큰 관리를 위해 `SessionLocalDataSourceImpl`에 DataStore 로직 추가
  - 로그인 요청 => `AppCookieJar` 클래스가 응답 쿠키로 받은 Refresh 토큰 확인 & 로컬에 저장
  - 토큰 재발급 요청 => `AppCookieJar` 클래스가 "auth/reissue" 경로 포함 요청에 Refresh 토큰 쿠키 추가
- api 호출 도중 Access 토큰이 만료된 경우를 위한 `Token Athenticator` 클래스 추가
  - `FailResponseInterceptor`에서 401인 경우 CustomHttpException으로 변환하지 않고 그대로 response 반환 
  -> `Token Authenticator`에서 AccessToken 재발급 & 저장 & 요청 재시도
  - `Token Authenticator`에서 `ReissueApiService` 의존
  -> 의존 사이클이 발생하지 않도록, `ReissueApiService`는 독립적인 Retrofit 객체로 생성
- 스플래시 화면 **자동 로그인 시, 액세스 토큰 재발급 & 요청 재시도**를 위한 로직 추가
  - `AuthRepositoryImpl` 내부 checkSession() 함수에서 세션 만료 시, 토큰 재발급 후 한번 더 세션 확인 요청 호출
  -> Access 토큰 만료 시, 갱신되지 않고 자동로그인 해제되는 이슈(QA-30) 해결

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 액세스 토큰 자동 재발급(토큰 리이슈) 및 관련 네트워크 리트라이 도입
  * HTTP 쿠키 기반 리프레시 토큰 관리 및 자동 저장/전달 추가

* **개선사항**
  * 로컬에 리프레시 토큰 저장/조회 기능 추가로 세션 유지 개선
  * 인증 실패 시 재발급 후 재시도하는 흐름으로 인증 복구 신뢰성 향상

* **기타**
  * 일부 API의 인증 적용 방식 조정 (어노테이션 기반 조건 제거)

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->