### PR TITLE
Hot fix/daily report response 일일리포트 api 응답 처리 & 로딩 로직 고침

### DIFF
--- a/core/common/src/main/java/com/emotionstorage/common/SerializerUtil.kt
+++ b/core/common/src/main/java/com/emotionstorage/common/SerializerUtil.kt
@@ -8,22 +8,21 @@ import kotlinx.serialization.encoding.Encoder
 import java.time.LocalDate
 import java.time.LocalDateTime
 import java.time.format.DateTimeFormatter
+import java.time.format.DateTimeFormatter.ISO_LOCAL_DATE
 
 object LocalDateSerializer : KSerializer<LocalDate> {
-    private val formatter = DateTimeFormatter.ofPattern("yyyy/MM/dd")
-
     override val descriptor: SerialDescriptor =
         PrimitiveSerialDescriptor("LocalDate", PrimitiveKind.STRING)
 
     override fun deserialize(decoder: Decoder): LocalDate {
-        return LocalDate.parse(decoder.decodeString(), formatter) // Deserialize from "yyyy-MM-dd"
+        return LocalDate.parse(decoder.decodeString(), ISO_LOCAL_DATE) // Deserialize from "yyyy-MM-dd"
     }
 
     override fun serialize(
         encoder: Encoder,
         value: LocalDate,
     ) {
-        encoder.encodeString(value.format(formatter)) // Serialize to "yyyy-MM-dd"
+        encoder.encodeString(value.format(ISO_LOCAL_DATE)) // Serialize to "yyyy-MM-dd"
     }
 }
 

--- a/core/common/src/main/java/com/emotionstorage/common/SerializerUtil.kt
+++ b/core/common/src/main/java/com/emotionstorage/common/SerializerUtil.kt
@@ -7,7 +7,6 @@ import kotlinx.serialization.encoding.Decoder
 import kotlinx.serialization.encoding.Encoder
 import java.time.LocalDate
 import java.time.LocalDateTime
