### PR TITLE
[Fix] 임시 저장된 채팅 불러올 때 App 종료되는 현상 수정

### DIFF
--- a/core/remote/src/main/java/com/emotionstorage/remote/dataSourceImpl/ChatWSDataSourceImpl.kt
+++ b/core/remote/src/main/java/com/emotionstorage/remote/dataSourceImpl/ChatWSDataSourceImpl.kt
@@ -22,6 +22,7 @@ import org.hildan.krossbow.stomp.headers.StompSendHeaders
 import org.hildan.krossbow.stomp.subscribeText
 import org.hildan.krossbow.websocket.okhttp.OkHttpWebSocketClient
 import java.time.Duration
+import java.util.UUID
 import javax.inject.Inject
 
 private const val WS_URL = "ws://${BuildConfig.MOOI_DEV_SERVER_URL}ws"
@@ -30,6 +31,7 @@ class ChatWSDataSourceImpl @Inject constructor(
     private val getAccessTokenUseCase: GetAccessTokenUseCase,
 ) : ChatWSDataSource {
     private val json = Json { ignoreUnknownKeys = true }
+    private var currentServerClientId: String? = null
 
     private val client =
         StompClient(
@@ -73,32 +75,40 @@ class ChatWSDataSourceImpl @Inject constructor(
                 flow {
                     raw
                         .lines()
-                        // 응답에 문제가 없다면 필요 없는 부분
-                        .map { it.replace("\uFFFD", "").trim() }
                         .filter { it.isNotBlank() }
                         .forEach { line ->
                             Logger.d("observeChatMessages() line: $line")
                             try {
                                 val dto = json.decodeFromString<ChatMessageResponse>(line)
                                 val isComplete = dto.messageType == "chat.complete"
-
                                 val content = dto.content.orEmpty()
-                                if (content.isBlank() && !isComplete) return@forEach
 
+                                if (content.isBlank() && !isComplete) return@forEach
                                 if (!isComplete) {
                                     delay(1500L)
                                 }
 
+                                // Server에서 내려오는 값이 없어 UUID로 식별
+                                val serverClientId =
+                                    currentServerClientId ?: UUID
+                                        .randomUUID()
+                                        .toString()
+                                        .also { currentServerClientId = it }
+
                                 emit(
-                                    ChatMessage(
+                                    ChatMessage.newServerMessage(
                                         roomId = roomId,
-                                        source = ChatMessage.MessageSource.SERVER,
+                                        clientId = serverClientId,
                                         content = content,
                                         gaugeScore = dto.gauge?.gaugeScore,
                                         turnCountScore = dto.gauge?.turnCountScore,
                                         isComplete = isComplete,
                                     ),
                                 )
+
+                                if (isComplete) {
+                                    currentServerClientId = null
+                                }
                             } catch (e: Exception) {
                                 Logger.e("observeChatMessages() decode failed. line=$line", e)
                             }

--- a/core/remote/src/main/java/com/emotionstorage/remote/modelMapper/ChatRoomMessagesMapper.kt
+++ b/core/remote/src/main/java/com/emotionstorage/remote/modelMapper/ChatRoomMessagesMapper.kt
@@ -18,6 +18,7 @@ object ChatRoomMessagesMapper {
                         response.roomWithChats.chats.map { chat ->
                             ChatMessageEntity(
                                 id = chat.id,
+                                clientId = chat.clientId,
                                 sender = chat.sender,
                                 message = chat.message,
                                 chatTime = chat.chatTime,

--- a/core/remote/src/main/java/com/emotionstorage/remote/response/chat/ChatRoomMessagesResponse.kt
+++ b/core/remote/src/main/java/com/emotionstorage/remote/response/chat/ChatRoomMessagesResponse.kt
@@ -21,6 +21,7 @@ data class RoomWithChatsResponse(
 @Serializable
 data class ChatMessagesResponse(
     val id: Long,
+    val clientId: String,
     val sender: String,
     val message: String,
     val chatTime: String,

--- a/data/src/main/java/com/emotionstorage/data/model/ChatRoomMessagesEntity.kt
+++ b/data/src/main/java/com/emotionstorage/data/model/ChatRoomMessagesEntity.kt
@@ -16,6 +16,7 @@ data class RoomWithChatsEntity(
 
 data class ChatMessageEntity(
     val id: Long,
+    val clientId: String,
     val sender: String,
     val message: String,
     val chatTime: String,

--- a/data/src/main/java/com/emotionstorage/data/modelMapper/ChatMessageMapper.kt
+++ b/data/src/main/java/com/emotionstorage/data/modelMapper/ChatMessageMapper.kt
@@ -16,6 +16,7 @@ object ChatMessageMapper {
             .map { chat ->
                 ChatMessage(
                     id = chat.id.toString(),
+                    clientId = chat.clientId,
                     roomId = roomId,
                     source = toMessageSource(chat.sender),
                     content = chat.message,

--- a/domain/src/main/java/com/emotionstorage/domain/model/ChatMessage.kt
+++ b/domain/src/main/java/com/emotionstorage/domain/model/ChatMessage.kt
@@ -5,7 +5,7 @@ import java.util.UUID
 
 data class ChatMessage(
     val id: String = UUID.randomUUID().toString(),
-    val clientId: String = "",
+    val clientId: String,
     val roomId: Long,
     val source: MessageSource,
     val content: String,
@@ -17,5 +17,39 @@ data class ChatMessage(
     enum class MessageSource {
         CLIENT,
         SERVER,
+    }
+
+    companion object {
+        fun newClientMessage(
+            roomId: Long,
+            content: String,
+            clientId: String = UUID.randomUUID().toString(),
+        ): ChatMessage =
+            ChatMessage(
+                clientId = clientId,
+                roomId = roomId,
+                source = MessageSource.CLIENT,
+                content = content,
+            )
+
+        fun newServerMessage(
+            roomId: Long,
+            clientId: String,
+            content: String,
+            gaugeScore: Int? = null,
+            turnCountScore: Int? = null,
+            isComplete: Boolean = false,
+            timestamp: LocalDateTime = LocalDateTime.now(),
+        ): ChatMessage =
+            ChatMessage(
+                clientId = clientId,
+                roomId = roomId,
+                source = MessageSource.SERVER,
+                content = content,
+                gaugeScore = gaugeScore,
+                turnCountScore = turnCountScore,
+                isComplete = isComplete,
+                timestamp = timestamp,
+            )
     }
 }

--- a/domain/src/main/java/com/emotionstorage/domain/model/ChatMessage.kt
+++ b/domain/src/main/java/com/emotionstorage/domain/model/ChatMessage.kt
@@ -5,6 +5,7 @@ import java.util.UUID
 
 data class ChatMessage(
     val id: String = UUID.randomUUID().toString(),
+    val clientId: String = "",
     val roomId: Long,
     val source: MessageSource,
     val content: String,

--- a/feat/ai-chat/src/main/java/com/emotionstorage/ai_chat/presentation/AIChatViewModel.kt
+++ b/feat/ai-chat/src/main/java/com/emotionstorage/ai_chat/presentation/AIChatViewModel.kt
@@ -415,11 +415,22 @@ class AIChatViewModel @Inject constructor(
 
         val mergedContent =
             when {
-                incomingMessage.isComplete -> incomingMessage.content
-                incomingMessage.content.startsWith(existing.content) -> incomingMessage.content
+                incomingMessage.isComplete -> {
+                    incomingMessage.content
+                }
+
+                incomingMessage.content.startsWith(existing.content) -> {
+                    incomingMessage.content
+                }
+
                 existing.content.length >= incomingMessage.content.length &&
-                    incomingMessage.content.isNotBlank() -> existing.content
-                else -> existing.content + incomingMessage.content
+                    incomingMessage.content.isNotBlank() -> {
+                    existing.content
+                }
+
+                else -> {
+                    existing.content + incomingMessage.content
+                }
             }
 
         val merged =

--- a/feat/ai-chat/src/main/java/com/emotionstorage/ai_chat/presentation/AIChatViewModel.kt
+++ b/feat/ai-chat/src/main/java/com/emotionstorage/ai_chat/presentation/AIChatViewModel.kt
@@ -230,8 +230,7 @@ class AIChatViewModel @Inject constructor(
                                         nextTurnScore >= quitTriggerTurn
 
                                 state.copy(
-                                    messages =
-                                        if (isComplete) state.messages else state.messages + message,
+                                    messages = state.messages.upsertById(message),
                                     gaugeScore = nextGauge,
                                     chatProgress = newProgress,
                                     canCreateTimesCapsule = canCreate,
@@ -262,16 +261,14 @@ class AIChatViewModel @Inject constructor(
     private fun handleSendMessage(message: String) =
         intent {
             if (message.isBlank() || state.isWaitingReply) return@intent
-            val newMessage =
-                ChatMessage(
+            val outgoing =
+                ChatMessage.newClientMessage(
                     roomId = state.roomId,
-                    source = ChatMessage.MessageSource.CLIENT,
                     content = message,
                 )
-
             reduce {
                 state.copy(
-                    messages = state.messages + newMessage,
+                    messages = state.messages + outgoing,
                     isWaitingReply = true,
                     isMooiTyping = true,
                 )
@@ -279,11 +276,7 @@ class AIChatViewModel @Inject constructor(
 
             sendChatMessage(
                 state.roomId,
-                ChatMessage(
-                    roomId = state.roomId,
-                    source = ChatMessage.MessageSource.CLIENT,
-                    content = message,
-                ),
+                outgoing,
             ).collect { result ->
                 when (result) {
                     is DataState.Success -> {
@@ -296,7 +289,9 @@ class AIChatViewModel @Inject constructor(
 
                         reduce {
                             state.copy(
-                                messages = state.messages.filterNot { it == newMessage },
+                                messages = state.messages.filterNot { it.clientId == outgoing.clientId },
+                                isWaitingReply = false,
+                                isMooiTyping = false,
                             )
                         }
                     }
@@ -411,4 +406,31 @@ class AIChatViewModel @Inject constructor(
 
             postSideEffect(AIChatSideEffect.NavigateBack)
         }
+
+    private fun List<ChatMessage>.upsertById(incomingMessage: ChatMessage): List<ChatMessage> {
+        val idx = indexOfFirst { it.clientId == incomingMessage.clientId && it.source == incomingMessage.source }
+        if (idx == -1) return this + incomingMessage
+
+        val existing = this[idx]
+
+        val mergedContent =
+            when {
+                incomingMessage.isComplete -> incomingMessage.content
+                incomingMessage.content.startsWith(existing.content) -> incomingMessage.content
+                existing.content.length >= incomingMessage.content.length &&
+                    incomingMessage.content.isNotBlank() -> existing.content
+                else -> existing.content + incomingMessage.content
+            }
+
+        val merged =
+            existing.copy(
+                content = mergedContent,
+                isComplete = existing.isComplete || incomingMessage.isComplete,
+                gaugeScore = incomingMessage.gaugeScore ?: existing.gaugeScore,
+                turnCountScore = incomingMessage.turnCountScore ?: existing.turnCountScore,
+                timestamp = incomingMessage.timestamp,
+            )
+
+        return toMutableList().apply { set(idx, merged) }
+    }
 }

--- a/feat/ai-chat/src/main/java/com/emotionstorage/ai_chat/ui/component/ChatMessageList.kt
+++ b/feat/ai-chat/src/main/java/com/emotionstorage/ai_chat/ui/component/ChatMessageList.kt
@@ -52,7 +52,7 @@ fun ChatMessageList(
                 .fillMaxSize(),
         state = listState,
     ) {
-        itemsIndexed(items = chatMessages, key = { _, item -> item.clientId }) { index, item ->
+        itemsIndexed(items = chatMessages, key = { _, item -> "${item.source.name}-${item.clientId}" }) { index, item ->
             if (index == 0 || chatMessages[index - 1].timestamp.toLocalDate() != item.timestamp.toLocalDate()) {
                 Spacer(modifier = Modifier.height(16.dp))
                 DateDivider(

--- a/feat/ai-chat/src/main/java/com/emotionstorage/ai_chat/ui/component/ChatMessageList.kt
+++ b/feat/ai-chat/src/main/java/com/emotionstorage/ai_chat/ui/component/ChatMessageList.kt
@@ -30,14 +30,14 @@ import androidx.compose.ui.platform.LocalConfiguration
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
+import com.emotionstorage.common.toKorDateWithWeekDay
 import com.emotionstorage.domain.model.ChatMessage
 import com.emotionstorage.domain.model.ChatMessage.MessageSource
-import com.emotionstorage.common.toKorDateWithWeekDay
+import com.emotionstorage.ui.R
 import com.emotionstorage.ui.component.loading.LoadingDots
 import com.emotionstorage.ui.theme.MooiTheme
 import java.time.LocalDate
 import java.time.LocalDateTime
-import com.emotionstorage.ui.R
 
 @Composable
 fun ChatMessageList(
@@ -52,7 +52,7 @@ fun ChatMessageList(
                 .fillMaxSize(),
         state = listState,
     ) {
-        itemsIndexed(items = chatMessages, key = { _, item -> item.id }) { index, item ->
+        itemsIndexed(items = chatMessages, key = { _, item -> item.clientId }) { index, item ->
             if (index == 0 || chatMessages[index - 1].timestamp.toLocalDate() != item.timestamp.toLocalDate()) {
                 Spacer(modifier = Modifier.height(16.dp))
                 DateDivider(
@@ -251,6 +251,7 @@ private fun ChatMessageListPreview() {
         List(6, init = { it }).map { it ->
             ChatMessage(
                 roomId = 1L,
+                clientId = "1234",
                 source = if (it % 3 == 0) MessageSource.CLIENT else MessageSource.SERVER,
                 content = "안녕하세요",
                 timestamp = LocalDateTime.of(2025, 9, 2, 17, it, 1, 1),
@@ -261,6 +262,7 @@ private fun ChatMessageListPreview() {
             listOf(
                 ChatMessage(
                     roomId = 1L,
+                    clientId = "1234",
                     source = MessageSource.SERVER,
                     content = "안녕하세요. 안녕하세요. 안녕하세요. 안녕하세요. 안녕하세요. 안녕하세요. 안녕하세요. 안녕하세요. 안녕하세요. 안녕하세요. 안녕하세요. 안녕하세요.",
                     timestamp = LocalDateTime.of(2025, 9, 3, 17, 1, 1, 1),
@@ -273,6 +275,7 @@ private fun ChatMessageListPreview() {
                     content = "안녕하세요. 안녕하세요. 안녕하세요. 안녕하세요. 안녕하세요. 안녕하세요. 안녕하세요. 안녕하세요. 안녕하세요. 안녕하세요. 안녕하세요. 안녕하세요.",
                     timestamp = LocalDateTime.of(2025, 9, 3, 17, 1, 1, 1),
                     gaugeScore = 40,
+                    clientId = "1234",
                     turnCountScore = 6,
                 ),
             ) +
@@ -280,6 +283,7 @@ private fun ChatMessageListPreview() {
                 ChatMessage(
                     roomId = 1L,
                     source = if (it % 3 == 0) MessageSource.SERVER else MessageSource.CLIENT,
+                    clientId = "1234",
                     content = "안녕하세요",
                     timestamp = LocalDateTime.of(2025, 9, 4, 17, it, 1, 1),
                     gaugeScore = 60,


### PR DESCRIPTION
## Related Issue
- Issue #213

## 작업 상세 내용
- Lazy Column id 값이 중복되어 Server 측에서 임시로 clientId 값 반환 하는 것으로 수정
 (채팅을 로컬에도 저장한다면 백엔드 측부터 모든 채팅이 식별되도록 수정 필요)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **개선 사항**
  * 채팅 메시지에 클라이언트 식별자(clientId)가 도입되어 메시지 추적 및 상태 동기화가 향상되었습니다.
  * 메시지 목록 렌더링이 키 기반으로 안정화되어 재조합 시 일관성이 높아졌습니다.
  * 서버 발신 메시지의 클라이언트 식별 처리 개선으로 스트림 처리 신뢰성이 향상되었습니다.
  * 전송 실패 및 수신 시 메시지 병합·업데이트 로직이 개선되어 중복·불완전한 메시지 처리가 더 정교해졌습니다.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->