### PR TITLE
Dev/custom preview 디바이스 크기별 프리뷰 생성 애노테이션

### DIFF
--- a/core/ui/src/main/java/com/emotionstorage/ui/annotation/PreviewDevices.kt
+++ b/core/ui/src/main/java/com/emotionstorage/ui/annotation/PreviewDevices.kt
@@ -4,45 +4,44 @@ import androidx.compose.ui.tooling.preview.Preview
 
 @Retention(AnnotationRetention.SOURCE)
 @Target(AnnotationTarget.FUNCTION)
-
-// 최소 대응
 @Preview(
+    // 최소 대응
     name = "Android Small",
     showBackground = true,
     widthDp = 360,
     heightDp = 640,
 )
-// 기준 디바이스
 @Preview(
+    // 기준 디바이스
     name = "Android Normal",
     showBackground = true,
     widthDp = 411,
     heightDp = 891,
 )
-// 큰 폰 대응
 @Preview(
+    // 큰 폰 대응
     name = "Android Large",
     showBackground = true,
     widthDp = 412,
     heightDp = 915,
 )
-// Z Flip 대응
-// Z Flip 펼친 크기 = Z Fold 접힌 크기와 거의 동일
 @Preview(
+    // Z Flip 대응
+    // Z Flip 펼친 크기 = Z Fold 접힌 크기와 거의 동일
     name = "Z Flip",
     showBackground = true,
     widthDp = 360,
     heightDp = 748,
 )
-// Z Fold 대응
 @Preview(
+    // Z Fold 대응
     name = "Z Fold",
     showBackground = true,
     widthDp = 673,
     heightDp = 841,
 )
-// 태블릿 대응
 @Preview(
+    // 태블릿 대응
     name = "Tablet",
     showBackground = true,
     widthDp = 800,

--- a/core/ui/src/main/java/com/emotionstorage/ui/annotation/PreviewDevices.kt
+++ b/core/ui/src/main/java/com/emotionstorage/ui/annotation/PreviewDevices.kt
@@ -1,0 +1,52 @@
+package com.emotionstorage.ui.annotation
+
+import androidx.compose.ui.tooling.preview.Devices
+import androidx.compose.ui.tooling.preview.Preview
+
+@Retention(AnnotationRetention.SOURCE)
+@Target(AnnotationTarget.FUNCTION)
+
+// 최소 대응
+@Preview(
+    name = "Android Small",
+    showBackground = true,
+    widthDp = 360,
+    heightDp = 640
+)
+// 기준 디바이스
+@Preview(
+    name = "Android Normal",
+    showBackground = true,
+    widthDp = 411,
+    heightDp = 891
+)
+// 큰 폰 대응
+@Preview(
+    name = "Android Large",
+    showBackground = true,
+    widthDp = 412,
+    heightDp = 915
+)
+// Z Flip 대응
+// Z Flip 펼친 크기 = Z Fold 접힌 크기와 거의 동일
+@Preview(
+    name = "Z Flip",
+    showBackground = true,
+    widthDp = 360,
+    heightDp = 748
+)
+// Z Fold 대응
+@Preview(
+    name = "Z Fold",
+    showBackground = true,
+    widthDp = 673,
+    heightDp = 841
+)
+// 태블릿 대응
+@Preview(
+    name = "Tablet",
+    showBackground = true,
+    widthDp = 800,
+    heightDp = 1280
+)
+annotation class PreviewDevices

--- a/core/ui/src/main/java/com/emotionstorage/ui/annotation/PreviewDevices.kt
+++ b/core/ui/src/main/java/com/emotionstorage/ui/annotation/PreviewDevices.kt
@@ -1,50 +1,37 @@
 package com.emotionstorage.ui.annotation
 
+import androidx.compose.ui.tooling.preview.Devices.PIXEL_4
+import androidx.compose.ui.tooling.preview.Devices.PIXEL_7_PRO
+import androidx.compose.ui.tooling.preview.Devices.TABLET
 import androidx.compose.ui.tooling.preview.Preview
 
 @Retention(AnnotationRetention.SOURCE)
 @Target(AnnotationTarget.FUNCTION)
 @Preview(
-    // 최소 대응
     name = "Android Small",
     showBackground = true,
-    widthDp = 360,
-    heightDp = 640,
+    widthDp = 320,
+    heightDp = 480,
 )
 @Preview(
-    // 기준 디바이스
     name = "Android Normal",
     showBackground = true,
-    widthDp = 411,
-    heightDp = 891,
+    device = PIXEL_4,
 )
 @Preview(
-    // 큰 폰 대응
     name = "Android Large",
     showBackground = true,
-    widthDp = 412,
-    heightDp = 915,
+    device = PIXEL_7_PRO,
 )
 @Preview(
-    // Z Flip 대응
-    // Z Flip 펼친 크기 = Z Fold 접힌 크기와 거의 동일
-    name = "Z Flip",
-    showBackground = true,
+    name = "Z Flip 5 - Open",
     widthDp = 360,
     heightDp = 748,
 )
 @Preview(
-    // Z Fold 대응
-    name = "Z Fold",
+    name = "Z Fold 5 - Open",
     showBackground = true,
     widthDp = 673,
     heightDp = 841,
-)
-@Preview(
-    // 태블릿 대응
-    name = "Tablet",
-    showBackground = true,
-    widthDp = 800,
-    heightDp = 1280,
 )
 annotation class PreviewDevices

--- a/core/ui/src/main/java/com/emotionstorage/ui/annotation/PreviewDevices.kt
+++ b/core/ui/src/main/java/com/emotionstorage/ui/annotation/PreviewDevices.kt
@@ -1,6 +1,5 @@
 package com.emotionstorage.ui.annotation
 
-import androidx.compose.ui.tooling.preview.Devices
 import androidx.compose.ui.tooling.preview.Preview
 
 @Retention(AnnotationRetention.SOURCE)
@@ -11,21 +10,21 @@ import androidx.compose.ui.tooling.preview.Preview
     name = "Android Small",
     showBackground = true,
     widthDp = 360,
-    heightDp = 640
+    heightDp = 640,
 )
 // 기준 디바이스
 @Preview(
     name = "Android Normal",
     showBackground = true,
     widthDp = 411,
-    heightDp = 891
+    heightDp = 891,
 )
 // 큰 폰 대응
 @Preview(
     name = "Android Large",
     showBackground = true,
     widthDp = 412,
-    heightDp = 915
+    heightDp = 915,
 )
 // Z Flip 대응
 // Z Flip 펼친 크기 = Z Fold 접힌 크기와 거의 동일
