### PR TITLE
[Fix] 토스트 메세지 노출

### DIFF
--- a/feat/my/src/main/java/com/emotionstorage/my/ui/myPage/MyPageScreen.kt
+++ b/feat/my/src/main/java/com/emotionstorage/my/ui/myPage/MyPageScreen.kt
@@ -1,6 +1,8 @@
 package com.emotionstorage.my.ui.myPage
 
 import android.content.ClipData
+import android.os.Build
+import android.widget.Toast
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
@@ -27,6 +29,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.ClipEntry
 import androidx.compose.ui.platform.LocalClipboard
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
@@ -157,6 +160,7 @@ private fun StatelessMyPageScreen(
 //    navToNotificationSetting: () -> Unit = {},
 ) {
     val clipboardManager = LocalClipboard.current
+    val context = LocalContext.current
     val scope = rememberCoroutineScope()
 
     Scaffold(
@@ -211,6 +215,12 @@ private fun StatelessMyPageScreen(
                                     ),
                                 ),
                             )
+
+                            if (Build.VERSION.SDK_INT < Build.VERSION_CODES.TIRAMISU) {
+                                Toast
+                                    .makeText(context, "이메일이 복사되었습니다.", Toast.LENGTH_SHORT)
+                                    .show()
+                            }
                         }
                     },
                     onTermsAndPrivacyClick = navToTermsAndPrivacy,

--- a/feat/my/src/main/java/com/emotionstorage/my/ui/myPage/component/MenuSection.kt
+++ b/feat/my/src/main/java/com/emotionstorage/my/ui/myPage/component/MenuSection.kt
@@ -158,7 +158,8 @@ fun EmailMenuItem(
         modifier =
             Modifier
                 .padding(horizontal = 18.dp, vertical = 16.dp)
-                .fillMaxWidth(),
+                .fillMaxWidth()
+                .clickable(onClick = onCopyClick),
         verticalAlignment = Alignment.CenterVertically,
     ) {
         Column(
@@ -185,10 +186,7 @@ fun EmailMenuItem(
             modifier =
                 Modifier
                     .align(Alignment.Bottom)
-                    .offset(x = 0.dp, y = (-6).dp)
-                    .clickable {
-                        onCopyClick()
-                    },
+                    .offset(x = 0.dp, y = (-6).dp),
         )
     }
 }

--- a/feat/time-capsule-detail/src/main/java/com/emotionstorage/time_capsule_detail/presentation/TimeCapsuleDetailViewModel.kt
+++ b/feat/time-capsule-detail/src/main/java/com/emotionstorage/time_capsule_detail/presentation/TimeCapsuleDetailViewModel.kt
@@ -5,18 +5,17 @@ import com.emotionstorage.domain.common.DataState
 import com.emotionstorage.domain.common.collectDataState
 import com.emotionstorage.domain.model.TimeCapsule
 import com.emotionstorage.domain.useCase.key.GetKeyCountUseCase
-import com.emotionstorage.domain.useCase.timeCapsule.GetTimeCapsuleByIdUseCase
 import com.emotionstorage.domain.useCase.key.GetRequiredKeyCountUseCase
 import com.emotionstorage.domain.useCase.timeCapsule.DeleteTimeCapsuleUseCase
+import com.emotionstorage.domain.useCase.timeCapsule.GetTimeCapsuleByIdUseCase
 import com.emotionstorage.domain.useCase.timeCapsule.OpenTimeCapsuleUseCase
 import com.emotionstorage.domain.useCase.timeCapsule.SaveTimeCapsuleNoteUseCase
 import com.emotionstorage.time_capsule_detail.presentation.TimeCapsuleDetailAction.Init
 import com.emotionstorage.time_capsule_detail.presentation.TimeCapsuleDetailAction.OnDeleteTimeCapsule
 import com.emotionstorage.time_capsule_detail.presentation.TimeCapsuleDetailAction.OnNoteChanged
-import com.emotionstorage.time_capsule_detail.presentation.TimeCapsuleDetailAction.OnUnlockTimeCapsule
 import com.emotionstorage.time_capsule_detail.presentation.TimeCapsuleDetailAction.OnSaveNote
+import com.emotionstorage.time_capsule_detail.presentation.TimeCapsuleDetailAction.OnUnlockTimeCapsule
 import com.emotionstorage.time_capsule_detail.presentation.TimeCapsuleDetailSideEffect.DeleteTimeCapsuleSuccess
