### PR TITLE
fix: set time capsule detail note to nullable (QA-44)

### DIFF
--- a/core/remote/src/main/java/com/emotionstorage/remote/modelMapper/TimeCapsuleResponseMapper.kt
+++ b/core/remote/src/main/java/com/emotionstorage/remote/modelMapper/TimeCapsuleResponseMapper.kt
@@ -46,7 +46,7 @@ internal object TimeCapsuleResponseMapper {
                     )
                 },
             comments = response.comments,
-            note = response.note,
+            note = response.note ?: "",
             historyDate = response.historyDate,
             createdAt = response.createdAt,
             openAt = response.openAt,

--- a/core/remote/src/main/java/com/emotionstorage/remote/response/timeCapsule/GetTimeCapsuleDetailResponse.kt
+++ b/core/remote/src/main/java/com/emotionstorage/remote/response/timeCapsule/GetTimeCapsuleDetailResponse.kt
@@ -22,7 +22,7 @@ data class GetTimeCapsuleDetailResponse(
     val summary: String,
     val emotionDetails: List<EmotionDetail>,
     val comments: List<String>,
-    val note: String,
+    val note: String? = null,
 ) {
     @Serializable
     data class EmotionDetail(


### PR DESCRIPTION
## Related Issue
- Closes #227 

## 작업 상세 내용
- 타임캡슐 상세 api 응답 note 값 null 일 경우, 파싱 오류로 타임캡슐 상세 진입 불가했음
-> api response의 note nullable 타입으로 변경 & null인 경우 빈 문자열로 매핑

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **버그 수정**
  * 타임 캡슐의 노트 필드 처리 안정성을 개선했습니다. 빈 노트 값에 대한 예외 처리가 추가되어 더욱 견고한 데이터 처리가 가능해졌습니다.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->