### PR TITLE
feat: attendance reward save last claim date on local

### DIFF
--- a/core/local/src/main/java/com/emotionstorage/local/dataSourceImpl/AttendanceClaimLocalDataSourceImpl.kt
+++ b/core/local/src/main/java/com/emotionstorage/local/dataSourceImpl/AttendanceClaimLocalDataSourceImpl.kt
@@ -12,7 +12,7 @@ import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.flow.catch
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.map
-import okio.IOException
+import java.io.IOException
 import javax.inject.Inject
 
 private val Context.attendanceDataStore by preferencesDataStore(name = "attendance_prefs")
@@ -36,8 +36,8 @@ class AttendanceClaimLocalDataSourceImpl @Inject constructor(
             }
         } catch (e: CancellationException) {
             throw e
-        } catch (e: Exception) {
-            Logger.e("Failed setLastClaimDate")
+        } catch (e: IOException) {
+            Logger.e("Failed setLastClaimDate ${e.message}")
         }
     }
 
@@ -48,8 +48,8 @@ class AttendanceClaimLocalDataSourceImpl @Inject constructor(
             }
         } catch (e: CancellationException) {
             throw e
-        } catch (e: Exception) {
-            Logger.e("Failed clear preferences")
+        } catch (e: IOException) {
+            Logger.e("Failed clear preferences ${e.message}")
         }
     }
 

