### PR TITLE
Dev/feat navigation stack

### DIFF
--- a/app/src/main/java/com/emotionstorage/emotionstorage/ui/AppNavHost.kt
+++ b/app/src/main/java/com/emotionstorage/emotionstorage/ui/AppNavHost.kt
@@ -338,7 +338,7 @@ internal fun AppNavHost(
             AIChatScreen(
                 roomId = arguments.roomId,
                 navToTimeCapsuleDetail = { id ->
-                    navController.navigate(AppDestination.TimeCapsuleDetail(id, isNewTimeCapsule = true))
+                    navController.navigateWithClearStack(AppDestination.TimeCapsuleDetail(id, isNewTimeCapsule = true))
                 },
                 navToBack = {
                     navController.popBackStack()
@@ -409,7 +409,10 @@ internal fun AppNavHost(
                 id = arguments.id,
                 isNewTimeCapsule = arguments.isNewTimeCapsule,
                 navToMain = {
-                    navController.navigateWithClearStack(AppDestination.Home)
+                    navController.navigate(AppDestination.Home) {
+                        popUpTo(navController.graph.id) { inclusive = true }
+                        launchSingleTop = true
+                    }
                 },
                 navToPrevious = {
                     // pop twice, to navigate to previous screen


### PR DESCRIPTION
## Related Issue
- Issue #203

## 작업 상세 내용
- 채팅 종료 후 타임캡슐 만들 때 채팅 화면 Stack 비우는 작업
- 타임캡슐 저장 후 홈 화면에서 뒤로가기 눌렀을 때 이전 타임 캡슐이 Stack에 남아있어 open유도 Modal이 나오지 않도록 Stack에서 제거

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **버그 수정**
  * AI 채팅에서 타임캡슐 상세 페이지로 이동할 때 네비게이션 흐름을 개선했습니다.
  * 타임캡슐 저장 후 홈 화면으로 돌아갈 때 뒤로가기 동작을 최적화했습니다.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->