-import com.emotionstorage.time_capsule_detail.presentation.TimeCapsuleDetailSideEffect.SaveChangesBeforeExitSuccess
 import com.emotionstorage.time_capsule_detail.presentation.TimeCapsuleDetailSideEffect.ShowUnlockModal
 import com.emotionstorage.time_capsule_detail.presentation.TimeCapsuleDetailSideEffect.ShowUnlockModal.UnlockModalState
 import com.orhanobut.logger.Logger
@@ -75,6 +74,10 @@ sealed class TimeCapsuleDetailSideEffect {
             val openAt: LocalDateTime = LocalDateTime.now(),
         )
     }
+
+    data class ShowChangeSavedToast(
+        val exitAfterSave: Boolean,
+    ) : TimeCapsuleDetailSideEffect()
 }
 
 @HiltViewModel
@@ -234,9 +237,10 @@ class TimeCapsuleDetailViewModel @Inject constructor(
                         isNoteChanged = false,
                     )
                 }
-                if (exitAfterSave) {
-                    postSideEffect(SaveChangesBeforeExitSuccess)
-                }
+
+                postSideEffect(
+                    TimeCapsuleDetailSideEffect.ShowChangeSavedToast(exitAfterSave = exitAfterSave),
+                )
             },
             onError = { throwable, code, data ->
                 Logger.e("saveNote error: $throwable")

--- a/feat/time-capsule-detail/src/main/java/com/emotionstorage/time_capsule_detail/presentation/TimeCapsuleDetailViewModel.kt
+++ b/feat/time-capsule-detail/src/main/java/com/emotionstorage/time_capsule_detail/presentation/TimeCapsuleDetailViewModel.kt
@@ -63,8 +63,6 @@ sealed class TimeCapsuleDetailSideEffect {
 
     object DeleteTimeCapsuleSuccess : TimeCapsuleDetailSideEffect()
 
-    object SaveChangesBeforeExitSuccess : TimeCapsuleDetailSideEffect()
-
     data class ShowUnlockModal(
         val modalState: UnlockModalState,
     ) : TimeCapsuleDetailSideEffect() {
@@ -75,7 +73,7 @@ sealed class TimeCapsuleDetailSideEffect {
         )
     }
 
-    data class ShowChangeSavedToast(
+    data class SaveChangesSuccess(
         val exitAfterSave: Boolean,
     ) : TimeCapsuleDetailSideEffect()
 }
@@ -239,7 +237,7 @@ class TimeCapsuleDetailViewModel @Inject constructor(
                 }
 
                 postSideEffect(
-                    TimeCapsuleDetailSideEffect.ShowChangeSavedToast(exitAfterSave = exitAfterSave),
+                    TimeCapsuleDetailSideEffect.SaveChangesSuccess(exitAfterSave = exitAfterSave),
                 )
             },
             onError = { throwable, code, data ->

--- a/feat/time-capsule-detail/src/main/java/com/emotionstorage/time_capsule_detail/ui/TimeCapsuleDetailScreen.kt
+++ b/feat/time-capsule-detail/src/main/java/com/emotionstorage/time_capsule_detail/ui/TimeCapsuleDetailScreen.kt
@@ -29,11 +29,10 @@ import com.emotionstorage.time_capsule_detail.presentation.TimeCapsuleDetailActi
 import com.emotionstorage.time_capsule_detail.presentation.TimeCapsuleDetailAction.OnNoteChanged
 import com.emotionstorage.time_capsule_detail.presentation.TimeCapsuleDetailAction.OnSaveNote
 import com.emotionstorage.time_capsule_detail.presentation.TimeCapsuleDetailAction.OnUnlockTimeCapsule
-import com.emotionstorage.time_capsule_detail.presentation.TimeCapsuleDetailSideEffect.ShowChangeSavedToast
+import com.emotionstorage.time_capsule_detail.presentation.TimeCapsuleDetailSideEffect.SaveChangesSuccess
 import com.emotionstorage.time_capsule_detail.presentation.TimeCapsuleDetailSideEffect.DeleteTimeCapsuleSuccess
 import com.emotionstorage.time_capsule_detail.presentation.TimeCapsuleDetailSideEffect.GetTimeCapsuleFail
 import com.emotionstorage.time_capsule_detail.presentation.TimeCapsuleDetailSideEffect.OpenTimeCapsuleFail
-import com.emotionstorage.time_capsule_detail.presentation.TimeCapsuleDetailSideEffect.SaveChangesBeforeExitSuccess
 import com.emotionstorage.time_capsule_detail.presentation.TimeCapsuleDetailSideEffect.ShowUnlockModal
 import com.emotionstorage.time_capsule_detail.presentation.TimeCapsuleDetailSideEffect.ShowUnlockModal.UnlockModalState
 import com.emotionstorage.time_capsule_detail.presentation.TimeCapsuleDetailState
@@ -128,10 +127,6 @@ fun TimeCapsuleDetailScreen(
                     navToBack()
                 }
 
-                is SaveChangesBeforeExitSuccess -> {
-                    navToBack()
-                }
-
                 is DeleteTimeCapsuleSuccess -> {
                     navToBack()
                 }
@@ -141,7 +136,7 @@ fun TimeCapsuleDetailScreen(
                     setModalState(TimeCapsuleDetailModal.UNLOCK)
                 }
 
-                is ShowChangeSavedToast -> {
+                is SaveChangesSuccess -> {
                     setModalState(TimeCapsuleDetailModal.NONE)
 
                     snackState.currentSnackbarData?.dismiss()

--- a/feat/time-capsule-detail/src/main/java/com/emotionstorage/time_capsule_detail/ui/TimeCapsuleDetailScreen.kt
+++ b/feat/time-capsule-detail/src/main/java/com/emotionstorage/time_capsule_detail/ui/TimeCapsuleDetailScreen.kt
@@ -21,18 +21,18 @@ import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import com.emotionstorage.domain.model.TimeCapsule
-import com.emotionstorage.time_capsule_detail.presentation.TimeCapsuleDetailState
 import com.emotionstorage.time_capsule_detail.presentation.TimeCapsuleDetailAction
 import com.emotionstorage.time_capsule_detail.presentation.TimeCapsuleDetailAction.OnDeleteTimeCapsule
 import com.emotionstorage.time_capsule_detail.presentation.TimeCapsuleDetailAction.OnNoteChanged
-import com.emotionstorage.time_capsule_detail.presentation.TimeCapsuleDetailAction.OnUnlockTimeCapsule
 import com.emotionstorage.time_capsule_detail.presentation.TimeCapsuleDetailAction.OnSaveNote
+import com.emotionstorage.time_capsule_detail.presentation.TimeCapsuleDetailAction.OnUnlockTimeCapsule
 import com.emotionstorage.time_capsule_detail.presentation.TimeCapsuleDetailSideEffect.DeleteTimeCapsuleSuccess
 import com.emotionstorage.time_capsule_detail.presentation.TimeCapsuleDetailSideEffect.GetTimeCapsuleFail
 import com.emotionstorage.time_capsule_detail.presentation.TimeCapsuleDetailSideEffect.OpenTimeCapsuleFail
 import com.emotionstorage.time_capsule_detail.presentation.TimeCapsuleDetailSideEffect.SaveChangesBeforeExitSuccess
 import com.emotionstorage.time_capsule_detail.presentation.TimeCapsuleDetailSideEffect.ShowUnlockModal
 import com.emotionstorage.time_capsule_detail.presentation.TimeCapsuleDetailSideEffect.ShowUnlockModal.UnlockModalState
+import com.emotionstorage.time_capsule_detail.presentation.TimeCapsuleDetailState
 import com.emotionstorage.time_capsule_detail.presentation.TimeCapsuleDetailViewModel
 import com.emotionstorage.time_capsule_detail.presentation.ToggleSingleFavoriteAction
 import com.emotionstorage.time_capsule_detail.presentation.ToggleSingleFavoriteSideEffect.ShowFavoriteFailToast
@@ -44,19 +44,19 @@ import com.emotionstorage.time_capsule_detail.ui.component.TimeCapsuleDetailActi
 import com.emotionstorage.time_capsule_detail.ui.component.TimeCapsuleEmotionComments
 import com.emotionstorage.time_capsule_detail.ui.component.TimeCapsuleNote
 import com.emotionstorage.time_capsule_detail.ui.component.TimeCapsuleSummary
-import com.emotionstorage.time_capsule_detail.ui.modal.SaveChangesModal
 import com.emotionstorage.time_capsule_detail.ui.modal.DeleteTimeCapsuleModal
 import com.emotionstorage.time_capsule_detail.ui.modal.ExitTempTimeCapsuleModal
+import com.emotionstorage.time_capsule_detail.ui.modal.SaveChangesModal
 import com.emotionstorage.time_capsule_detail.ui.modal.TimeCapsuleExpiredModal
 import com.emotionstorage.time_capsule_detail.ui.modal.UnlockTimeCapsuleModal
 import com.emotionstorage.ui.R
 import com.emotionstorage.ui.annotation.PreviewScreenRatios
 import com.emotionstorage.ui.component.HideKeyboard
-import com.emotionstorage.ui.component.toast.AppSnackbarHost
-import com.emotionstorage.ui.component.loading.LoadingScreen
-import com.emotionstorage.ui.component.button.RoundedToggleButton
 import com.emotionstorage.ui.component.appBar.TopAppBar
+import com.emotionstorage.ui.component.button.RoundedToggleButton
+import com.emotionstorage.ui.component.loading.LoadingScreen
 import com.emotionstorage.ui.component.toast.AppSnackbarController
+import com.emotionstorage.ui.component.toast.AppSnackbarHost
 import com.emotionstorage.ui.theme.MooiTheme
 import java.time.LocalDateTime
 import java.time.format.DateTimeFormatter
@@ -367,6 +367,7 @@ private fun StatelessTimeCapsuleDetailScreen(
                     expireAt = state.timeCapsule.expireAt,
                     status = state.timeCapsule.status,
                     isNewTimeCapsule = isNewTimeCapsule,
+                    saveNoteEnabled = state.isNoteChanged,
                     onSaveTimeCapsule = {
                         navToSaveTimeCapsule()
                     },

--- a/feat/time-capsule-detail/src/main/java/com/emotionstorage/time_capsule_detail/ui/TimeCapsuleDetailScreen.kt
+++ b/feat/time-capsule-detail/src/main/java/com/emotionstorage/time_capsule_detail/ui/TimeCapsuleDetailScreen.kt
@@ -1,7 +1,9 @@
 package com.emotionstorage.time_capsule_detail.ui
 
+import android.view.Gravity
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
@@ -15,6 +17,7 @@ import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.blur
 import androidx.compose.ui.platform.LocalContext
@@ -26,6 +29,7 @@ import com.emotionstorage.time_capsule_detail.presentation.TimeCapsuleDetailActi
 import com.emotionstorage.time_capsule_detail.presentation.TimeCapsuleDetailAction.OnNoteChanged
 import com.emotionstorage.time_capsule_detail.presentation.TimeCapsuleDetailAction.OnSaveNote
 import com.emotionstorage.time_capsule_detail.presentation.TimeCapsuleDetailAction.OnUnlockTimeCapsule
+import com.emotionstorage.time_capsule_detail.presentation.TimeCapsuleDetailSideEffect.ShowChangeSavedToast
 import com.emotionstorage.time_capsule_detail.presentation.TimeCapsuleDetailSideEffect.DeleteTimeCapsuleSuccess
 import com.emotionstorage.time_capsule_detail.presentation.TimeCapsuleDetailSideEffect.GetTimeCapsuleFail
 import com.emotionstorage.time_capsule_detail.presentation.TimeCapsuleDetailSideEffect.OpenTimeCapsuleFail
@@ -57,7 +61,9 @@ import com.emotionstorage.ui.component.button.RoundedToggleButton
 import com.emotionstorage.ui.component.loading.LoadingScreen
 import com.emotionstorage.ui.component.toast.AppSnackbarController
 import com.emotionstorage.ui.component.toast.AppSnackbarHost
+import com.emotionstorage.ui.component.toast.Toast
 import com.emotionstorage.ui.theme.MooiTheme
+import kotlinx.coroutines.launch
 import java.time.LocalDateTime
 import java.time.format.DateTimeFormatter
 
@@ -96,6 +102,8 @@ fun TimeCapsuleDetailScreen(
             mutableStateOf(UnlockModalState())
         }
 
+    val scope = rememberCoroutineScope()
+
     // init states
     LaunchedEffect(id) {
         viewModel.onAction(TimeCapsuleDetailAction.Init(id))
@@ -131,6 +139,28 @@ fun TimeCapsuleDetailScreen(
                 is ShowUnlockModal -> {
                     setUnlockModalState(sideEffect.modalState)
                     setModalState(TimeCapsuleDetailModal.UNLOCK)
+                }
+
+                is ShowChangeSavedToast -> {
+                    setModalState(TimeCapsuleDetailModal.NONE)
+
+                    snackState.currentSnackbarData?.dismiss()
+
+                    scope.launch {
+                        snackbarController.showSnackbar(
+                            message = "나의 회고 일기가 저장되었어요.",
+                            iconResId = R.drawable.ic_success_filled,
+                        )
+                    }
+
+                    scope.launch {
+                        kotlinx.coroutines.delay(2000)
+                        snackState.currentSnackbarData?.dismiss()
+
+                        if (sideEffect.exitAfterSave) {
+                            navToBack()
+                        }
+                    }
                 }
             }
         }
@@ -242,7 +272,6 @@ fun TimeCapsuleDetailScreen(
                 },
                 onSave = {
                     viewModel.onAction(OnSaveNote(id, true))
-                    navToBack()
                 },
                 onDismiss = {
                     navToBack()
@@ -326,7 +355,14 @@ private fun StatelessTimeCapsuleDetailScreen(
                 AppSnackbarHost(
                     hostState = snackState,
                     customDataFlow = snackbarController?.currentData,
-                )
+                    gravity = Gravity.BOTTOM,
+                ) { message, iconId ->
+                    Toast(
+                        message = message,
+                        iconId = iconId,
+                        paddingValues = PaddingValues(horizontal = 25.dp, vertical = 16.dp),
+                    )
+                }
             },
         ) { innerPadding ->
             Column(

--- a/feat/time-capsule-detail/src/main/java/com/emotionstorage/time_capsule_detail/ui/component/TimeCapsuleDetailActionButtons.kt
+++ b/feat/time-capsule-detail/src/main/java/com/emotionstorage/time_capsule_detail/ui/component/TimeCapsuleDetailActionButtons.kt
@@ -37,6 +37,7 @@ fun TimeCapsuleDetailActionButtons(
     modifier: Modifier = Modifier,
     isNewTimeCapsule: Boolean = false,
     expireAt: LocalDateTime? = null,
+    saveNoteEnabled: Boolean = false,
 ) {
     Column(
         modifier = modifier.fillMaxWidth(),
@@ -55,6 +56,7 @@ fun TimeCapsuleDetailActionButtons(
             SaveNoteButton(
                 modifier = Modifier.padding(top = 85.dp),
                 onSaveNote = onSaveMindNote,
+                enabled = saveNoteEnabled,
             )
         }
         // delete button
@@ -119,6 +121,7 @@ private fun SaveTimeCapsuleButton(
 @Composable
 private fun SaveNoteButton(
     modifier: Modifier = Modifier,
+    enabled: Boolean = false,
     onSaveNote: () -> Unit = {},
 ) {
     Column(
@@ -128,6 +131,7 @@ private fun SaveNoteButton(
         CtaButton(
             modifier = Modifier.fillMaxWidth(),
             labelString = "변경사항 저장하기",
+            enabled = enabled,
             onClick = {
                 onSaveNote()
             },


### PR DESCRIPTION
## Related Issue
- Issue #218 

## 작업 상세 내용
- 문의하기 클릭 시 Android 12버전 이하에서는 토스트 "클립보드에 복사되었습니다" 시스템 메세지가 등장하지 않아 버전 별 분기로 내용 추가 (QA-35)
- 타임캡슐 나의 회고일기 작성 및 수정 후 저장할 때 사용자에게 Toast 메세지 제공 (QA-41)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **버그 수정**
  * 클립보드 복사 후 OS 버전에 따른 토스트 표시 동작 개선(신규 OS에서는 토스트 미표시)
  * 이메일 복사 영역을 행 전체로 확대하여 클릭성 향상

* **개선 사항**
  * 저장 완료 시 토스트 기반 피드백 추가 및 일정 지연 후 자동 화면 전환 지원
  * 변경사항 저장 확인 모달 추가로 흐름 명확화
  * 저장 버튼 활성화를 변경 여부에 따라 동적으로 제어

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->