### PR TITLE
[QA-38] 임시 탈퇴 확인 팝업 작업

### DIFF
--- a/app/src/main/java/com/emotionstorage/emotionstorage/ui/AppNavHost.kt
+++ b/app/src/main/java/com/emotionstorage/emotionstorage/ui/AppNavHost.kt
@@ -448,9 +448,9 @@ internal fun AppNavHost(
                 navToLogin = {
                     navController.navigateWithClearStack(AppDestination.Login)
                 },
-                navToNotificationSetting = {
+              /*  navToNotificationSetting = {
                     navController.navigateWithClearStack(AppDestination.NotificationSetting)
-                },
+                },*/
             )
         }
 

--- a/feat/my/src/main/java/com/emotionstorage/my/ui/modal/ConfirmWithdrawModal.kt
+++ b/feat/my/src/main/java/com/emotionstorage/my/ui/modal/ConfirmWithdrawModal.kt
@@ -20,16 +20,19 @@ import com.emotionstorage.ui.component.modal.Modal
 @Composable
 fun ConfirmWithdrawModal(
     onDismissRequest: () -> Unit,
-    onChangeNotification: () -> Unit,
     onWithDraw: () -> Unit,
+//    onChangeNotification: () -> Unit,
 ) {
     Modal(
         onDismissRequest = onDismissRequest,
-        title = "기록을 잠시 멈추고 싶다면,\n알림을 끄거나\n앱을 쉬어가보는 건 어떨까요?",
-        confirmLabel = "알림을 끄고 쉬어갈래요.",
-        onConfirm = onChangeNotification,
+        title = "정말 탈퇴하시겠어요?",
+        bottomDescription = "저장된 감정 기록을 다시는 볼 수 없어요",
+        confirmLabel = "아니요, 그냥 있을래요.",
+        onConfirm = onDismissRequest,
         dismissLabel = "서비스를 탈퇴할래요.",
         onDismiss = onWithDraw,
+        dismissOnBackPress = true,
+        dismissOnClickOutside = true,
     )
 }
 
@@ -38,7 +41,7 @@ fun ConfirmWithdrawModal(
 private fun ConfirmWithdrawModalPreview() {
     ConfirmWithdrawModal(
         onDismissRequest = {},
-        onChangeNotification = {},
         onWithDraw = {},
+//        onChangeNotification = {},
     )
 }

--- a/feat/my/src/main/java/com/emotionstorage/my/ui/withdraw/WithDrawNoticeScreen.kt
+++ b/feat/my/src/main/java/com/emotionstorage/my/ui/withdraw/WithDrawNoticeScreen.kt
@@ -49,8 +49,8 @@ private sealed class WithdrawNoticeModalState {
 fun WithDrawNoticeScreen(
     viewModel: WithdrawNoticeViewModel = hiltViewModel(),
     navToBack: () -> Unit = {},
-    navToNotificationSetting: () -> Unit = {},
     navToLogin: () -> Unit = {},
+//    navToNotificationSetting: () -> Unit = {},
 ) {
     val state by viewModel.container.stateFlow.collectAsState()
     val (modalState, setModalState) =
@@ -98,12 +98,12 @@ fun WithDrawNoticeScreen(
                 onDismissRequest = {
                     setModalState(WithdrawNoticeModalState.None)
                 },
-                onChangeNotification = {
-                    navToNotificationSetting()
-                },
                 onWithDraw = {
                     viewModel.onAction(WithdrawNoticeAction.WithDraw)
                 },
+               /* onChangeNotification = {
+                    navToNotificationSetting()
+                },*/
             )
         }
 


### PR DESCRIPTION
## Related Issue
- Issue #211 

## 작업 상세 내용
- 푸시 알림 기능 배포 보류로 인하여 알림 설정 관련 로직 주석 처리
 (탈퇴 Modal에서 알림 설정 유도하는 부분 임시 제거)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **Bug Fixes**
  * 회원 탈퇴 알림 화면에서 알림 설정으로의 불필요한 탐색 경로를 제거했습니다.

* **UI/UX 개선**
  * 탈퇴 확인 모달의 상호작용 방식을 개선하여 더 명확한 사용자 경험을 제공합니다.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->