@@ -33,20 +32,20 @@ import androidx.compose.ui.tooling.preview.Preview
     name = "Z Flip",
     showBackground = true,
     widthDp = 360,
-    heightDp = 748
+    heightDp = 748,
 )
 // Z Fold 대응
 @Preview(
     name = "Z Fold",
     showBackground = true,
     widthDp = 673,
-    heightDp = 841
+    heightDp = 841,
 )
 // 태블릿 대응
 @Preview(
     name = "Tablet",
     showBackground = true,
     widthDp = 800,
-    heightDp = 1280
+    heightDp = 1280,
 )
 annotation class PreviewDevices

--- a/feat/auth/src/main/java/com/emotionstorage/auth/ui/LoginScreen.kt
+++ b/feat/auth/src/main/java/com/emotionstorage/auth/ui/LoginScreen.kt
@@ -44,6 +44,7 @@ import com.emotionstorage.auth.ui.modal.RetryHandleLoginModal
 import com.emotionstorage.domain.common.ErrorCode
 import com.emotionstorage.domain.model.User.AuthProvider
 import com.emotionstorage.presentation.BaseSideEffect
+import com.emotionstorage.ui.annotation.PreviewDevices
 import com.emotionstorage.ui.component.loading.LoadingOverlay
 import com.emotionstorage.ui.component.modal.TempErrorModal
 import com.emotionstorage.ui.component.toast.AppSnackbarHost
@@ -280,7 +281,7 @@ private fun StatelessLoginScreen(
     }
 }
 
-@PreviewScreenSizes
+@PreviewDevices
 @Composable
 private fun LoginScreenPreview() {
     MooiTheme {

--- a/feat/auth/src/main/java/com/emotionstorage/auth/ui/LoginScreen.kt
+++ b/feat/auth/src/main/java/com/emotionstorage/auth/ui/LoginScreen.kt
@@ -28,7 +28,6 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.SpanStyle
-import androidx.compose.ui.tooling.preview.PreviewScreenSizes
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.zIndex
 import androidx.hilt.navigation.compose.hiltViewModel

--- a/feat/tutorial/src/main/java/com/emotionstorage/tutorial/ui/SplashScreen.kt
+++ b/feat/tutorial/src/main/java/com/emotionstorage/tutorial/ui/SplashScreen.kt
@@ -20,6 +20,7 @@ import com.emotionstorage.tutorial.presentation.SplashAction
 import com.emotionstorage.tutorial.presentation.SplashSideEffect
 import com.emotionstorage.tutorial.presentation.SplashViewModel
 import com.emotionstorage.ui.R
+import com.emotionstorage.ui.annotation.PreviewDevices
 import com.emotionstorage.ui.theme.MooiTheme
 
 @Composable
@@ -76,7 +77,7 @@ private fun StatelessSplashScreen(modifier: Modifier = Modifier) {
     }
 }
 
-@Preview
+@PreviewDevices
 @Composable
 private fun SplashScreenPreview() {
     MooiTheme {

--- a/feat/tutorial/src/main/java/com/emotionstorage/tutorial/ui/SplashScreen.kt
+++ b/feat/tutorial/src/main/java/com/emotionstorage/tutorial/ui/SplashScreen.kt
@@ -13,7 +13,6 @@ import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.painterResource
-import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import com.emotionstorage.tutorial.presentation.SplashAction


### PR DESCRIPTION
## Related Issue
- Closes #167

## 작업 상세 내용
- 디바이스 크기 별 프리뷰 생성 애노테이션 추가
  - 사이즈 별 기본 기기 - Small, Normal, Large
  - 특수 기기 - Z 플립, Z 폴더, 태블릿
=> **Small & 태블릿 크기를 주의**하며 UI 수정 진행하면 될 것 같습니다!

<img width="1043" height="451" alt="image" src="https://github.com/user-attachments/assets/3a0ecc2e-697e-45ec-82e3-09f5187970d8" />



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

**Chores**
- 멀티 디바이스 프리뷰 어노테이션 추가로 소형·일반·대형·폴더블·태블릿 화면에서 컴포넌트 미리보기가 통합·확장되었습니다.
- 기존 미리보기 어노테이션을 새 통합 어노테이션으로 교체하여 로그인 및 시작 화면 등의 미리보기가 여러 기기 크기에서 자동으로 표시됩니다.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->