### PR TITLE
Feat/check new timecpasule 최근 3주 내 타임캡슐 도착한 경우, 캘린더탭 N 뱃지 표시

### DIFF
--- a/core/remote/src/main/java/com/emotionstorage/remote/dataSourceImpl/ChatWSDataSourceImpl.kt
+++ b/core/remote/src/main/java/com/emotionstorage/remote/dataSourceImpl/ChatWSDataSourceImpl.kt
@@ -30,7 +30,6 @@ class ChatWSDataSourceImpl @Inject constructor(
     private val json: Json,
     private val getAccessTokenUseCase: GetAccessTokenUseCase,
 ) : ChatWSDataSource {
-
     private val client =
         StompClient(
             webSocketClient =

--- a/core/remote/src/main/java/com/emotionstorage/remote/dataSourceImpl/ChatWSDataSourceImpl.kt
+++ b/core/remote/src/main/java/com/emotionstorage/remote/dataSourceImpl/ChatWSDataSourceImpl.kt
@@ -27,9 +27,9 @@ import javax.inject.Inject
 private const val WS_URL = "ws://${BuildConfig.MOOI_DEV_SERVER_URL}ws"
 
 class ChatWSDataSourceImpl @Inject constructor(
+    private val json: Json,
     private val getAccessTokenUseCase: GetAccessTokenUseCase,
 ) : ChatWSDataSource {
-    private val json = Json { ignoreUnknownKeys = true }
 
     private val client =
         StompClient(

--- a/core/remote/src/main/java/com/emotionstorage/remote/dataSourceImpl/DailyReportRemoteDataSourceImpl.kt
+++ b/core/remote/src/main/java/com/emotionstorage/remote/dataSourceImpl/DailyReportRemoteDataSourceImpl.kt
@@ -4,6 +4,7 @@ import com.emotionstorage.data.dataSource.remote.DailyReportRemoteDataSource
 import com.emotionstorage.data.model.DailyReportEntity
 import com.emotionstorage.remote.api.DailyReportApiService
 import com.emotionstorage.remote.modelMapper.DailyReportResponseMapper
+import com.orhanobut.logger.Logger
 import java.time.LocalDate
 import java.time.format.DateTimeFormatter
 import javax.inject.Inject
@@ -18,11 +19,13 @@ class DailyReportRemoteDataSourceImpl @Inject constructor(
                     date = date.format(DateTimeFormatter.ofPattern("yyyy-MM-dd")),
                 )
             if (response.data != null) {
-                return DailyReportResponseMapper.toData(response.data!!)
+                return DailyReportResponseMapper.toData(response.data)
             } else {
+                Logger.e("getDailyReport response data is empty, $response")
                 throw Exception("getDailyReport response data is empty, $response")
             }
         } catch (e: Exception) {
+            Logger.e("getDailyReport error: $e")
             throw Exception("getDailyReport api fail", e)
         }
     }
@@ -32,11 +35,13 @@ class DailyReportRemoteDataSourceImpl @Inject constructor(
             val response =
                 apiService.getDailyReport(id)
             if (response.data != null) {
-                return DailyReportResponseMapper.toData(response.data!!)
+                return DailyReportResponseMapper.toData(response.data)
             } else {
+                Logger.e("getDailyReport response data is empty, $response")
                 throw Exception("getDailyReport response data is empty, $response")
             }
         } catch (e: Exception) {
+            Logger.e("getDailyReport api error: $e")
             throw Exception("getDailyReport api fail", e)
         }
     }

--- a/core/remote/src/main/java/com/emotionstorage/remote/di/RetrofitModule.kt
+++ b/core/remote/src/main/java/com/emotionstorage/remote/di/RetrofitModule.kt
@@ -71,7 +71,7 @@ object RetrofitModule {
 
     @Singleton
     @Provides
-    fun provideFailResponseHeaderInterceptor() = FailResponseInterceptor()
+    fun provideFailResponseHeaderInterceptor(json: Json) = FailResponseInterceptor(json)
 
     @Singleton
     @Provides

--- a/core/remote/src/main/java/com/emotionstorage/remote/interceptor/FailResponseInterceptor.kt
+++ b/core/remote/src/main/java/com/emotionstorage/remote/interceptor/FailResponseInterceptor.kt
@@ -10,9 +10,8 @@ import java.time.LocalDateTime
 import javax.inject.Inject
 
 class FailResponseInterceptor @Inject constructor(
-    private val json: Json
+    private val json: Json,
 ) : Interceptor {
-
     override fun intercept(chain: Interceptor.Chain): Response {
         val httpRequest = chain.request()
         val httpResponse = chain.proceed(httpRequest)

--- a/core/remote/src/main/java/com/emotionstorage/remote/interceptor/FailResponseInterceptor.kt
+++ b/core/remote/src/main/java/com/emotionstorage/remote/interceptor/FailResponseInterceptor.kt
@@ -9,8 +9,9 @@ import okhttp3.Response
 import java.time.LocalDateTime
 import javax.inject.Inject
 
-class FailResponseInterceptor @Inject constructor() : Interceptor {
-    private val json = Json { ignoreUnknownKeys = true }
+class FailResponseInterceptor @Inject constructor(
+    private val json: Json
+) : Interceptor {
 
     override fun intercept(chain: Interceptor.Chain): Response {
         val httpRequest = chain.request()

--- a/data/src/main/java/com/emotionstorage/data/repoImpl/DailyReportRepositoryImpl.kt
+++ b/data/src/main/java/com/emotionstorage/data/repoImpl/DailyReportRepositoryImpl.kt
@@ -20,6 +20,7 @@ class DailyReportRepositoryImpl @Inject constructor(
                 )
             }
         } catch (e: Exception) {
+            Napier.e("getDailyReport error: $e")
             DataState.Error(e)
         }
 
@@ -31,6 +32,7 @@ class DailyReportRepositoryImpl @Inject constructor(
                 )
             }
         } catch (e: Exception) {
+            Napier.e("getDailyReport error: $e")
             DataState.Error(e)
         }
 
@@ -38,7 +40,7 @@ class DailyReportRepositoryImpl @Inject constructor(
         try {
             return remoteDataSource.openDailyReport(id)
         } catch (e: Exception) {
-            Napier.e("DailyReportRepositoryImpl: openDailyReport error: $e")
+            Napier.e("openDailyReport error: $e")
             return false
         }
     }

--- a/domain/src/main/java/com/emotionstorage/domain/useCase/timeCapsule/GetHasNewTimeCapsuleUseCase.kt
+++ b/domain/src/main/java/com/emotionstorage/domain/useCase/timeCapsule/GetHasNewTimeCapsuleUseCase.kt
@@ -1,0 +1,21 @@
+package com.emotionstorage.domain.useCase.timeCapsule
+
+import com.emotionstorage.domain.common.DataState
+import com.emotionstorage.domain.useCase.home.GetHomeUseCase
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.map
+import javax.inject.Inject
+
+class GetHasNewTimeCapsuleUseCase @Inject constructor(
+    private val getHomeUseCase: GetHomeUseCase
+) {
+    suspend operator fun invoke(): Flow<DataState<Boolean>> {
+        return getHomeUseCase().map {
+            if (it is DataState.Success) {
+                DataState.Success(it.data.hasNewTimeCapsule)
+            } else {
+                it
+            } as DataState<Boolean>
+        }
+    }
+}

--- a/domain/src/main/java/com/emotionstorage/domain/useCase/timeCapsule/GetHasNewTimeCapsuleUseCase.kt
+++ b/domain/src/main/java/com/emotionstorage/domain/useCase/timeCapsule/GetHasNewTimeCapsuleUseCase.kt
@@ -7,15 +7,14 @@ import kotlinx.coroutines.flow.map
 import javax.inject.Inject
 
 class GetHasNewTimeCapsuleUseCase @Inject constructor(
-    private val getHomeUseCase: GetHomeUseCase
+    private val getHomeUseCase: GetHomeUseCase,
 ) {
-    suspend operator fun invoke(): Flow<DataState<Boolean>> {
-        return getHomeUseCase().map {
+    suspend operator fun invoke(): Flow<DataState<Boolean>> =
+        getHomeUseCase().map {
             if (it is DataState.Success) {
                 DataState.Success(it.data.hasNewTimeCapsule)
             } else {
                 it
             } as DataState<Boolean>
         }
-    }
 }

--- a/domain/src/main/java/com/emotionstorage/domain/useCase/timeCapsule/GetPagedArrivedTimeCapsulesUseCase.kt
+++ b/domain/src/main/java/com/emotionstorage/domain/useCase/timeCapsule/GetPagedArrivedTimeCapsulesUseCase.kt
@@ -12,11 +12,8 @@ class GetPagedArrivedTimeCapsulesUseCase @Inject constructor(
 ) {
     operator fun invoke(): Flow<PagingData<TimeCapsule>> =
         timeCapsuleRepository.getPagedTimeCapsules(
-            startDate = LocalDate.now(),
-            endDate = LocalDate.now().plusWeeks(3),
-            // test code:
-//            startDate = LocalDate.of(2024,1,1),
-//            endDate = LocalDate.of(2024,1,31),
+            startDate = LocalDate.now().minusWeeks(3),
+            endDate = LocalDate.now(),
             status = "arrived",
         )
 }

--- a/feat/daily-report/src/main/java/com/emotionstorage/daily_report/presentation/DailyReportDetailViewModel.kt
+++ b/feat/daily-report/src/main/java/com/emotionstorage/daily_report/presentation/DailyReportDetailViewModel.kt
@@ -76,7 +76,7 @@ class DailyReportDetailViewModel @Inject constructor(
         subIntent {
             try {
                 openDailyReport.invoke(id)
-            }catch (e: Exception){
+            } catch (e: Exception) {
                 Logger.e("openDailyReport onError: $e")
                 postSideEffect(DailyReportDetailSideEffect.ShowDailyReportError)
             }

--- a/feat/daily-report/src/main/java/com/emotionstorage/daily_report/presentation/DailyReportDetailViewModel.kt
+++ b/feat/daily-report/src/main/java/com/emotionstorage/daily_report/presentation/DailyReportDetailViewModel.kt
@@ -4,6 +4,7 @@ import androidx.lifecycle.ViewModel
 import com.emotionstorage.domain.model.DailyReport
 import com.emotionstorage.domain.useCase.dailyReport.GetDailyReportByIdUseCase
 import com.emotionstorage.domain.useCase.dailyReport.OpenDailyReportUseCase
+import com.orhanobut.logger.Logger
 import dagger.hilt.android.lifecycle.HiltViewModel
 import org.orbitmvi.orbit.Container
 import org.orbitmvi.orbit.ContainerHost
@@ -59,6 +60,7 @@ class DailyReportDetailViewModel @Inject constructor(
                     if (!it.isOpen) openNewReport(id)
                 },
                 onError = { throwable, _ ->
+                    Logger.e("getDailyReportById onError: $throwable")
                     reduce {
                         state.copy(
                             isLoading = false,
@@ -72,6 +74,11 @@ class DailyReportDetailViewModel @Inject constructor(
 
     private suspend fun openNewReport(id: Long) =
         subIntent {
-            openDailyReport.invoke(id)
+            try {
+                openDailyReport.invoke(id)
+            }catch (e: Exception){
+                Logger.e("openDailyReport onError: $e")
+                postSideEffect(DailyReportDetailSideEffect.ShowDailyReportError)
+            }
         }
 }

--- a/feat/time-capsule/src/main/java/com/emotionstorage/time_capsule/presentation/CalendarViewModel.kt
+++ b/feat/time-capsule/src/main/java/com/emotionstorage/time_capsule/presentation/CalendarViewModel.kt
@@ -8,6 +8,7 @@ import androidx.paging.map
 import com.emotionstorage.domain.common.collectDataState
 import com.emotionstorage.domain.useCase.dailyReport.GetDailyReportOfDateUseCase
 import com.emotionstorage.domain.useCase.key.GetKeyCountUseCase
+import com.emotionstorage.domain.useCase.timeCapsule.GetHasNewTimeCapsuleUseCase
 import com.emotionstorage.domain.useCase.timeCapsule.GetPagedTimeCapsulesOfDateUseCase
 import com.emotionstorage.domain.useCase.timeCapsule.GetTimeCapsuleDatesUseCase
 import com.emotionstorage.time_capsule.ui.model.TimeCapsuleItemState
@@ -26,6 +27,7 @@ import javax.inject.Inject
 
 data class CalendarState(
     val keyCount: Int? = null,
+    val hsNewTimeCapsule: Boolean = false,
     // calendar states
     val calendarYearMonth: YearMonth = YearMonth.now(),
     val calendarTimeCapsuleDates: List<LocalDate> = emptyList(),
@@ -62,6 +64,7 @@ sealed class CalendarSideEffect {
 @HiltViewModel
 class CalendarViewModel @Inject constructor(
     private val getKeyCount: GetKeyCountUseCase,
+    private val getHasNewTimeCapsule: GetHasNewTimeCapsuleUseCase,
     private val getTimeCapsuleDates: GetTimeCapsuleDatesUseCase,
     private val getTimeCapsulesOfDate: GetPagedTimeCapsulesOfDateUseCase,
     private val getDailyReportOfDate: GetDailyReportOfDateUseCase,
@@ -93,6 +96,7 @@ class CalendarViewModel @Inject constructor(
     private fun handleInitiate() =
         intent {
             initKeyCount()
+            initHasNewTimeCapsule()
             handleSelectCalendarYearMonth(YearMonth.from(LocalDate.now()))
         }
 
@@ -108,6 +112,24 @@ class CalendarViewModel @Inject constructor(
                     Logger.e("handleInitKey error: $throwable")
                     reduce {
                         state.copy(keyCount = null)
+                    }
+                },
+            )
+        }
+
+    private suspend fun initHasNewTimeCapsule() =
+        subIntent {
+            collectDataState(
+                flow = getHasNewTimeCapsule(),
+                onSuccess = { data ->
+                    reduce {
+                        state.copy(hsNewTimeCapsule = data)
+                    }
+                },
+                onError = { throwable, code, data ->
+                    Logger.e("handleInitHasNewTimeCapsule error: $throwable")
+                    reduce {
+                        state.copy(hsNewTimeCapsule = false)
                     }
                 },
             )

--- a/feat/time-capsule/src/main/java/com/emotionstorage/time_capsule/presentation/CalendarViewModel.kt
+++ b/feat/time-capsule/src/main/java/com/emotionstorage/time_capsule/presentation/CalendarViewModel.kt
@@ -27,7 +27,7 @@ import javax.inject.Inject
 
 data class CalendarState(
     val keyCount: Int? = null,
-    val hsNewTimeCapsule: Boolean = false,
+    val hasNewTimeCapsule: Boolean = false,
     // calendar states
     val calendarYearMonth: YearMonth = YearMonth.now(),
     val calendarTimeCapsuleDates: List<LocalDate> = emptyList(),
@@ -123,13 +123,13 @@ class CalendarViewModel @Inject constructor(
                 flow = getHasNewTimeCapsule(),
                 onSuccess = { data ->
                     reduce {
-                        state.copy(hsNewTimeCapsule = data)
+                        state.copy(hasNewTimeCapsule = data)
                     }
                 },
                 onError = { throwable, code, data ->
                     Logger.e("handleInitHasNewTimeCapsule error: $throwable")
                     reduce {
-                        state.copy(hsNewTimeCapsule = false)
+                        state.copy(hasNewTimeCapsule = false)
                     }
                 },
             )

--- a/feat/time-capsule/src/main/java/com/emotionstorage/time_capsule/ui/CalendarScreen.kt
+++ b/feat/time-capsule/src/main/java/com/emotionstorage/time_capsule/ui/CalendarScreen.kt
@@ -58,6 +58,7 @@ import com.emotionstorage.ui.component.bottomSheet.YearMonthPickerBottomSheet
 import com.emotionstorage.time_capsule.ui.component.TimeCapsuleCalendar
 import com.emotionstorage.time_capsule.ui.component.TimeCapsuleBottomSheet
 import com.emotionstorage.ui.R
+import com.emotionstorage.ui.annotation.PreviewScreenRatios
 import com.emotionstorage.ui.component.toast.AppSnackbarHost
 import com.emotionstorage.ui.component.IconWithCount
 import com.emotionstorage.ui.component.toast.AppSnackbarController
@@ -255,8 +256,7 @@ private fun StatelessCalendarScreen(
                     CalendarNavButton(
                         modifier = Modifier.weight(1f),
                         label = "도착한 타임캡슐",
-                        // todo: add new arrived timecapsules logic
-                        showNewBadge = true,
+                        showNewBadge = state.hsNewTimeCapsule,
                         onClick = navToArrived,
                     )
 
@@ -426,7 +426,7 @@ private fun CalendarTodayButton(
     }
 }
 
-@PreviewScreenSizes
+@PreviewScreenRatios
 @Composable
 private fun CalendarScreenPreview() {
     MooiTheme {

--- a/feat/time-capsule/src/main/java/com/emotionstorage/time_capsule/ui/CalendarScreen.kt
+++ b/feat/time-capsule/src/main/java/com/emotionstorage/time_capsule/ui/CalendarScreen.kt
@@ -255,7 +255,7 @@ private fun StatelessCalendarScreen(
                     CalendarNavButton(
                         modifier = Modifier.weight(1f),
                         label = "도착한 타임캡슐",
-                        showNewBadge = state.hsNewTimeCapsule,
+                        showNewBadge = state.hasNewTimeCapsule,
                         onClick = navToArrived,
                     )
 

--- a/feat/time-capsule/src/main/java/com/emotionstorage/time_capsule/ui/CalendarScreen.kt
+++ b/feat/time-capsule/src/main/java/com/emotionstorage/time_capsule/ui/CalendarScreen.kt
@@ -38,7 +38,6 @@ import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.text.SpanStyle
 import androidx.compose.ui.text.buildAnnotatedString
 import androidx.compose.ui.text.withStyle
-import androidx.compose.ui.tooling.preview.PreviewScreenSizes
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import androidx.hilt.navigation.compose.hiltViewModel


### PR DESCRIPTION
## Related Issue
- Closes #208

## 작업 상세 내용
- 최근 3주 내 타임캡슐 도착한 경우, 캘린더캡 N 뱃지 표시 로직 추가
- 최근 3주 내 도착한 타임캡슐 조회 api - 날짜 범위 쿼리 파라미터 값 고침
- 기타
  - 일일리포트 상세 조회 에러 로그 추가
  - 네트워크 계층 Json - Hilt로 주입받도록 리팩토링


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **New Features**
  * 도착한 타임캡슐의 신규 여부를 자동으로 감지해 배지로 표시합니다.

* **Bug Fixes**
  * 응답 데이터 매핑의 null 안전성이 개선되었습니다.
  * 여러 오류 경로에 로깅이 추가되어 문제 추적이 용이해졌습니다.

* **Changes**
  * 도착한 타임캡슐 조회 기간이 이전보다 앞당겨진 범위로 조정되었습니다.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->