--- a/core/local/src/main/java/com/emotionstorage/local/dataSourceImpl/AttendanceClaimLocalDataSourceImpl.kt
+++ b/core/local/src/main/java/com/emotionstorage/local/dataSourceImpl/AttendanceClaimLocalDataSourceImpl.kt
@@ -12,22 +12,37 @@ import javax.inject.Inject
 class AttendanceClaimLocalDataSourceImpl @Inject constructor(
     @ApplicationContext private val context: Context,
 ) : AttendanceClaimLocalDataSource {
-    override suspend fun getLastClaimDate(): String? = context.attendanceDataStore.data.first()[KEY_LAST_CLAIM_DATE]
+    private val Context.attendanceDataStore by preferencesDataStore(name = "attendance_prefs")
+
+    override suspend fun getLastClaimDate(): String? =
+        try {
+            context.attendanceDataStore.data.first()[KEY_LAST_CLAIM_DATE]
+        } catch (e: Exception) {
+            e.printStackTrace()
+            null
+        }
 
     override suspend fun setLastClaimDate(date: String) {
-        context.attendanceDataStore.edit { prefs ->
-            prefs[KEY_LAST_CLAIM_DATE] = date
+        try {
+            context.attendanceDataStore.edit { prefs ->
+                prefs[KEY_LAST_CLAIM_DATE] = date
+            }
+        } catch (e: Exception) {
+            e.printStackTrace()
         }
     }
 
     override suspend fun clear() {
-        context.attendanceDataStore.edit { prefs ->
-            prefs.remove(KEY_LAST_CLAIM_DATE)
+        try {
+            context.attendanceDataStore.edit { prefs ->
+                prefs.remove(KEY_LAST_CLAIM_DATE)
+            }
+        } catch (e: Exception) {
+            e.printStackTrace()
         }
     }
 
     companion object {
-        private val Context.attendanceDataStore by preferencesDataStore(name = "attendance_prefs")
         private val KEY_LAST_CLAIM_DATE = stringPreferencesKey("last_claim_date")
     }
 }

--- a/core/local/src/main/java/com/emotionstorage/local/dataSourceImpl/AttendanceClaimLocalDataSourceImpl.kt
+++ b/core/local/src/main/java/com/emotionstorage/local/dataSourceImpl/AttendanceClaimLocalDataSourceImpl.kt
@@ -1,0 +1,33 @@
+package com.emotionstorage.local.dataSourceImpl
+
+import android.content.Context
+import androidx.datastore.preferences.core.edit
+import androidx.datastore.preferences.core.stringPreferencesKey
+import androidx.datastore.preferences.preferencesDataStore
+import com.emotionstorage.data.dataSource.local.AttendanceClaimLocalDataSource
+import dagger.hilt.android.qualifiers.ApplicationContext
+import kotlinx.coroutines.flow.first
+import javax.inject.Inject
+
+class AttendanceClaimLocalDataSourceImpl @Inject constructor(
+    @ApplicationContext private val context: Context,
+) : AttendanceClaimLocalDataSource {
+    override suspend fun getLastClaimDate(): String? = context.attendanceDataStore.data.first()[KEY_LAST_CLAIM_DATE]
+
+    override suspend fun setLastClaimDate(date: String) {
+        context.attendanceDataStore.edit { prefs ->
+            prefs[KEY_LAST_CLAIM_DATE] = date
+        }
+    }
+
+    override suspend fun clear() {
+        context.attendanceDataStore.edit { prefs ->
+            prefs.remove(KEY_LAST_CLAIM_DATE)
+        }
+    }
+
+    companion object {
+        private val Context.attendanceDataStore by preferencesDataStore(name = "attendance_prefs")
+        private val KEY_LAST_CLAIM_DATE = stringPreferencesKey("last_claim_date")
+    }
+}

--- a/core/local/src/main/java/com/emotionstorage/local/dataSourceImpl/AttendanceClaimLocalDataSourceImpl.kt
+++ b/core/local/src/main/java/com/emotionstorage/local/dataSourceImpl/AttendanceClaimLocalDataSourceImpl.kt
@@ -2,33 +2,42 @@ package com.emotionstorage.local.dataSourceImpl
 
 import android.content.Context
 import androidx.datastore.preferences.core.edit
+import androidx.datastore.preferences.core.emptyPreferences
 import androidx.datastore.preferences.core.stringPreferencesKey
 import androidx.datastore.preferences.preferencesDataStore
 import com.emotionstorage.data.dataSource.local.AttendanceClaimLocalDataSource
+import com.orhanobut.logger.Logger
 import dagger.hilt.android.qualifiers.ApplicationContext
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.flow.catch
 import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.map
+import okio.IOException
 import javax.inject.Inject
+
+private val Context.attendanceDataStore by preferencesDataStore(name = "attendance_prefs")
 
 class AttendanceClaimLocalDataSourceImpl @Inject constructor(
     @ApplicationContext private val context: Context,
 ) : AttendanceClaimLocalDataSource {
-    private val Context.attendanceDataStore by preferencesDataStore(name = "attendance_prefs")
-
     override suspend fun getLastClaimDate(): String? =
-        try {
-            context.attendanceDataStore.data.first()[KEY_LAST_CLAIM_DATE]
-        } catch (e: Exception) {
-            e.printStackTrace()
-            null
-        }
+        context
+            .attendanceDataStore
+            .data
+            .catch { e ->
+                if (e is IOException) emit(emptyPreferences()) else throw e
+            }.map { prefs -> prefs[KEY_LAST_CLAIM_DATE] }
+            .first()
 
     override suspend fun setLastClaimDate(date: String) {
         try {
             context.attendanceDataStore.edit { prefs ->
                 prefs[KEY_LAST_CLAIM_DATE] = date
             }
+        } catch (e: CancellationException) {
+            throw e
         } catch (e: Exception) {
-            e.printStackTrace()
+            Logger.e("Failed setLastClaimDate")
         }
     }
 
@@ -37,8 +46,10 @@ class AttendanceClaimLocalDataSourceImpl @Inject constructor(
             context.attendanceDataStore.edit { prefs ->
                 prefs.remove(KEY_LAST_CLAIM_DATE)
             }
+        } catch (e: CancellationException) {
+            throw e
         } catch (e: Exception) {
-            e.printStackTrace()
+            Logger.e("Failed clear preferences")
         }
     }
 

--- a/core/local/src/main/java/com/emotionstorage/local/di/LocalDataSourceModule.kt
+++ b/core/local/src/main/java/com/emotionstorage/local/di/LocalDataSourceModule.kt
@@ -1,6 +1,7 @@
 package com.emotionstorage.local.di
 
 import com.emotionstorage.data.dataSource.local.AiChatIntroLocalDataSource
+import com.emotionstorage.data.dataSource.local.AttendanceClaimLocalDataSource
 import com.emotionstorage.data.dataSource.local.FcmLocalDataSource
 import com.emotionstorage.data.dataSource.local.NotificationPermissionLocalDataSource
 import com.emotionstorage.data.dataSource.local.SessionLocalDataSource
@@ -9,6 +10,7 @@ import com.emotionstorage.data.dataSource.local.UserLocalDataSource
 import com.emotionstorage.data.repoImpl.AiChatIntroRepositoryImpl
 import com.emotionstorage.domain.repo.ChatIntroRepository
 import com.emotionstorage.local.dataSourceImpl.AiChatIntroLocalDataSourceImpl
+import com.emotionstorage.local.dataSourceImpl.AttendanceClaimLocalDataSourceImpl
 import com.emotionstorage.local.dataSourceImpl.FcmLocalDataSourceImpl
 import com.emotionstorage.local.dataSourceImpl.NotificationPermissionLocalLocalDataSourceImpl
 import com.emotionstorage.local.dataSourceImpl.SessionLocalDataSourceImpl
@@ -52,4 +54,10 @@ abstract class LocalDataSourceModule {
     @Binds
     @Singleton
     abstract fun bindAiChatIntroRepository(impl: AiChatIntroRepositoryImpl): ChatIntroRepository
+
+    @Binds
+    @Singleton
+    abstract fun bindAttendanceClaimLocalDataSource(
+        impl: AttendanceClaimLocalDataSourceImpl,
+    ): AttendanceClaimLocalDataSource
 }

--- a/data/src/main/java/com/emotionstorage/data/dataSource/local/AttendanceClaimLocalDataSource.kt
+++ b/data/src/main/java/com/emotionstorage/data/dataSource/local/AttendanceClaimLocalDataSource.kt
@@ -1,0 +1,9 @@
+package com.emotionstorage.data.dataSource.local
+
+interface AttendanceClaimLocalDataSource {
+    suspend fun getLastClaimDate(): String?
+
+    suspend fun setLastClaimDate(date: String)
+
+    suspend fun clear()
+}

--- a/data/src/main/java/com/emotionstorage/data/repoImpl/AttendanceRepositoryImpl.kt
+++ b/data/src/main/java/com/emotionstorage/data/repoImpl/AttendanceRepositoryImpl.kt
@@ -1,5 +1,6 @@
 package com.emotionstorage.data.repoImpl
 
+import com.emotionstorage.data.dataSource.local.AttendanceClaimLocalDataSource
 import com.emotionstorage.data.dataSource.remote.AttendanceRemoteDataSource
 import com.emotionstorage.domain.common.DataState
 import com.emotionstorage.domain.model.AttendanceSummary
@@ -12,13 +13,19 @@ import javax.inject.Inject
 
 class AttendanceRepositoryImpl @Inject constructor(
     private val remote: AttendanceRemoteDataSource,
+    private val local: AttendanceClaimLocalDataSource,
 ) : AttendanceRepository {
     override fun getAttendanceSummary(): Flow<DataState<AttendanceSummary>> =
         flow {
             try {
+                val today = LocalDate.now()
+                val rewardDate = today.format(DateTimeFormatter.ISO_DATE)
+                val lastClaim = local.getLastClaimDate()
+                val claimedByLocal = (lastClaim == rewardDate)
+
                 val entity = remote.getAttendanceStatus()
                 val streak = entity.streak.toInt()
-                val alreadyClaimedToday = entity.isAttendedToday
+                val alreadyClaimedToday = entity.isAttendedToday || claimedByLocal
 
                 val days = buildDays(streak, alreadyClaimedToday)
                 val canClaimToday = !alreadyClaimedToday
@@ -35,10 +42,21 @@ class AttendanceRepositoryImpl @Inject constructor(
                 val today = LocalDate.now()
                 val rewardDate = today.format(DateTimeFormatter.ISO_DATE)
 
+                if (local.getLastClaimDate() == rewardDate) {
+                    val entity = remote.getAttendanceStatus()
+                    val streak = entity.streak.toInt()
+                    val alreadyClaimedToday = true
+                    val days = buildDays(streak, alreadyClaimedToday)
+                    emit(DataState.Success(AttendanceSummary(days, canClaimToday = false)))
+                    return@flow
+                }
+
                 val entity = remote.requestAttendance(rewardDate)
+
+                local.setLastClaimDate(rewardDate)
+
                 val streak = entity.streak.toInt()
                 val alreadyClaimedToday = entity.isAttendedToday
-
                 val days = buildDays(streak, alreadyClaimedToday)
                 val canClaimToday = !alreadyClaimedToday
 


### PR DESCRIPTION
## Related Issue
- Issue #216 

## 작업 상세 내용
- 로컬에 출석 보상 수령 날짜 저장하여 중복 호출 방지 강화
-> QA-27 항목의 출석 보상이 2회 등장한 Issue는 세션이 만료되며(404 에러) 테스트용 사용자 정보가 응답으로 내려오게 될 때 그 계정의 출석 보상 수령 Modal이 등장한 것으로 확인

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * 출석 체크의 로컬 추적을 도입해 같은 날 중복 청구를 방지합니다.
  * 앱이 기기에 마지막 출석 날짜를 저장해 오늘 이미 청구했는지를 즉시 반영합니다.
  * 출석 요약과 청구 동작이 로컬 상태를 우선 고려해 즉시 업데이트됩니다.

* **Chores**
  * 로컬 데이터 연동 및 바인딩이 추가되어 오프라인 상황과 응답성이 개선되었습니다.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->