-import java.time.format.DateTimeFormatter
 import java.time.format.DateTimeFormatter.ISO_LOCAL_DATE
 
 object LocalDateSerializer : KSerializer<LocalDate> {

--- a/core/remote/src/main/java/com/emotionstorage/remote/modelMapper/DailyReportResponseMapper.kt
+++ b/core/remote/src/main/java/com/emotionstorage/remote/modelMapper/DailyReportResponseMapper.kt
@@ -19,7 +19,7 @@ internal object DailyReportResponseMapper {
                         // filter emotion changes with valid time format - HH:mm
                         try {
                             val (h, m) = it.time.split(":")
-                            if (h.isNullOrBlank() || h.toInt() !in (0..24)) false
+                            if (h.isBlank() || h.toInt() !in (0..24)) false
                             if (m.isNotBlank() || m.toInt() !in (0..60)) false
                             true
                         } catch (e: Exception) {
@@ -29,15 +29,15 @@ internal object DailyReportResponseMapper {
                     }.filter {
                         // filter emotion changes with valid label format - label (description)
                         try {
-                            val (label, desc) = it.label.split("(", ")")
-                            !(label.isNullOrBlank() || desc.isNullOrBlank())
+                            val (label, desc) = it.label.split("(", ")").dropLast(1)
+                            !(label.isBlank() || desc.isBlank())
                         } catch (e: Exception) {
-                            Logger.e("Emotion log time format error: ${it.time}, $e")
+                            Logger.e("Emotion log label format error: ${it.time}, $e")
                             false
                         }
                     }.map {
                         val (h, m) = it.time.split(":")
-                        val (label, desc) = it.label.split("(", ")")
+                        val (label, desc) = it.label.split("(", ")").dropLast(1)
 
                         DailyReportEntity.EmotionLog(
                             emotion = label.trim(),

--- a/core/remote/src/main/java/com/emotionstorage/remote/modelMapper/DailyReportResponseMapper.kt
+++ b/core/remote/src/main/java/com/emotionstorage/remote/modelMapper/DailyReportResponseMapper.kt
@@ -40,7 +40,7 @@ internal object DailyReportResponseMapper {
                         DailyReportEntity.EmotionLog(
                             emotion = label.trim(),
                             description = desc.trim(),
-                            time = response.createdAt.withHour(h.toInt()).withMinute(m.toInt()),
+                            time = response.createdAt.withHour(h.trim().toInt()).withMinute(m.trim().toInt()),
                         )
                     },
             stressScore = response.stressIndex,

--- a/core/remote/src/main/java/com/emotionstorage/remote/modelMapper/DailyReportResponseMapper.kt
+++ b/core/remote/src/main/java/com/emotionstorage/remote/modelMapper/DailyReportResponseMapper.kt
@@ -16,23 +16,21 @@ internal object DailyReportResponseMapper {
                 response
                     .emotionChanges
                     .filter {
-                        // filter emotion changes with valid time format - HH:mm
                         try {
-                            val (h, m) = it.time.split(":")
-                            if (h.isBlank() || h.toInt() !in (0..24)) false
-                            if (m.isNotBlank() || m.toInt() !in (0..60)) false
-                            true
+                            // hh:mm
+                            val regex = "^(0\\d|1\\d|2[0-4])\\s*:\\s*(0\\d|[1-5]\\d|60)$".toRegex()
+                            regex.matches(it.time)
                         } catch (e: Exception) {
-                            Logger.e("Emotion log time format error: ${it.time}, $e")
+                            Logger.e("emotionChanges time parsing error: ${it.time}, $e")
                             false
                         }
                     }.filter {
-                        // filter emotion changes with valid label format - label (description)
                         try {
-                            val (label, desc) = it.label.split("(", ")").dropLast(1)
-                            !(label.isBlank() || desc.isBlank())
+                            // label (description)
+                            val regex = "^[^()]+ \\([^()]+\\)$".toRegex()
+                            regex.matches(it.label)
                         } catch (e: Exception) {
-                            Logger.e("Emotion log label format error: ${it.time}, $e")
+                            Logger.e("label parsing error: ${it.label}, $e")
                             false
                         }
                     }.map {

--- a/core/remote/src/main/java/com/emotionstorage/remote/modelMapper/DailyReportResponseMapper.kt
+++ b/core/remote/src/main/java/com/emotionstorage/remote/modelMapper/DailyReportResponseMapper.kt
@@ -3,7 +3,6 @@ package com.emotionstorage.remote.modelMapper
 import com.emotionstorage.data.model.DailyReportEntity
 import com.emotionstorage.remote.response.dailyReport.GetDailyReportResponse
 import com.orhanobut.logger.Logger
-import java.time.LocalDate
 
 internal object DailyReportResponseMapper {
     fun toData(response: GetDailyReportResponse): DailyReportEntity =
@@ -27,8 +26,7 @@ internal object DailyReportResponseMapper {
                             Logger.e("Emotion log time format error: ${it.time}, $e")
                             false
                         }
-                    }
-                    .filter {
+                    }.filter {
                         // filter emotion changes with valid label format - label (description)
                         try {
                             val (label, desc) = it.label.split("(", ")")

--- a/core/remote/src/main/java/com/emotionstorage/remote/modelMapper/DailyReportResponseMapper.kt
+++ b/core/remote/src/main/java/com/emotionstorage/remote/modelMapper/DailyReportResponseMapper.kt
@@ -3,19 +3,21 @@ package com.emotionstorage.remote.modelMapper
 import com.emotionstorage.data.model.DailyReportEntity
 import com.emotionstorage.remote.response.dailyReport.GetDailyReportResponse
 import com.orhanobut.logger.Logger
+import java.time.LocalDate
 
 internal object DailyReportResponseMapper {
     fun toData(response: GetDailyReportResponse): DailyReportEntity =
         DailyReportEntity(
             id = response.id,
-            isOpen = response.isOpen,
+            date = response.historyDate,
+            isOpen = response.opened,
             summaries = response.summaries,
             keywords = response.keywords,
             emotionLogs =
                 response
                     .emotionChanges
                     .filter {
-                        // filter emotion changes with valid time format
+                        // filter emotion changes with valid time format - HH:mm
                         try {
                             val (h, m) = it.time.split(":")
                             if (h.isNullOrBlank() || h.toInt() !in (0..24)) false
@@ -25,12 +27,23 @@ internal object DailyReportResponseMapper {
                             Logger.e("Emotion log time format error: ${it.time}, $e")
                             false
                         }
+                    }
+                    .filter {
+                        // filter emotion changes with valid label format - label (description)
+                        try {
+                            val (label, desc) = it.label.split("(", ")")
+                            !(label.isNullOrBlank() || desc.isNullOrBlank())
+                        } catch (e: Exception) {
+                            Logger.e("Emotion log time format error: ${it.time}, $e")
+                            false
+                        }
                     }.map {
                         val (h, m) = it.time.split(":")
+                        val (label, desc) = it.label.split("(", ")")
 
                         DailyReportEntity.EmotionLog(
-                            emotion = it.label,
-                            description = it.description,
+                            emotion = label.trim(),
+                            description = desc.trim(),
                             time = response.createdAt.withHour(h.toInt()).withMinute(m.toInt()),
                         )
                     },

--- a/core/remote/src/main/java/com/emotionstorage/remote/response/dailyReport/GetDailyReportResponse.kt
+++ b/core/remote/src/main/java/com/emotionstorage/remote/response/dailyReport/GetDailyReportResponse.kt
@@ -1,13 +1,17 @@
 package com.emotionstorage.remote.response.dailyReport
 
+import com.emotionstorage.common.LocalDateSerializer
 import com.emotionstorage.common.LocalDateTimeSerializer
 import kotlinx.serialization.Serializable
+import java.time.LocalDate
 import java.time.LocalDateTime
 
 @Serializable
 data class GetDailyReportResponse(
     val id: Long,
-    val isOpen: Boolean,
+    val opened: Boolean,
+    @Serializable(with = LocalDateSerializer::class)
+    val historyDate: LocalDate,
     @Serializable(with = LocalDateTimeSerializer::class)
     val createdAt: LocalDateTime,
     @Serializable(with = LocalDateTimeSerializer::class)
@@ -24,6 +28,5 @@ data class GetDailyReportResponse(
         // HH:mm
         val time: String,
         val label: String,
-        val description: String,
     )
 }

--- a/data/src/main/java/com/emotionstorage/data/model/DailyReportEntity.kt
+++ b/data/src/main/java/com/emotionstorage/data/model/DailyReportEntity.kt
@@ -1,9 +1,11 @@
 package com.emotionstorage.data.model
 
+import java.time.LocalDate
 import java.time.LocalDateTime
 
 data class DailyReportEntity(
     val id: Long,
+    val date: LocalDate,
     val isOpen: Boolean = false,
     val summaries: List<String> = emptyList(),
     val keywords: List<String> = emptyList(),

--- a/data/src/main/java/com/emotionstorage/data/modelMapper/DailyReportMapper.kt
+++ b/data/src/main/java/com/emotionstorage/data/modelMapper/DailyReportMapper.kt
@@ -7,6 +7,7 @@ internal object DailyReportMapper {
     fun toDomain(entity: DailyReportEntity): DailyReport =
         DailyReport(
             id = entity.id,
+            date = entity.date,
             isOpen = entity.isOpen,
             summaries = entity.summaries,
             keywords = entity.keywords,

--- a/domain/src/main/java/com/emotionstorage/domain/model/DailyReport.kt
+++ b/domain/src/main/java/com/emotionstorage/domain/model/DailyReport.kt
@@ -1,9 +1,11 @@
 package com.emotionstorage.domain.model
 
+import java.time.LocalDate
 import java.time.LocalDateTime
 
 data class DailyReport(
     val id: Long,
+    val date: LocalDate,
     val isOpen: Boolean = false,
     val summaries: List<String> = emptyList(),
     val keywords: List<String> = emptyList(),

--- a/feat/daily-report/src/main/java/com/emotionstorage/daily_report/presentation/DailyReportDetailViewModel.kt
+++ b/feat/daily-report/src/main/java/com/emotionstorage/daily_report/presentation/DailyReportDetailViewModel.kt
@@ -48,16 +48,13 @@ class DailyReportDetailViewModel @Inject constructor(
     private fun handleInit(id: Long) =
         intent {
             getDailyReportById(id).handle(
-                onLoading = {
-                    reduce {
-                        state.copy(isLoading = it)
-                    }
-                },
                 onSuccess = {
                     reduce {
-                        state.copy(dailyReport = it)
+                        state.copy(isLoading = false, dailyReport = it)
                     }
-                    if (!it.isOpen) openNewReport(id)
+                    if (!it.isOpen) {
+                        openNewDailyReport(id)
+                    }
                 },
                 onError = { throwable, _ ->
                     Logger.e("getDailyReportById onError: $throwable")
@@ -72,10 +69,11 @@ class DailyReportDetailViewModel @Inject constructor(
             )
         }
 
-    private suspend fun openNewReport(id: Long) =
+    private suspend fun openNewDailyReport(id: Long) =
         subIntent {
             try {
-                openDailyReport.invoke(id)
+                Logger.d("openDailyReport id: $id")
+                openDailyReport(id)
             } catch (e: Exception) {
                 Logger.e("openDailyReport onError: $e")
                 postSideEffect(DailyReportDetailSideEffect.ShowDailyReportError)

--- a/feat/daily-report/src/main/java/com/emotionstorage/daily_report/ui/DailyReportDetailScreen.kt
+++ b/feat/daily-report/src/main/java/com/emotionstorage/daily_report/ui/DailyReportDetailScreen.kt
@@ -37,6 +37,7 @@ import com.emotionstorage.daily_report.ui.component.DailyReportKeywords
 import com.emotionstorage.daily_report.ui.component.DailyReportSummaries
 import com.emotionstorage.domain.model.DailyReport
 import com.emotionstorage.domain.model.DailyReport.EmotionLog
+import com.emotionstorage.ui.annotation.PreviewScreenRatios
 import com.emotionstorage.ui.component.modal.Modal
 import com.emotionstorage.ui.component.loading.LoadingScreen
 import com.emotionstorage.ui.component.appBar.TopAppBar
@@ -51,15 +52,13 @@ fun DailyReportDetailScreen(
     navToBack: () -> Unit = {},
 ) {
     val state = viewModel.container.stateFlow.collectAsState()
+    val (showErrorModal, setShowErrorModal) = remember { mutableStateOf(false) }
+
     LaunchedEffect(id) {
         viewModel.onAction(DailyReportDetailAction.Init(id))
     }
 
-    val (showErrorModal, setShowErrorModal) =
-        remember {
-            mutableStateOf(false)
-        }
-    LaunchedEffect("init") {
+    LaunchedEffect(Unit) {
         viewModel.container.sideEffectFlow.collect {
             when (it) {
                 DailyReportDetailSideEffect.ShowDailyReportError -> {
@@ -165,7 +164,8 @@ private fun StatelessDailyReportDetailScreen(
                             .background(
                                 color = Color(0xFF0E0C12).copy(alpha = 0.5f),
                                 shape = RoundedCornerShape(50),
-                            ).padding(vertical = 15.dp, horizontal = 38.dp),
+                            )
+                            .padding(vertical = 15.dp, horizontal = 38.dp),
                     verticalArrangement = Arrangement.spacedBy(2.dp),
                     horizontalAlignment = Alignment.CenterHorizontally,
                 ) {
@@ -198,7 +198,7 @@ private fun StatelessDailyReportDetailScreen(
     }
 }
 
-@Preview
+@PreviewScreenRatios
 @Composable
 private fun DailyReportDetailScreenPreview() {
     MooiTheme {
@@ -262,7 +262,7 @@ private fun DailyReportDetailScreenPreview() {
     }
 }
 
-@Preview
+@PreviewScreenRatios
 @Composable
 private fun DailyReportDetailScreenPreview2() {
     MooiTheme {
@@ -282,8 +282,8 @@ private fun DailyReportDetailScreenPreview2() {
                         listOf(
                             EmotionLog(
                                 emoji = "\uD83D\uDE20",
-                                label = "짜증남",
-                                description = "친구의 지각",
+                                label = "짜증남짜증남",
+                                description = "친구의 지각 친구의 지각 친구의 지각",
                                 time = LocalDateTime.now(),
                             ),
                         ),

--- a/feat/daily-report/src/main/java/com/emotionstorage/daily_report/ui/DailyReportDetailScreen.kt
+++ b/feat/daily-report/src/main/java/com/emotionstorage/daily_report/ui/DailyReportDetailScreen.kt
@@ -23,7 +23,6 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
-import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import androidx.hilt.navigation.compose.hiltViewModel
@@ -42,6 +41,7 @@ import com.emotionstorage.ui.component.modal.Modal
 import com.emotionstorage.ui.component.loading.LoadingScreen
 import com.emotionstorage.ui.component.appBar.TopAppBar
 import com.emotionstorage.ui.theme.MooiTheme
+import java.time.LocalDate
 import java.time.LocalDateTime
 
 @Composable
@@ -108,8 +108,7 @@ private fun StatelessDailyReportDetailScreen(
             TopAppBar(
                 title =
                     dailyReport
-                        .createdAt
-                        .toLocalDate()
+                        .date
                         .toKorDateWithWeekDay(),
                 showBackButton = true,
                 onBackClick = navToBack,
@@ -164,8 +163,7 @@ private fun StatelessDailyReportDetailScreen(
                             .background(
                                 color = Color(0xFF0E0C12).copy(alpha = 0.5f),
                                 shape = RoundedCornerShape(50),
-                            )
-                            .padding(vertical = 15.dp, horizontal = 38.dp),
+                            ).padding(vertical = 15.dp, horizontal = 38.dp),
                     verticalArrangement = Arrangement.spacedBy(2.dp),
                     horizontalAlignment = Alignment.CenterHorizontally,
                 ) {
@@ -206,6 +204,7 @@ private fun DailyReportDetailScreenPreview() {
             dailyReport =
                 DailyReport(
                     id = 123L,
+                    date = LocalDate.now(),
                     summaries =
                         listOf(
                             "아침에 출근길에 친구와 같이 출근하기로 했는데 친구가 지각해놓고 미안하단말을 하지 않아 기분이 좋지 않았어요.",
@@ -270,6 +269,7 @@ private fun DailyReportDetailScreenPreview2() {
             dailyReport =
                 DailyReport(
                     id = 123L,
+                    date = LocalDate.now(),
                     summaries =
                         listOf(
                             "아침에 출근길에 친구와 같이 출근하기로 했는데 친구가 지각해놓고 미안하단말을 하지 않아 기분이 좋지 않았어요.",


### PR DESCRIPTION
## Related Issue
- Closes #228 

## 작업 상세 내용
- 일일리포트 상세 조회 api 응답 파싱 오류 해결
  - LocalDateSerializer 날짜 포맷 ISO_LOCAL_DATE로 고침
  - 일일리포트 상세 label -> label & description 파싱 로직 추가
- 일일리포트 model 날짜 추가 
  - historyDate: 일일리포트 날짜
  - createdAt: 일일리포트 생성 시점 (마지막 대화 시작 25시간 후)
- 일일리포트 화면 진입 시, 무한 로딩 이슈 해결
 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 일일 리포트 오류 시 에러 모달 표시 추가
  * 보고서가 닫힌 경우 자동으로 새 일일 리포트 생성/오픈 동작 추가
  * 도메인 및 모델에 날짜(date) 필드 추가 및 화면 제목에 날짜 사용

* **버그 수정**
  * 감정 로그 시간 포맷 검증 강화 및 시간 파싱 오류 필터링
  * 레이블 형식 검증 강화(정해진 패턴만 허용) 및 관련 오류 로깅 정비

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->