### PR TITLE
Feat/notifications api 알림 내역 화면 api 연동, 상세 화면 이동, 접근 불가 에러 토스트

### DIFF
--- a/app/src/main/java/com/emotionstorage/emotionstorage/ui/AppNavHost.kt
+++ b/app/src/main/java/com/emotionstorage/emotionstorage/ui/AppNavHost.kt
@@ -327,9 +327,9 @@ internal fun AppNavHost(
                 navToTermsAndPrivacy = {
                     navController.navigate(AppDestination.TermsAndPrivacy)
                 },
-               /* navToNotificationSetting = {
-                    navController.navigate(AppDestination.NotificationSetting)
-                },*/
+                /* navToNotificationSetting = {
+                     navController.navigate(AppDestination.NotificationSetting)
+                 },*/
             )
         }
 
@@ -451,9 +451,9 @@ internal fun AppNavHost(
                 navToLogin = {
                     navController.navigateWithClearStack(AppDestination.Login)
                 },
-              /*  navToNotificationSetting = {
-                    navController.navigateWithClearStack(AppDestination.NotificationSetting)
-                },*/
+                /*  navToNotificationSetting = {
+                      navController.navigateWithClearStack(AppDestination.NotificationSetting)
+                  },*/
             )
         }
 
@@ -491,6 +491,12 @@ internal fun AppNavHost(
 
         composable<AppDestination.PushNotification> {
             PushNotificationScreen(
+                navToDailyReportDetail = { id ->
+                    navController.navigate(AppDestination.DailyReportDetail(id))
+                },
+                navToTimeCapsuleDetail = { id ->
+                    navController.navigate(AppDestination.TimeCapsuleDetail(id, isNewTimeCapsule = false))
+                },
                 navToBack = {
                     navController.popBackStack()
                 },

--- a/core/common/src/main/java/com/emotionstorage/common/LocalDateTimeUtil.kt
+++ b/core/common/src/main/java/com/emotionstorage/common/LocalDateTimeUtil.kt
@@ -3,6 +3,7 @@ package com.emotionstorage.common
 import java.time.LocalDateTime
 import java.time.ZoneId
 import java.time.format.DateTimeFormatter
+import java.time.temporal.ChronoUnit
 
 fun LocalDateTime.formatToKorDateTime(
     datePattern: String = "yyyy.MM.dd",
@@ -17,3 +18,17 @@ fun LocalDateTime.formatToKorTime(addDoubleSpacing: Boolean = false): String =
 
 fun LocalDateTime.toEpochMillis(zoneId: String = "Asia/Seoul"): Long =
     this.atZone(ZoneId.of(zoneId)).toInstant().toEpochMilli()
+
+fun LocalDateTime.timeAgo(): String {
+    val now = LocalDateTime.now()
+
+    val minutes = ChronoUnit.MINUTES.between(this, now)
+    val hours = ChronoUnit.HOURS.between(this, now)
+    val days = ChronoUnit.DAYS.between(this, now)
+
+    return when {
+        minutes < 60 -> "${minutes}분 전"
+        hours < 24 -> "${hours}시간 전"
+        else -> "${days}일 전"
+    }
+}

--- a/core/remote/src/main/java/com/emotionstorage/remote/api/NotificationApiService.kt
+++ b/core/remote/src/main/java/com/emotionstorage/remote/api/NotificationApiService.kt
@@ -1,0 +1,14 @@
+package com.emotionstorage.remote.api
+
+import com.emotionstorage.remote.response.ResponseDto
+import com.emotionstorage.remote.response.notification.GetNotificationsResponse
+import retrofit2.http.PATCH
+import retrofit2.http.Query
+
+interface NotificationApiService {
+    @PATCH("api/v1/notifications")
+    suspend fun getNotifications(
+        @Query("page") page: Int,
+        @Query("limit") limit: Int,
+    ): ResponseDto<GetNotificationsResponse>
+}

--- a/core/remote/src/main/java/com/emotionstorage/remote/api/NotificationApiService.kt
+++ b/core/remote/src/main/java/com/emotionstorage/remote/api/NotificationApiService.kt
@@ -2,11 +2,11 @@ package com.emotionstorage.remote.api
 
 import com.emotionstorage.remote.response.ResponseDto
 import com.emotionstorage.remote.response.notification.GetNotificationsResponse
-import retrofit2.http.PATCH
+import retrofit2.http.GET
 import retrofit2.http.Query
 
 interface NotificationApiService {
-    @PATCH("api/v1/notifications")
+    @GET("api/v1/notifications")
     suspend fun getNotifications(
         @Query("page") page: Int,
         @Query("limit") limit: Int,

--- a/core/remote/src/main/java/com/emotionstorage/remote/dataSourceImpl/NotificationRemoteDataSourceImpl.kt
+++ b/core/remote/src/main/java/com/emotionstorage/remote/dataSourceImpl/NotificationRemoteDataSourceImpl.kt
@@ -1,0 +1,24 @@
+package com.emotionstorage.remote.dataSourceImpl
+
+import com.emotionstorage.data.dataSource.remote.NotificationRemoteDataSource
+import com.emotionstorage.data.model.NotificationEntity
+import com.emotionstorage.remote.api.NotificationApiService
+import com.emotionstorage.remote.modelMapper.NotificationResponseMapper
+import javax.inject.Inject
+
+class NotificationRemoteDataSourceImpl @Inject constructor(
+    private val apiService: NotificationApiService
+) : NotificationRemoteDataSource {
+
+    override suspend fun getNotifications(
+        page: Int,
+        limit: Int
+    ): List<NotificationEntity> = try {
+        val response = apiService.getNotifications(page, limit)
+        response.data?.let{
+            NotificationResponseMapper.toData(it)
+        } ?: throw Exception("getNotifications response data is empty, $response")
+    } catch (e: Exception) {
+        throw Exception("getNotifications api fail, ${e.message}", e)
+    }
+}

--- a/core/remote/src/main/java/com/emotionstorage/remote/dataSourceImpl/NotificationRemoteDataSourceImpl.kt
+++ b/core/remote/src/main/java/com/emotionstorage/remote/dataSourceImpl/NotificationRemoteDataSourceImpl.kt
@@ -7,18 +7,18 @@ import com.emotionstorage.remote.modelMapper.NotificationResponseMapper
 import javax.inject.Inject
 
 class NotificationRemoteDataSourceImpl @Inject constructor(
-    private val apiService: NotificationApiService
+    private val apiService: NotificationApiService,
 ) : NotificationRemoteDataSource {
-
     override suspend fun getNotifications(
         page: Int,
-        limit: Int
-    ): List<NotificationEntity> = try {
-        val response = apiService.getNotifications(page, limit)
-        response.data?.let{
-            NotificationResponseMapper.toData(it)
-        } ?: throw Exception("getNotifications response data is empty, $response")
-    } catch (e: Exception) {
-        throw Exception("getNotifications api fail, ${e.message}", e)
-    }
+        limit: Int,
+    ): List<NotificationEntity> =
+        try {
+            val response = apiService.getNotifications(page, limit)
+            response.data?.let {
+                NotificationResponseMapper.toData(it)
+            } ?: throw Exception("getNotifications response data is empty, $response")
+        } catch (e: Exception) {
+            throw Exception("getNotifications api fail, ${e.message}", e)
+        }
 }

--- a/core/remote/src/main/java/com/emotionstorage/remote/di/ApiServiceModule.kt
+++ b/core/remote/src/main/java/com/emotionstorage/remote/di/ApiServiceModule.kt
@@ -7,6 +7,7 @@ import com.emotionstorage.remote.api.DailyReportApiService
 import com.emotionstorage.remote.api.FcmApiService
 import com.emotionstorage.remote.api.HomeApiService
 import com.emotionstorage.remote.api.MyPageApiService
+import com.emotionstorage.remote.api.NotificationApiService
 import com.emotionstorage.remote.api.TimeCapsuleApiService
 import com.emotionstorage.remote.api.UserApiService
 import dagger.Module
@@ -30,6 +31,11 @@ object ApiServiceModule {
     @Singleton
     @Provides
     fun provideFcmApiService(retrofit: Retrofit): FcmApiService = retrofit.create(FcmApiService::class.java)
+
+    @Singleton
+    @Provides
+    fun provideNotificationApiService(retrofit: Retrofit): NotificationApiService =
+        retrofit.create(NotificationApiService::class.java)
 
     @Singleton
     @Provides

--- a/core/remote/src/main/java/com/emotionstorage/remote/di/RemoteDataSourceModule.kt
+++ b/core/remote/src/main/java/com/emotionstorage/remote/di/RemoteDataSourceModule.kt
@@ -10,6 +10,7 @@ import com.emotionstorage.data.dataSource.remote.GoogleRemoteDataSource
 import com.emotionstorage.data.dataSource.remote.HomeRemoteDataSource
 import com.emotionstorage.data.dataSource.remote.KakaoRemoteDataSource
 import com.emotionstorage.data.dataSource.remote.MyPageRemoteDataSource
+import com.emotionstorage.data.dataSource.remote.NotificationRemoteDataSource
 import com.emotionstorage.data.dataSource.remote.NotificationSettingRemoteDataSource
 import com.emotionstorage.data.dataSource.remote.ReissueRemoteDataSource
 import com.emotionstorage.data.dataSource.remote.TimeCapsuleRemoteDataSource
@@ -24,6 +25,7 @@ import com.emotionstorage.remote.dataSourceImpl.GoogleRemoteDataSourceImpl
 import com.emotionstorage.remote.dataSourceImpl.HomeRemoteDataSourceImpl
 import com.emotionstorage.remote.dataSourceImpl.KakaoRemoteDataSourceImpl
 import com.emotionstorage.remote.dataSourceImpl.MyPageRemoteDataSourceImpl
+import com.emotionstorage.remote.dataSourceImpl.NotificationRemoteDataSourceImpl
 import com.emotionstorage.remote.dataSourceImpl.NotificationSettingRemoteDataSourceImpl
 import com.emotionstorage.remote.dataSourceImpl.ReissueRemoteDataSourceImpl
 import com.emotionstorage.remote.dataSourceImpl.TimeCapsuleRemoteDataSourceImpl
@@ -60,6 +62,11 @@ abstract class RemoteDataSourceModule {
     @Binds
     @Singleton
     abstract fun bindFcmRemoteDataSource(impl: FcmRemoteDataSourceImpl): FcmRemoteDataSource
+
+
+    @Binds
+    @Singleton
+    abstract fun bindNotificationRemoteDataSource(impl: NotificationRemoteDataSourceImpl): NotificationRemoteDataSource
 
     @Binds
     @Singleton

--- a/core/remote/src/main/java/com/emotionstorage/remote/di/RemoteDataSourceModule.kt
+++ b/core/remote/src/main/java/com/emotionstorage/remote/di/RemoteDataSourceModule.kt
@@ -63,7 +63,6 @@ abstract class RemoteDataSourceModule {
     @Singleton
     abstract fun bindFcmRemoteDataSource(impl: FcmRemoteDataSourceImpl): FcmRemoteDataSource
 
-
     @Binds
     @Singleton
     abstract fun bindNotificationRemoteDataSource(impl: NotificationRemoteDataSourceImpl): NotificationRemoteDataSource

--- a/core/remote/src/main/java/com/emotionstorage/remote/modelMapper/NotificationResponseMapper.kt
+++ b/core/remote/src/main/java/com/emotionstorage/remote/modelMapper/NotificationResponseMapper.kt
@@ -1,0 +1,26 @@
+package com.emotionstorage.remote.modelMapper
+
+import com.emotionstorage.data.model.NotificationEntity
+import com.emotionstorage.data.model.NotificationEntity.PageData
+import com.emotionstorage.remote.response.notification.GetNotificationsResponse
+
+
+internal object NotificationResponseMapper {
+    fun toData(response: GetNotificationsResponse): List<NotificationEntity> =
+        response.notifications.map { it ->
+            NotificationEntity(
+                id = it.notificationId,
+                title = it.notification.title,
+                body = it.notification.body,
+                isRead = it.isRead,
+                arrivedAt = it.arrivedAt,
+                type = it.data.type,
+                targetId = it.data.targetId,
+                pageData =
+                    PageData(
+                        page = response.pagination.page,
+                        hasNextPage = response.pagination.page < response.pagination.totalPage,
+                    ),
+            )
+        }
+}

--- a/core/remote/src/main/java/com/emotionstorage/remote/modelMapper/NotificationResponseMapper.kt
+++ b/core/remote/src/main/java/com/emotionstorage/remote/modelMapper/NotificationResponseMapper.kt
@@ -4,7 +4,6 @@ import com.emotionstorage.data.model.NotificationEntity
 import com.emotionstorage.data.model.NotificationEntity.PageData
 import com.emotionstorage.remote.response.notification.GetNotificationsResponse
 
-
 internal object NotificationResponseMapper {
     fun toData(response: GetNotificationsResponse): List<NotificationEntity> =
         response.notifications.map { it ->

--- a/core/remote/src/main/java/com/emotionstorage/remote/response/notification/GetNotificationsResponse.kt
+++ b/core/remote/src/main/java/com/emotionstorage/remote/response/notification/GetNotificationsResponse.kt
@@ -35,7 +35,7 @@ data class GetNotificationsResponse(
         @Serializable
         data class NotificationData(
             val type: String,
-            val targetId: Long? = null
+            val targetId: Long? = null,
         )
     }
 }

--- a/core/remote/src/main/java/com/emotionstorage/remote/response/notification/GetNotificationsResponse.kt
+++ b/core/remote/src/main/java/com/emotionstorage/remote/response/notification/GetNotificationsResponse.kt
@@ -1,0 +1,41 @@
+package com.emotionstorage.remote.response.notification
+
+import com.emotionstorage.common.LocalDateTimeSerializer
+import kotlinx.serialization.Serializable
+import java.time.LocalDateTime
+
+@Serializable
+data class GetNotificationsResponse(
+    val pagination: PaginationInfo,
+    val totalNotifications: Int,
+    val notifications: List<Notification>,
+) {
+    @Serializable
+    data class PaginationInfo(
+        val page: Int,
+        val limit: Int,
+        val totalPage: Int,
+    )
+
+    @Serializable
+    data class Notification(
+        val notificationId: Long,
+        val notification: NotificationInfo,
+        val isRead: Boolean,
+        @Serializable(with = LocalDateTimeSerializer::class)
+        val arrivedAt: LocalDateTime,
+        val data: NotificationData,
+    ) {
+        @Serializable
+        data class NotificationInfo(
+            val title: String,
+            val body: String,
+        )
+
+        @Serializable
+        data class NotificationData(
+            val type: String,
+            val targetId: Long? = null
+        )
+    }
+}

--- a/data/src/main/java/com/emotionstorage/data/dataSource/remote/NotificationRemoteDataSource.kt
+++ b/data/src/main/java/com/emotionstorage/data/dataSource/remote/NotificationRemoteDataSource.kt
@@ -1,0 +1,7 @@
+package com.emotionstorage.data.dataSource.remote
+
+import com.emotionstorage.data.model.NotificationEntity
+
+interface NotificationRemoteDataSource {
+    suspend fun getNotifications(page: Int, limit: Int): List<NotificationEntity>
+}

--- a/data/src/main/java/com/emotionstorage/data/dataSource/remote/NotificationRemoteDataSource.kt
+++ b/data/src/main/java/com/emotionstorage/data/dataSource/remote/NotificationRemoteDataSource.kt
@@ -3,5 +3,8 @@ package com.emotionstorage.data.dataSource.remote
 import com.emotionstorage.data.model.NotificationEntity
 
 interface NotificationRemoteDataSource {
-    suspend fun getNotifications(page: Int, limit: Int): List<NotificationEntity>
+    suspend fun getNotifications(
+        page: Int,
+        limit: Int,
+    ): List<NotificationEntity>
 }

--- a/data/src/main/java/com/emotionstorage/data/dataSource/remote/TimeCapsuleRemoteDataSource.kt
+++ b/data/src/main/java/com/emotionstorage/data/dataSource/remote/TimeCapsuleRemoteDataSource.kt
@@ -46,9 +46,3 @@ interface TimeCapsuleRemoteDataSource {
 
     suspend fun createTimeCapsule(id: Long): Long
 }
-
-enum class FavoriteResultEntity {
-    ADDED,
-    REMOVED,
-    FULL,
-}

--- a/data/src/main/java/com/emotionstorage/data/di/RepositoryModule.kt
+++ b/data/src/main/java/com/emotionstorage/data/di/RepositoryModule.kt
@@ -8,6 +8,7 @@ import com.emotionstorage.data.repoImpl.DailyReportRepositoryImpl
 import com.emotionstorage.data.repoImpl.FcmRepositoryImpl
 import com.emotionstorage.data.repoImpl.MyPageRepositoryImpl
 import com.emotionstorage.data.repoImpl.NotificationPermissionRepositoryImpl
+import com.emotionstorage.data.repoImpl.NotificationRepositoryImpl
 import com.emotionstorage.data.repoImpl.NotificationSettingsRepositoryImpl
 import com.emotionstorage.data.repoImpl.SessionRepositoryImpl
 import com.emotionstorage.data.repoImpl.TimeCapsuleRepositoryImpl
@@ -20,6 +21,7 @@ import com.emotionstorage.domain.repo.FcmRepository
 import com.emotionstorage.domain.repo.HomeRepository
 import com.emotionstorage.domain.repo.MyPageRepository
 import com.emotionstorage.domain.repo.NotificationPermissionRepository
+import com.emotionstorage.domain.repo.NotificationRepository
 import com.emotionstorage.domain.repo.NotificationSettingRepository
 import com.emotionstorage.domain.repo.SessionRepository
 import com.emotionstorage.domain.repo.TimeCapsuleRepository
@@ -48,6 +50,10 @@ abstract class RepositoryModule {
     @Binds
     @Singleton
     abstract fun bindFcmRepository(impl: FcmRepositoryImpl): FcmRepository
+
+    @Binds
+    @Singleton
+    abstract fun bindNotificationRepository(impl: NotificationRepositoryImpl): NotificationRepository
 
     @Binds
     @Singleton

--- a/data/src/main/java/com/emotionstorage/data/model/NotificationEntity.kt
+++ b/data/src/main/java/com/emotionstorage/data/model/NotificationEntity.kt
@@ -1,0 +1,16 @@
+package com.emotionstorage.data.model
+
+data class NotificationEntity(
+    val id: Long,
+    val title: String,
+    val body: String,
+    val isRead: Boolean,
+    val type: String,
+    val targetId: String? = null,
+    val pageData: PageData? = null,
+) {
+    data class PageData(
+        val page: Int,
+        val hasNextPage: Boolean,
+    )
+}

--- a/data/src/main/java/com/emotionstorage/data/model/NotificationEntity.kt
+++ b/data/src/main/java/com/emotionstorage/data/model/NotificationEntity.kt
@@ -1,12 +1,15 @@
 package com.emotionstorage.data.model
 
+import java.time.LocalDateTime
+
 data class NotificationEntity(
     val id: Long,
     val title: String,
     val body: String,
     val isRead: Boolean,
+    val arrivedAt: LocalDateTime,
     val type: String,
-    val targetId: String? = null,
+    val targetId: Long? = null,
     val pageData: PageData? = null,
 ) {
     data class PageData(

--- a/data/src/main/java/com/emotionstorage/data/modelMapper/NotificationMapper.kt
+++ b/data/src/main/java/com/emotionstorage/data/modelMapper/NotificationMapper.kt
@@ -10,7 +10,10 @@ internal object NotificationMapper {
             id = entity.id,
             type =
                 when (entity.type) {
-                    "RECORD_SCHEDULE" -> NotificationType.RecordSchedule
+                    "RECORD_SCHEDULE" -> {
+                        NotificationType.RecordSchedule
+                    }
+
                     "DAILY_REPORT_ARRIVAL" -> {
                         entity.targetId?.let {
                             NotificationType.DailyReportArrival(it)
@@ -23,8 +26,13 @@ internal object NotificationMapper {
                         } ?: throw IllegalArgumentException("targetId is null")
                     }
 
-                    "RECORD_REMINDER" -> NotificationType.RecordReminder
-                    else -> throw IllegalArgumentException("Invalid notification type")
+                    "RECORD_REMINDER" -> {
+                        NotificationType.RecordReminder
+                    }
+
+                    else -> {
+                        throw IllegalArgumentException("Invalid notification type")
+                    }
                 },
             arrivedAt = entity.arrivedAt,
             isRead = entity.isRead,

--- a/data/src/main/java/com/emotionstorage/data/modelMapper/NotificationMapper.kt
+++ b/data/src/main/java/com/emotionstorage/data/modelMapper/NotificationMapper.kt
@@ -1,0 +1,31 @@
+package com.emotionstorage.data.modelMapper
+
+import com.emotionstorage.data.model.NotificationEntity
+import com.emotionstorage.domain.model.Notification
+import com.emotionstorage.domain.model.NotificationType
+
+internal object NotificationMapper {
+    fun toDomain(entity: NotificationEntity) =
+        Notification(
+            id = entity.id,
+            type = when (entity.type) {
+                "RECORD_SCHEDULE" -> NotificationType.RecordSchedule
+                "DAILY_REPORT_ARRIVAL" -> {
+                    entity.targetId?.let {
+                        NotificationType.DailyReportArrival(it)
+                    } ?: throw IllegalArgumentException("targetId is null")
+                }
+
+                "TIME_CAPSULE_ARRIVAL" -> {
+                    entity.targetId?.let {
+                        NotificationType.TimeCapsuleArrival(it)
+                    } ?: throw IllegalArgumentException("targetId is null")
+                }
+
+                "RECORD_REMINDER" -> NotificationType.RecordReminder
+                else -> throw IllegalArgumentException("Invalid notification type")
+            },
+            arrivedAt = entity.arrivedAt,
+            isRead = entity.isRead
+        )
+}

--- a/data/src/main/java/com/emotionstorage/data/modelMapper/NotificationMapper.kt
+++ b/data/src/main/java/com/emotionstorage/data/modelMapper/NotificationMapper.kt
@@ -31,7 +31,8 @@ internal object NotificationMapper {
                     }
 
                     else -> {
-                        throw IllegalArgumentException("Invalid notification type")
+                        // fall back type
+                        NotificationType.UnKnown(entity.targetId)
                     }
                 },
             arrivedAt = entity.arrivedAt,

--- a/data/src/main/java/com/emotionstorage/data/modelMapper/NotificationMapper.kt
+++ b/data/src/main/java/com/emotionstorage/data/modelMapper/NotificationMapper.kt
@@ -8,24 +8,25 @@ internal object NotificationMapper {
     fun toDomain(entity: NotificationEntity) =
         Notification(
             id = entity.id,
-            type = when (entity.type) {
-                "RECORD_SCHEDULE" -> NotificationType.RecordSchedule
-                "DAILY_REPORT_ARRIVAL" -> {
-                    entity.targetId?.let {
-                        NotificationType.DailyReportArrival(it)
-                    } ?: throw IllegalArgumentException("targetId is null")
-                }
+            type =
+                when (entity.type) {
+                    "RECORD_SCHEDULE" -> NotificationType.RecordSchedule
+                    "DAILY_REPORT_ARRIVAL" -> {
+                        entity.targetId?.let {
+                            NotificationType.DailyReportArrival(it)
+                        } ?: throw IllegalArgumentException("targetId is null")
+                    }
 
-                "TIME_CAPSULE_ARRIVAL" -> {
-                    entity.targetId?.let {
-                        NotificationType.TimeCapsuleArrival(it)
-                    } ?: throw IllegalArgumentException("targetId is null")
-                }
+                    "TIME_CAPSULE_ARRIVAL" -> {
+                        entity.targetId?.let {
+                            NotificationType.TimeCapsuleArrival(it)
+                        } ?: throw IllegalArgumentException("targetId is null")
+                    }
 
-                "RECORD_REMINDER" -> NotificationType.RecordReminder
-                else -> throw IllegalArgumentException("Invalid notification type")
-            },
+                    "RECORD_REMINDER" -> NotificationType.RecordReminder
+                    else -> throw IllegalArgumentException("Invalid notification type")
+                },
             arrivedAt = entity.arrivedAt,
-            isRead = entity.isRead
+            isRead = entity.isRead,
         )
 }

--- a/data/src/main/java/com/emotionstorage/data/pagingSource/GetNotificationsPagingSource.kt
+++ b/data/src/main/java/com/emotionstorage/data/pagingSource/GetNotificationsPagingSource.kt
@@ -5,9 +5,8 @@ import androidx.paging.PagingState
 import com.emotionstorage.data.dataSource.remote.NotificationRemoteDataSource
 import com.emotionstorage.data.model.NotificationEntity
 import io.github.aakira.napier.Napier
-import javax.inject.Inject
 
-class GetNotificationsPagingSource @Inject constructor(
+class GetNotificationsPagingSource (
     private val remoteDataSource: NotificationRemoteDataSource,
 ) : PagingSource<Int, NotificationEntity>() {
     override suspend fun load(params: LoadParams<Int>): LoadResult<Int, NotificationEntity> {

--- a/data/src/main/java/com/emotionstorage/data/pagingSource/GetNotificationsPagingSource.kt
+++ b/data/src/main/java/com/emotionstorage/data/pagingSource/GetNotificationsPagingSource.kt
@@ -6,7 +6,7 @@ import com.emotionstorage.data.dataSource.remote.NotificationRemoteDataSource
 import com.emotionstorage.data.model.NotificationEntity
 import io.github.aakira.napier.Napier
 
-class GetNotificationsPagingSource (
+class GetNotificationsPagingSource(
     private val remoteDataSource: NotificationRemoteDataSource,
 ) : PagingSource<Int, NotificationEntity>() {
     override suspend fun load(params: LoadParams<Int>): LoadResult<Int, NotificationEntity> {

--- a/data/src/main/java/com/emotionstorage/data/pagingSource/GetNotificationsPagingSource.kt
+++ b/data/src/main/java/com/emotionstorage/data/pagingSource/GetNotificationsPagingSource.kt
@@ -1,0 +1,45 @@
+package com.emotionstorage.data.pagingSource
+
+import androidx.paging.PagingSource
+import androidx.paging.PagingState
+import com.emotionstorage.data.dataSource.remote.NotificationRemoteDataSource
+import com.emotionstorage.data.model.NotificationEntity
+import io.github.aakira.napier.Napier
+import javax.inject.Inject
+
+class GetNotificationsPagingSource @Inject constructor(
+    private val remoteDataSource: NotificationRemoteDataSource,
+) : PagingSource<Int, NotificationEntity>() {
+    override suspend fun load(params: LoadParams<Int>): LoadResult<Int, NotificationEntity> {
+        Napier.d("load params key: ${params.key}")
+
+        val pageIndex = params.key ?: 1
+        val pageSize = params.loadSize
+        return try {
+            val notifications =
+                remoteDataSource.getNotifications(
+                    page = pageIndex,
+                    limit = pageSize,
+                )
+
+            LoadResult.Page(
+                data = notifications,
+                // only load page forwards
+                prevKey = null,
+                nextKey =
+                    notifications.lastOrNull()?.pageData?.let {
+                        if (it.hasNextPage) it.page + 1 else null
+                    },
+            )
+        } catch (e: Exception) {
+            LoadResult.Error(e)
+        }
+    }
+
+    override fun getRefreshKey(state: PagingState<Int, NotificationEntity>): Int? =
+        state.anchorPosition?.let { anchor ->
+            Napier.d("getRefreshKey anchor: $anchor")
+            val page = state.closestPageToPosition(anchor)
+            page?.nextKey?.minus(1)
+        }
+}

--- a/data/src/main/java/com/emotionstorage/data/repoImpl/NotificationRepositoryImpl.kt
+++ b/data/src/main/java/com/emotionstorage/data/repoImpl/NotificationRepositoryImpl.kt
@@ -1,0 +1,46 @@
+package com.emotionstorage.data.repoImpl
+
+import androidx.paging.Pager
+import androidx.paging.PagingConfig
+import androidx.paging.PagingData
+import androidx.paging.map
+import com.emotionstorage.data.dataSource.remote.NotificationRemoteDataSource
+import com.emotionstorage.data.modelMapper.NotificationMapper
+import com.emotionstorage.data.modelMapper.TimeCapsuleMapper
+import com.emotionstorage.data.pagingSource.GetFavoriteTimeCapsulesPagingSource
+import com.emotionstorage.data.pagingSource.GetNotificationsPagingSource
+import com.emotionstorage.domain.model.Notification
+import com.emotionstorage.domain.model.TimeCapsule
+import com.emotionstorage.domain.repo.FavoriteSortBy
+import com.emotionstorage.domain.repo.NotificationRepository
+import io.github.aakira.napier.Napier
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.map
+import javax.inject.Inject
+
+private const val PAGE_SIZE = 20
+
+class NotificationRepositoryImpl @Inject constructor(
+    private val remoteDataSource: NotificationRemoteDataSource,
+) : NotificationRepository {
+
+    override fun getPagedNotifications(): Flow<PagingData<Notification>> {
+        return Pager(
+            config =
+                PagingConfig(
+                    pageSize = PAGE_SIZE,
+                    enablePlaceholders = false,
+                ),
+            pagingSourceFactory =
+                {
+                    GetNotificationsPagingSource(
+                        remoteDataSource = remoteDataSource,
+                    )
+                },
+        ).flow.map {
+            it.map { entity ->
+                NotificationMapper.toDomain(entity)
+            }
+        }
+    }
+}

--- a/data/src/main/java/com/emotionstorage/data/repoImpl/NotificationRepositoryImpl.kt
+++ b/data/src/main/java/com/emotionstorage/data/repoImpl/NotificationRepositoryImpl.kt
@@ -6,14 +6,9 @@ import androidx.paging.PagingData
 import androidx.paging.map
 import com.emotionstorage.data.dataSource.remote.NotificationRemoteDataSource
 import com.emotionstorage.data.modelMapper.NotificationMapper
-import com.emotionstorage.data.modelMapper.TimeCapsuleMapper
-import com.emotionstorage.data.pagingSource.GetFavoriteTimeCapsulesPagingSource
 import com.emotionstorage.data.pagingSource.GetNotificationsPagingSource
 import com.emotionstorage.domain.model.Notification
-import com.emotionstorage.domain.model.TimeCapsule
-import com.emotionstorage.domain.repo.FavoriteSortBy
 import com.emotionstorage.domain.repo.NotificationRepository
-import io.github.aakira.napier.Napier
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.map
 import javax.inject.Inject
@@ -23,9 +18,8 @@ private const val PAGE_SIZE = 20
 class NotificationRepositoryImpl @Inject constructor(
     private val remoteDataSource: NotificationRemoteDataSource,
 ) : NotificationRepository {
-
-    override fun getPagedNotifications(): Flow<PagingData<Notification>> {
-        return Pager(
+    override fun getPagedNotifications(): Flow<PagingData<Notification>> =
+        Pager(
             config =
                 PagingConfig(
                     pageSize = PAGE_SIZE,
@@ -42,5 +36,4 @@ class NotificationRepositoryImpl @Inject constructor(
                 NotificationMapper.toDomain(entity)
             }
         }
-    }
 }

--- a/domain/src/main/java/com/emotionstorage/domain/model/Notification.kt
+++ b/domain/src/main/java/com/emotionstorage/domain/model/Notification.kt
@@ -1,0 +1,28 @@
+package com.emotionstorage.domain.model
+
+import java.time.LocalDate
+import java.time.LocalDateTime
+import java.time.temporal.ChronoUnit
+
+data class Notification(
+    val id: Long,
+    val type: NotificationType,
+    val title: String,
+    val arrivedAt: LocalDateTime,
+    val body: String = "",
+    val isRead: Boolean = false,
+)
+
+sealed class NotificationType {
+    object RecordSchedule : NotificationType()
+
+    data class DailyReportArrival(
+        val dailyReportId: Long
+    ) : NotificationType()
+
+    data class TimeCapsuleArrival(
+        val timeCapsuleId: Long
+    ) : NotificationType()
+
+    object RecordReminder : NotificationType()
+}

--- a/domain/src/main/java/com/emotionstorage/domain/model/Notification.kt
+++ b/domain/src/main/java/com/emotionstorage/domain/model/Notification.kt
@@ -21,4 +21,8 @@ sealed class NotificationType {
     ) : NotificationType()
 
     object RecordReminder : NotificationType()
+
+    data class UnKnown(
+        val data: Any? = null
+    ): NotificationType()
 }

--- a/domain/src/main/java/com/emotionstorage/domain/model/Notification.kt
+++ b/domain/src/main/java/com/emotionstorage/domain/model/Notification.kt
@@ -1,15 +1,11 @@
 package com.emotionstorage.domain.model
 
-import java.time.LocalDate
 import java.time.LocalDateTime
-import java.time.temporal.ChronoUnit
 
 data class Notification(
     val id: Long,
     val type: NotificationType,
-    val title: String,
     val arrivedAt: LocalDateTime,
-    val body: String = "",
     val isRead: Boolean = false,
 )
 

--- a/domain/src/main/java/com/emotionstorage/domain/model/Notification.kt
+++ b/domain/src/main/java/com/emotionstorage/domain/model/Notification.kt
@@ -13,11 +13,11 @@ sealed class NotificationType {
     object RecordSchedule : NotificationType()
 
     data class DailyReportArrival(
-        val dailyReportId: Long
+        val dailyReportId: Long,
     ) : NotificationType()
 
     data class TimeCapsuleArrival(
-        val timeCapsuleId: Long
+        val timeCapsuleId: Long,
     ) : NotificationType()
 
     object RecordReminder : NotificationType()

--- a/domain/src/main/java/com/emotionstorage/domain/model/Notification.kt
+++ b/domain/src/main/java/com/emotionstorage/domain/model/Notification.kt
@@ -23,6 +23,6 @@ sealed class NotificationType {
     object RecordReminder : NotificationType()
 
     data class UnKnown(
-        val data: Any? = null
-    ): NotificationType()
+        val data: Any? = null,
+    ) : NotificationType()
 }

--- a/domain/src/main/java/com/emotionstorage/domain/repo/NotificationRepository.kt
+++ b/domain/src/main/java/com/emotionstorage/domain/repo/NotificationRepository.kt
@@ -1,0 +1,9 @@
+package com.emotionstorage.domain.repo
+
+import androidx.paging.PagingData
+import com.emotionstorage.domain.model.Notification
+import kotlinx.coroutines.flow.Flow
+
+interface NotificationRepository {
+    fun getPagedNotifications(): Flow<PagingData<Notification>>
+}

--- a/domain/src/main/java/com/emotionstorage/domain/useCase/notification/GetPagedNotificationsUseCase.kt
+++ b/domain/src/main/java/com/emotionstorage/domain/useCase/notification/GetPagedNotificationsUseCase.kt
@@ -4,12 +4,10 @@ import androidx.paging.PagingData
 import com.emotionstorage.domain.model.Notification
 import com.emotionstorage.domain.repo.NotificationRepository
 import kotlinx.coroutines.flow.Flow
-import java.time.LocalDate
 import javax.inject.Inject
 
 class GetPagedNotificationsUseCase @Inject constructor(
     private val notificationRepository: NotificationRepository,
 ) {
-    operator fun invoke(): Flow<PagingData<Notification>> =
-        notificationRepository.getPagedNotifications()
+    operator fun invoke(): Flow<PagingData<Notification>> = notificationRepository.getPagedNotifications()
 }

--- a/domain/src/main/java/com/emotionstorage/domain/useCase/notification/GetPagedNotificationsUseCase.kt
+++ b/domain/src/main/java/com/emotionstorage/domain/useCase/notification/GetPagedNotificationsUseCase.kt
@@ -1,0 +1,15 @@
+package com.emotionstorage.domain.useCase.notification
+
+import androidx.paging.PagingData
+import com.emotionstorage.domain.model.Notification
+import com.emotionstorage.domain.repo.NotificationRepository
+import kotlinx.coroutines.flow.Flow
+import java.time.LocalDate
+import javax.inject.Inject
+
+class GetPagedNotificationsUseCase @Inject constructor(
+    private val notificationRepository: NotificationRepository,
+) {
+    operator fun invoke(): Flow<PagingData<Notification>> =
+        notificationRepository.getPagedNotifications()
+}

--- a/feat/alarm/build.gradle.kts
+++ b/feat/alarm/build.gradle.kts
@@ -28,4 +28,6 @@ dependencies {
     implementation(projects.core.common)
     implementation(projects.core.presentation)
     implementation(projects.core.ui)
+
+    implementation(libs.androidx.paging.compose)
 }

--- a/feat/alarm/src/main/java/com/emotionstorage/alarm/presentation/PushNotificationViewModel.kt
+++ b/feat/alarm/src/main/java/com/emotionstorage/alarm/presentation/PushNotificationViewModel.kt
@@ -12,7 +12,9 @@ import java.time.LocalDateTime
 import javax.inject.Inject
 
 @HiltViewModel
-class PushNotificationViewModel @Inject constructor() : ViewModel() {
+class PushNotificationViewModel @Inject constructor(
+
+) : ViewModel() {
     private val _state = MutableStateFlow<List<Notification>>(emptyList())
     val state: StateFlow<List<Notification>> = _state
 
@@ -32,29 +34,21 @@ private fun mockItems() = listOf(
     Notification(
         id = 0,
         type = NotificationType.RecordSchedule,
-        title = "오늘 어떻게 보냈어요?",
-        body = "오늘 있었던 일, 아무거나 들어줄게요.",
         arrivedAt = LocalDateTime.now().minusHours(1),
     ),
     Notification(
         id = 0,
         type = NotificationType.DailyReportArrival(1),
-        title = "어제의 나, 리포트로 돌아왔어요",
-        body = "하루의 마음 여정을 한눈에 만나보세요.",
         arrivedAt = LocalDateTime.now().minusHours(3),
     ),
     Notification(
         id = 0,
         type = NotificationType.TimeCapsuleArrival(1),
-        title = "기다리던 타임캡슐 도착!",
-        body = "잠들어 있던 감정이 깨어났어요.",
         arrivedAt = LocalDateTime.now().minusDays(0),
     ),
     Notification(
         id = 0,
         type = NotificationType.RecordReminder,
-        title = "우리 못본지 오래된 것 같아요...",
-        body = "00님의 안부가 궁금해요.",
         arrivedAt = LocalDateTime.now().minusDays(3),
     ),
 )

--- a/feat/alarm/src/main/java/com/emotionstorage/alarm/presentation/PushNotificationViewModel.kt
+++ b/feat/alarm/src/main/java/com/emotionstorage/alarm/presentation/PushNotificationViewModel.kt
@@ -9,6 +9,7 @@ import com.emotionstorage.domain.model.Notification
 import com.emotionstorage.domain.useCase.dailyReport.GetDailyReportByIdUseCase
 import com.emotionstorage.domain.useCase.notification.GetPagedNotificationsUseCase
 import com.emotionstorage.domain.useCase.timeCapsule.GetTimeCapsuleByIdUseCase
+import com.orhanobut.logger.Logger
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.Flow
 import org.orbitmvi.orbit.ContainerHost
@@ -68,12 +69,14 @@ class PushNotificationViewModel @Inject constructor(
     private fun handleGetDailyReportDetail(id: Long) =
         intent {
             reduce { state.copy(isLoading = true) }
+            Logger.d("Check daily report of id: $id")
             getDailyReportById(id).handle(
                 onSuccess = {
                     reduce { state.copy(isLoading = false) }
                     postSideEffect(PushNotificationSideEffect.GetDailyReportDetailSuccess(it.id))
                 },
                 onError = { throwable, code, data ->
+                    Logger.d("Error: $throwable")
                     reduce { state.copy(isLoading = false) }
                     postSideEffect(PushNotificationSideEffect.GetDetailError)
                 },
@@ -82,12 +85,14 @@ class PushNotificationViewModel @Inject constructor(
 
     private fun handleGetTimeCapsuleDetail(id: Long) =
         intent {
+            Logger.d("Check time capsule of id: $id")
             reduce { state.copy(isLoading = true) }
             getTimeCapsuleById(id).collect {
                 if (it is DataState.Success) {
                     reduce { state.copy(isLoading = false) }
                     postSideEffect(PushNotificationSideEffect.GetTimeCapsuleDetailSuccess(it.data.id))
                 } else if (it is DataState.Error) {
+                    Logger.d("Error: $it")
                     reduce { state.copy(isLoading = false) }
                     postSideEffect(PushNotificationSideEffect.GetDetailError)
                 }

--- a/feat/alarm/src/main/java/com/emotionstorage/alarm/presentation/PushNotificationViewModel.kt
+++ b/feat/alarm/src/main/java/com/emotionstorage/alarm/presentation/PushNotificationViewModel.kt
@@ -11,7 +11,6 @@ import com.emotionstorage.domain.useCase.notification.GetPagedNotificationsUseCa
 import com.emotionstorage.domain.useCase.timeCapsule.GetTimeCapsuleByIdUseCase
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.Flow
-import org.orbitmvi.orbit.Container
 import org.orbitmvi.orbit.ContainerHost
 import org.orbitmvi.orbit.viewmodel.container
 import javax.inject.Inject
@@ -33,8 +32,13 @@ sealed class PushNotificationSideEffect {
 }
 
 sealed class PushNotificationAction {
-    data class GetDailyReportDetail(val id: Long) : PushNotificationAction()
-    data class GetTimeCapsuleDetail(val id: Long) : PushNotificationAction()
+    data class GetDailyReportDetail(
+        val id: Long,
+    ) : PushNotificationAction()
+
+    data class GetTimeCapsuleDetail(
+        val id: Long,
+    ) : PushNotificationAction()
 }
 
 @HiltViewModel
@@ -42,7 +46,8 @@ class PushNotificationViewModel @Inject constructor(
     private val getPagedNotifications: GetPagedNotificationsUseCase,
     private val getDailyReportById: GetDailyReportByIdUseCase,
     private val getTimeCapsuleById: GetTimeCapsuleByIdUseCase,
-) : ViewModel(), ContainerHost<PushNotificationState, PushNotificationSideEffect> {
+) : ViewModel(),
+    ContainerHost<PushNotificationState, PushNotificationSideEffect> {
     override val container = container<PushNotificationState, PushNotificationSideEffect>(PushNotificationState())
 
     val notifications: Flow<PagingData<Notification>> =
@@ -60,30 +65,32 @@ class PushNotificationViewModel @Inject constructor(
         }
     }
 
-    private fun handleGetDailyReportDetail(id: Long) = intent {
-        reduce { state.copy(isLoading = true) }
-        getDailyReportById(id).handle(
-            onSuccess = {
-                reduce { state.copy(isLoading = false) }
-                postSideEffect(PushNotificationSideEffect.GetDailyReportDetailSuccess(it.id))
-            },
-            onError = { throwable, code, data ->
-                reduce { state.copy(isLoading = false) }
-                postSideEffect(PushNotificationSideEffect.GetDetailError)
-            },
-        )
-    }
+    private fun handleGetDailyReportDetail(id: Long) =
+        intent {
+            reduce { state.copy(isLoading = true) }
+            getDailyReportById(id).handle(
+                onSuccess = {
+                    reduce { state.copy(isLoading = false) }
+                    postSideEffect(PushNotificationSideEffect.GetDailyReportDetailSuccess(it.id))
+                },
+                onError = { throwable, code, data ->
+                    reduce { state.copy(isLoading = false) }
+                    postSideEffect(PushNotificationSideEffect.GetDetailError)
+                },
+            )
+        }
 
-    private fun handleGetTimeCapsuleDetail(id: Long) = intent {
-        reduce { state.copy(isLoading = true) }
-        getTimeCapsuleById(id).collect {
-            if (it is DataState.Success) {
-                reduce { state.copy(isLoading = false) }
-                postSideEffect(PushNotificationSideEffect.GetTimeCapsuleDetailSuccess(it.data.id))
-            } else if (it is DataState.Error) {
-                reduce { state.copy(isLoading = false) }
-                postSideEffect(PushNotificationSideEffect.GetDetailError)
+    private fun handleGetTimeCapsuleDetail(id: Long) =
+        intent {
+            reduce { state.copy(isLoading = true) }
+            getTimeCapsuleById(id).collect {
+                if (it is DataState.Success) {
+                    reduce { state.copy(isLoading = false) }
+                    postSideEffect(PushNotificationSideEffect.GetTimeCapsuleDetailSuccess(it.data.id))
+                } else if (it is DataState.Error) {
+                    reduce { state.copy(isLoading = false) }
+                    postSideEffect(PushNotificationSideEffect.GetDetailError)
+                }
             }
         }
-    }
 }

--- a/feat/alarm/src/main/java/com/emotionstorage/alarm/presentation/PushNotificationViewModel.kt
+++ b/feat/alarm/src/main/java/com/emotionstorage/alarm/presentation/PushNotificationViewModel.kt
@@ -12,9 +12,7 @@ import java.time.LocalDateTime
 import javax.inject.Inject
 
 @HiltViewModel
-class PushNotificationViewModel @Inject constructor(
-
-) : ViewModel() {
+class PushNotificationViewModel @Inject constructor() : ViewModel() {
     private val _state = MutableStateFlow<List<Notification>>(emptyList())
     val state: StateFlow<List<Notification>> = _state
 
@@ -30,27 +28,26 @@ class PushNotificationViewModel @Inject constructor(
     }
 }
 
-private fun mockItems() = listOf(
-    Notification(
-        id = 0,
-        type = NotificationType.RecordSchedule,
-        arrivedAt = LocalDateTime.now().minusHours(1),
-    ),
-    Notification(
-        id = 0,
-        type = NotificationType.DailyReportArrival(1),
-        arrivedAt = LocalDateTime.now().minusHours(3),
-    ),
-    Notification(
-        id = 0,
-        type = NotificationType.TimeCapsuleArrival(1),
-        arrivedAt = LocalDateTime.now().minusDays(0),
-    ),
-    Notification(
-        id = 0,
-        type = NotificationType.RecordReminder,
-        arrivedAt = LocalDateTime.now().minusDays(3),
-    ),
-)
-
-
+private fun mockItems() =
+    listOf(
+        Notification(
+            id = 0,
+            type = NotificationType.RecordSchedule,
+            arrivedAt = LocalDateTime.now().minusHours(1),
+        ),
+        Notification(
+            id = 0,
+            type = NotificationType.DailyReportArrival(1),
+            arrivedAt = LocalDateTime.now().minusHours(3),
+        ),
+        Notification(
+            id = 0,
+            type = NotificationType.TimeCapsuleArrival(1),
+            arrivedAt = LocalDateTime.now().minusDays(0),
+        ),
+        Notification(
+            id = 0,
+            type = NotificationType.RecordReminder,
+            arrivedAt = LocalDateTime.now().minusDays(3),
+        ),
+    )

--- a/feat/alarm/src/main/java/com/emotionstorage/alarm/presentation/PushNotificationViewModel.kt
+++ b/feat/alarm/src/main/java/com/emotionstorage/alarm/presentation/PushNotificationViewModel.kt
@@ -2,16 +2,19 @@ package com.emotionstorage.alarm.presentation
 
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import com.emotionstorage.domain.model.Notification
+import com.emotionstorage.domain.model.NotificationType
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.launch
+import java.time.LocalDateTime
 import javax.inject.Inject
 
 @HiltViewModel
 class PushNotificationViewModel @Inject constructor() : ViewModel() {
-    private val _state = MutableStateFlow<List<PushNotificationState>>(emptyList())
-    val state: StateFlow<List<PushNotificationState>> = _state
+    private val _state = MutableStateFlow<List<Notification>>(emptyList())
+    val state: StateFlow<List<Notification>> = _state
 
     init {
         // TODO : Mock Data 추후 삭제
@@ -25,16 +28,35 @@ class PushNotificationViewModel @Inject constructor() : ViewModel() {
     }
 }
 
-private fun mockItems() =
-    listOf(
-        PushNotificationState("1", "어제의 일일리포트가 업데이트 되었습니다.", "0시간 전"),
-        PushNotificationState("2", "새로운 타임캡슐이 도착했어요!", "22시간 전"),
-        PushNotificationState("3", "어제의 일일리포트가 업데이트 되었습니다.", "1일 전"),
-        PushNotificationState("4", "새로운 타임캡슐이 도착했어요!", "21일 전"),
-    )
-
-data class PushNotificationState(
-    val id: String = "0",
-    val title: String = "",
-    val timeText: String = "",
+private fun mockItems() = listOf(
+    Notification(
+        id = 0,
+        type = NotificationType.RecordSchedule,
+        title = "오늘 어떻게 보냈어요?",
+        body = "오늘 있었던 일, 아무거나 들어줄게요.",
+        arrivedAt = LocalDateTime.now().minusHours(1),
+    ),
+    Notification(
+        id = 0,
+        type = NotificationType.DailyReportArrival(1),
+        title = "어제의 나, 리포트로 돌아왔어요",
+        body = "하루의 마음 여정을 한눈에 만나보세요.",
+        arrivedAt = LocalDateTime.now().minusHours(3),
+    ),
+    Notification(
+        id = 0,
+        type = NotificationType.TimeCapsuleArrival(1),
+        title = "기다리던 타임캡슐 도착!",
+        body = "잠들어 있던 감정이 깨어났어요.",
+        arrivedAt = LocalDateTime.now().minusDays(0),
+    ),
+    Notification(
+        id = 0,
+        type = NotificationType.RecordReminder,
+        title = "우리 못본지 오래된 것 같아요...",
+        body = "00님의 안부가 궁금해요.",
+        arrivedAt = LocalDateTime.now().minusDays(3),
+    ),
 )
+
+

--- a/feat/alarm/src/main/java/com/emotionstorage/alarm/presentation/PushNotificationViewModel.kt
+++ b/feat/alarm/src/main/java/com/emotionstorage/alarm/presentation/PushNotificationViewModel.kt
@@ -2,52 +2,88 @@ package com.emotionstorage.alarm.presentation
 
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import androidx.paging.PagingData
+import androidx.paging.cachedIn
+import com.emotionstorage.domain.common.DataState
 import com.emotionstorage.domain.model.Notification
-import com.emotionstorage.domain.model.NotificationType
+import com.emotionstorage.domain.useCase.dailyReport.GetDailyReportByIdUseCase
+import com.emotionstorage.domain.useCase.notification.GetPagedNotificationsUseCase
+import com.emotionstorage.domain.useCase.timeCapsule.GetTimeCapsuleByIdUseCase
 import dagger.hilt.android.lifecycle.HiltViewModel
-import kotlinx.coroutines.flow.MutableStateFlow
-import kotlinx.coroutines.flow.StateFlow
-import kotlinx.coroutines.launch
-import java.time.LocalDateTime
+import kotlinx.coroutines.flow.Flow
+import org.orbitmvi.orbit.Container
+import org.orbitmvi.orbit.ContainerHost
+import org.orbitmvi.orbit.viewmodel.container
 import javax.inject.Inject
 
-@HiltViewModel
-class PushNotificationViewModel @Inject constructor() : ViewModel() {
-    private val _state = MutableStateFlow<List<Notification>>(emptyList())
-    val state: StateFlow<List<Notification>> = _state
+data class PushNotificationState(
+    val isLoading: Boolean = true,
+)
 
-    init {
-        // TODO : Mock Data 추후 삭제
-        loadData(useMock = true)
+sealed class PushNotificationSideEffect {
+    data class GetDailyReportDetailSuccess(
+        val id: Long,
+    ) : PushNotificationSideEffect()
+
+    data class GetTimeCapsuleDetailSuccess(
+        val id: Long,
+    ) : PushNotificationSideEffect()
+
+    object GetDetailError : PushNotificationSideEffect()
+}
+
+sealed class PushNotificationAction {
+    data class GetDailyReportDetail(val id: Long) : PushNotificationAction()
+    data class GetTimeCapsuleDetail(val id: Long) : PushNotificationAction()
+}
+
+@HiltViewModel
+class PushNotificationViewModel @Inject constructor(
+    private val getPagedNotifications: GetPagedNotificationsUseCase,
+    private val getDailyReportById: GetDailyReportByIdUseCase,
+    private val getTimeCapsuleById: GetTimeCapsuleByIdUseCase,
+) : ViewModel(), ContainerHost<PushNotificationState, PushNotificationSideEffect> {
+    override val container = container<PushNotificationState, PushNotificationSideEffect>(PushNotificationState())
+
+    val notifications: Flow<PagingData<Notification>> =
+        getPagedNotifications().cachedIn(viewModelScope)
+
+    fun onAction(action: PushNotificationAction) {
+        when (action) {
+            is PushNotificationAction.GetDailyReportDetail -> {
+                handleGetDailyReportDetail(action.id)
+            }
+
+            is PushNotificationAction.GetTimeCapsuleDetail -> {
+                handleGetTimeCapsuleDetail(action.id)
+            }
+        }
     }
 
-    fun loadData(useMock: Boolean) {
-        viewModelScope.launch {
-            _state.value = if (useMock) mockItems() else emptyList()
+    private fun handleGetDailyReportDetail(id: Long) = intent {
+        reduce { state.copy(isLoading = true) }
+        getDailyReportById(id).handle(
+            onSuccess = {
+                reduce { state.copy(isLoading = false) }
+                postSideEffect(PushNotificationSideEffect.GetDailyReportDetailSuccess(it.id))
+            },
+            onError = { throwable, code, data ->
+                reduce { state.copy(isLoading = false) }
+                postSideEffect(PushNotificationSideEffect.GetDetailError)
+            },
+        )
+    }
+
+    private fun handleGetTimeCapsuleDetail(id: Long) = intent {
+        reduce { state.copy(isLoading = true) }
+        getTimeCapsuleById(id).collect {
+            if (it is DataState.Success) {
+                reduce { state.copy(isLoading = false) }
+                postSideEffect(PushNotificationSideEffect.GetTimeCapsuleDetailSuccess(it.data.id))
+            } else if (it is DataState.Error) {
+                reduce { state.copy(isLoading = false) }
+                postSideEffect(PushNotificationSideEffect.GetDetailError)
+            }
         }
     }
 }
-
-private fun mockItems() =
-    listOf(
-        Notification(
-            id = 0,
-            type = NotificationType.RecordSchedule,
-            arrivedAt = LocalDateTime.now().minusHours(1),
-        ),
-        Notification(
-            id = 0,
-            type = NotificationType.DailyReportArrival(1),
-            arrivedAt = LocalDateTime.now().minusHours(3),
-        ),
-        Notification(
-            id = 0,
-            type = NotificationType.TimeCapsuleArrival(1),
-            arrivedAt = LocalDateTime.now().minusDays(0),
-        ),
-        Notification(
-            id = 0,
-            type = NotificationType.RecordReminder,
-            arrivedAt = LocalDateTime.now().minusDays(3),
-        ),
-    )

--- a/feat/alarm/src/main/java/com/emotionstorage/alarm/ui/PushNotificationScreen.kt
+++ b/feat/alarm/src/main/java/com/emotionstorage/alarm/ui/PushNotificationScreen.kt
@@ -7,6 +7,7 @@ import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
@@ -116,15 +117,19 @@ private fun StatelessPushNotificationScreen(
                     .padding(innerPadding),
         ) {
             LazyColumn(
+                modifier = Modifier.fillMaxSize(),
                 contentPadding = PaddingValues(start = 16.dp, end = 16.dp, top = 12.dp),
                 verticalArrangement = Arrangement.spacedBy(13.dp),
+                horizontalAlignment = Alignment.CenterHorizontally,
             ) {
                 item {
                     Row(
                         modifier =
                             Modifier
+                                .fillMaxWidth()
                                 .height(24.dp),
                         verticalAlignment = Alignment.CenterVertically,
+                        horizontalArrangement = Arrangement.Start,
                     ) {
                         Icon(
                             modifier =

--- a/feat/alarm/src/main/java/com/emotionstorage/alarm/ui/PushNotificationScreen.kt
+++ b/feat/alarm/src/main/java/com/emotionstorage/alarm/ui/PushNotificationScreen.kt
@@ -14,9 +14,11 @@ import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.material3.Icon
 import androidx.compose.material3.Scaffold
+import androidx.compose.material3.SnackbarHostState
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.painterResource
@@ -36,6 +38,8 @@ import com.emotionstorage.ui.R
 import com.emotionstorage.ui.annotation.PreviewScreenRatios
 import com.emotionstorage.ui.component.appBar.TopAppBar
 import com.emotionstorage.ui.component.loading.LoadingDots
+import com.emotionstorage.ui.component.toast.AppSnackbarController
+import com.emotionstorage.ui.component.toast.AppSnackbarHost
 import com.emotionstorage.ui.theme.MooiTheme
 
 @Composable
@@ -46,6 +50,9 @@ fun PushNotificationScreen(
     navToBack: () -> Unit = {},
 ) {
     val lazyNotifications = viewModel.notifications.collectAsLazyPagingItems()
+
+    val snackState = remember { SnackbarHostState() }
+    val snackbarController = remember { AppSnackbarController(snackState) }
 
     LaunchedEffect(Unit) {
         viewModel.container.sideEffectFlow.collect {
@@ -59,7 +66,9 @@ fun PushNotificationScreen(
                 }
 
                 is PushNotificationSideEffect.GetDetailError -> {
-                    // todo: add error toast
+                    snackbarController.showSnackbar(
+                        message = "아쉽지만 이 기록은 더 이상 열 수 없어요.",
+                    )
                 }
             }
         }
@@ -67,6 +76,8 @@ fun PushNotificationScreen(
 
     StatelessPushNotificationScreen(
         lazyNotifications = lazyNotifications,
+        snackState = snackState,
+        snackbarController = snackbarController,
         onAction = viewModel::onAction,
         navToBack = navToBack,
     )
@@ -78,6 +89,8 @@ private fun StatelessPushNotificationScreen(
     navToBack: () -> Unit,
     modifier: Modifier = Modifier,
     lazyNotifications: LazyPagingItems<Notification>? = null,
+    snackState: SnackbarHostState = SnackbarHostState(),
+    snackbarController: AppSnackbarController? = null,
 ) {
     Scaffold(
         modifier = modifier,
@@ -86,6 +99,12 @@ private fun StatelessPushNotificationScreen(
                 title = "알림 내역",
                 showBackButton = true,
                 onBackClick = navToBack,
+            )
+        },
+        snackbarHost = {
+            AppSnackbarHost(
+                hostState = snackState,
+                customDataFlow = snackbarController?.currentData,
             )
         },
     ) { innerPadding ->

--- a/feat/alarm/src/main/java/com/emotionstorage/alarm/ui/PushNotificationScreen.kt
+++ b/feat/alarm/src/main/java/com/emotionstorage/alarm/ui/PushNotificationScreen.kt
@@ -169,7 +169,7 @@ private fun StatelessPushNotificationScreen(
                                                         item.id,
                                                     ),
                                                 )
-                                            }
+                                            },
                                         )
                                     }
 
@@ -209,7 +209,6 @@ private fun StatelessPushNotificationScreen(
         }
     }
 }
-
 
 @PreviewScreenRatios
 @Composable

--- a/feat/alarm/src/main/java/com/emotionstorage/alarm/ui/PushNotificationScreen.kt
+++ b/feat/alarm/src/main/java/com/emotionstorage/alarm/ui/PushNotificationScreen.kt
@@ -3,7 +3,7 @@ package com.emotionstorage.alarm.ui
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
-import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
@@ -12,17 +12,21 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.lazy.LazyColumn
-import androidx.compose.foundation.lazy.itemsIndexed
 import androidx.compose.material3.Icon
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.paging.LoadState
+import androidx.paging.compose.LazyPagingItems
+import androidx.paging.compose.collectAsLazyPagingItems
+import com.emotionstorage.alarm.presentation.PushNotificationAction
+import com.emotionstorage.alarm.presentation.PushNotificationSideEffect
 import com.emotionstorage.alarm.presentation.PushNotificationViewModel
 import com.emotionstorage.alarm.ui.component.EmptyPushHolder
 import com.emotionstorage.alarm.ui.component.PushAlarmCard
@@ -31,8 +35,8 @@ import com.emotionstorage.domain.model.NotificationType
 import com.emotionstorage.ui.R
 import com.emotionstorage.ui.annotation.PreviewScreenRatios
 import com.emotionstorage.ui.component.appBar.TopAppBar
+import com.emotionstorage.ui.component.loading.LoadingDots
 import com.emotionstorage.ui.theme.MooiTheme
-import java.time.LocalDateTime
 
 @Composable
 fun PushNotificationScreen(
@@ -41,24 +45,42 @@ fun PushNotificationScreen(
     navToDailyReportDetail: (Long) -> Unit = {},
     navToBack: () -> Unit = {},
 ) {
-    val state = viewModel.state.collectAsState()
+    val lazyNotifications = viewModel.notifications.collectAsLazyPagingItems()
+
+    LaunchedEffect(Unit) {
+        viewModel.container.sideEffectFlow.collect {
+            when (it) {
+                is PushNotificationSideEffect.GetDailyReportDetailSuccess -> {
+                    navToDailyReportDetail(it.id)
+                }
+
+                is PushNotificationSideEffect.GetTimeCapsuleDetailSuccess -> {
+                    navToTimeCapsuleDetail(it.id)
+                }
+
+                is PushNotificationSideEffect.GetDetailError -> {
+                    // todo: add error toast
+                }
+            }
+        }
+    }
 
     StatelessPushNotificationScreen(
-        value = state.value,
+        lazyNotifications = lazyNotifications,
+        onAction = viewModel::onAction,
         navToBack = navToBack,
-        navToTimeCapsuleDetail = navToTimeCapsuleDetail,
-        navToDailyReportDetail = navToDailyReportDetail,
     )
 }
 
 @Composable
 private fun StatelessPushNotificationScreen(
-    value: List<Notification> = emptyList(),
+    onAction: (action: PushNotificationAction) -> Unit,
     navToBack: () -> Unit,
-    navToTimeCapsuleDetail: (Long) -> Unit,
-    navToDailyReportDetail: (Long) -> Unit,
+    modifier: Modifier = Modifier,
+    lazyNotifications: LazyPagingItems<Notification>? = null,
 ) {
     Scaffold(
+        modifier = modifier,
         topBar = {
             TopAppBar(
                 title = "알림 내역",
@@ -74,72 +96,94 @@ private fun StatelessPushNotificationScreen(
                     .background(color = MooiTheme.colorScheme.backgroundDefault)
                     .padding(innerPadding),
         ) {
-            Column(
-                modifier = Modifier.padding(start = 16.dp, end = 16.dp, top = 12.dp),
+            LazyColumn(
+                contentPadding = PaddingValues(start = 16.dp, end = 16.dp, top = 12.dp),
+                verticalArrangement = Arrangement.spacedBy(13.dp),
             ) {
-                Row(
-                    modifier =
-                        Modifier
-                            .height(24.dp),
-                    verticalAlignment = Alignment.CenterVertically,
-                ) {
-                    Icon(
+                item {
+                    Row(
                         modifier =
                             Modifier
-                                .size(18.dp),
-                        painter = painterResource(R.drawable.ic_alarm),
-                        contentDescription = "알림 아이콘",
-                        tint = MooiTheme.colorScheme.gray600,
-                    )
+                                .height(24.dp),
+                        verticalAlignment = Alignment.CenterVertically,
+                    ) {
+                        Icon(
+                            modifier =
+                                Modifier
+                                    .size(18.dp),
+                            painter = painterResource(R.drawable.ic_alarm),
+                            contentDescription = "알림 아이콘",
+                            tint = MooiTheme.colorScheme.gray600,
+                        )
 
-                    Spacer(modifier = Modifier.width(6.dp))
+                        Spacer(modifier = Modifier.width(6.dp))
 
-                    Text(
-                        text = "최근 3주간의 알림이 표시됩니다.",
-                        style = MooiTheme.typography.caption7,
-                        color = MooiTheme.colorScheme.gray500,
-                    )
+                        Text(
+                            text = "최근 3주간의 알림이 표시됩니다.",
+                            style = MooiTheme.typography.caption7,
+                            color = MooiTheme.colorScheme.gray500,
+                        )
+                    }
                 }
 
-                if (value.isEmpty()) {
-                    EmptyPushHolder()
-                } else {
-                    LazyColumn(
-                        modifier = Modifier.padding(top = 22.dp),
-                        verticalArrangement = Arrangement.spacedBy(13.dp),
-                    ) {
-                        itemsIndexed(
-                            items = value,
-                            key = { _, item -> item.id },
-                        ) { index, item ->
-                            when (item.type) {
-                                is NotificationType.DailyReportArrival -> {
-                                    PushAlarmCard(
-                                        notification = item,
-                                        onClick = {
-                                            navToDailyReportDetail(
-                                                (item.type as NotificationType.DailyReportArrival).dailyReportId,
-                                            )
-                                        },
-                                    )
-                                }
+                // update ui when load state is not loading
+                when (lazyNotifications?.loadState?.refresh) {
+                    is LoadState.NotLoading -> {
+                        if (lazyNotifications.itemCount == 0) {
+                            item {
+                                EmptyPushHolder()
+                            }
+                        } else {
+                            items(
+                                count = lazyNotifications.itemCount,
+                                key = { lazyNotifications[it]?.id ?: it },
+                            ) { item ->
+                                val item = lazyNotifications[item] ?: return@items
 
-                                is NotificationType.TimeCapsuleArrival -> {
-                                    PushAlarmCard(
-                                        notification = item,
-                                        onClick = {
-                                            navToTimeCapsuleDetail(
-                                                (item.type as NotificationType.TimeCapsuleArrival).timeCapsuleId,
-                                            )
-                                        },
-                                    )
-                                }
+                                when (item.type) {
+                                    is NotificationType.DailyReportArrival -> {
+                                        PushAlarmCard(
+                                            notification = item,
+                                            onClick = {
+                                                onAction(
+                                                    PushNotificationAction.GetDailyReportDetail(
+                                                        item.id,
+                                                    ),
+                                                )
+                                            }
+                                        )
+                                    }
 
-                                else -> {
-                                    // no ui
+                                    is NotificationType.TimeCapsuleArrival -> {
+                                        PushAlarmCard(
+                                            notification = item,
+                                            onClick = {
+                                                onAction(
+                                                    PushNotificationAction.GetTimeCapsuleDetail(
+                                                        item.id,
+                                                    ),
+                                                )
+                                            },
+                                        )
+                                    }
+
+                                    else -> {
+                                        // no ui
+                                    }
                                 }
                             }
                         }
+                    }
+
+                    else -> {
+                        item {
+                            LoadingDots(
+                                modifier = Modifier.padding(top = 244.dp),
+                                dotSize = 13.dp,
+                                dotSpacing = 10.dp,
+                            )
+                        }
+                        // todo: add error ui
                     }
                 }
             }
@@ -147,50 +191,15 @@ private fun StatelessPushNotificationScreen(
     }
 }
 
-@PreviewScreenRatios
-@Composable
-fun EmptyPushNotificationScreenPreview() {
-    MooiTheme {
-        StatelessPushNotificationScreen(
-            value = listOf(),
-            navToBack = {},
-            navToTimeCapsuleDetail = {},
-            navToDailyReportDetail = {},
-        )
-    }
-}
 
 @PreviewScreenRatios
 @Composable
 fun PushNotificationScreenPreview() {
     MooiTheme {
         StatelessPushNotificationScreen(
-            value =
-                listOf(
-                    Notification(
-                        id = 0,
-                        type = NotificationType.RecordSchedule,
-                        arrivedAt = LocalDateTime.now().minusHours(1),
-                    ),
-                    Notification(
-                        id = 1,
-                        type = NotificationType.DailyReportArrival(1),
-                        arrivedAt = LocalDateTime.now().minusHours(3),
-                    ),
-                    Notification(
-                        id = 2,
-                        type = NotificationType.TimeCapsuleArrival(1),
-                        arrivedAt = LocalDateTime.now().minusDays(0),
-                    ),
-                    Notification(
-                        id = 3,
-                        type = NotificationType.RecordReminder,
-                        arrivedAt = LocalDateTime.now().minusDays(3),
-                    ),
-                ),
+            lazyNotifications = null,
+            onAction = {},
             navToBack = {},
-            navToTimeCapsuleDetail = {},
-            navToDailyReportDetail = {},
         )
     }
 }

--- a/feat/alarm/src/main/java/com/emotionstorage/alarm/ui/PushNotificationScreen.kt
+++ b/feat/alarm/src/main/java/com/emotionstorage/alarm/ui/PushNotificationScreen.kt
@@ -1,6 +1,7 @@
 package com.emotionstorage.alarm.ui
 
 import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
@@ -106,30 +107,35 @@ private fun StatelessPushNotificationScreen(
                 } else {
                     LazyColumn(
                         modifier = Modifier.padding(top = 22.dp),
+                        verticalArrangement = Arrangement.spacedBy(13.dp),
                     ) {
-                        itemsIndexed(items = value, key = { _, item -> item.id }) { index, item ->
-                            PushAlarmCard(
-                                title = item.title,
-                                body = item.body,
-                                arrivedAt = item.arrivedAt,
-                                onClick = {
-                                    // todo: add error toast, if error occurs on navigation
-                                    when (item.type) {
-                                        is NotificationType.TimeCapsuleArrival -> {
-                                            navToTimeCapsuleDetail((item.type as NotificationType.TimeCapsuleArrival).timeCapsuleId)
-                                        }
-
-                                        is NotificationType.DailyReportArrival -> {
+                        itemsIndexed(
+                            items = value,
+                            key = { _, item -> item.id },
+                        ) { index, item ->
+                            when (item.type) {
+                                is NotificationType.DailyReportArrival -> {
+                                    PushAlarmCard(
+                                        notification = item,
+                                        onClick = {
                                             navToDailyReportDetail((item.type as NotificationType.DailyReportArrival).dailyReportId)
                                         }
-
-                                        else -> {
-                                            // do nothing
-                                        }
-                                    }
+                                    )
                                 }
-                            )
-                            if (index < value.size - 1) Spacer(modifier = Modifier.size(12.dp))
+
+                                is NotificationType.TimeCapsuleArrival -> {
+                                    PushAlarmCard(
+                                        notification = item,
+                                        onClick = {
+                                            navToTimeCapsuleDetail((item.type as NotificationType.TimeCapsuleArrival).timeCapsuleId)
+                                        }
+                                    )
+                                }
+
+                                else -> {
+                                    // no ui
+                                }
+                            }
                         }
                     }
                 }
@@ -162,29 +168,21 @@ fun PushNotificationScreenPreview() {
                 Notification(
                     id = 0,
                     type = NotificationType.RecordSchedule,
-                    title = "오늘 어떻게 보냈어요?",
-                    body = "오늘 있었던 일, 아무거나 들어줄게요.",
                     arrivedAt = LocalDateTime.now().minusHours(1),
                 ),
                 Notification(
                     id = 1,
                     type = NotificationType.DailyReportArrival(1),
-                    title = "어제의 나, 리포트로 돌아왔어요",
-                    body = "하루의 마음 여정을 한눈에 만나보세요.",
                     arrivedAt = LocalDateTime.now().minusHours(3),
                 ),
                 Notification(
                     id = 2,
                     type = NotificationType.TimeCapsuleArrival(1),
-                    title = "기다리던 타임캡슐 도착!",
-                    body = "잠들어 있던 감정이 깨어났어요.",
                     arrivedAt = LocalDateTime.now().minusDays(0),
                 ),
                 Notification(
                     id = 3,
                     type = NotificationType.RecordReminder,
-                    title = "우리 못본지 오래된 것 같아요...",
-                    body = "00님의 안부가 궁금해요.",
                     arrivedAt = LocalDateTime.now().minusDays(3),
                 )
             ),

--- a/feat/alarm/src/main/java/com/emotionstorage/alarm/ui/PushNotificationScreen.kt
+++ b/feat/alarm/src/main/java/com/emotionstorage/alarm/ui/PushNotificationScreen.kt
@@ -34,7 +34,8 @@ import com.emotionstorage.alarm.presentation.PushNotificationViewModel
 import com.emotionstorage.alarm.ui.component.EmptyPushHolder
 import com.emotionstorage.alarm.ui.component.PushAlarmCard
 import com.emotionstorage.domain.model.Notification
-import com.emotionstorage.domain.model.NotificationType
+import com.emotionstorage.domain.model.NotificationType.DailyReportArrival
+import com.emotionstorage.domain.model.NotificationType.TimeCapsuleArrival
 import com.emotionstorage.ui.R
 import com.emotionstorage.ui.annotation.PreviewScreenRatios
 import com.emotionstorage.ui.component.appBar.TopAppBar
@@ -165,26 +166,26 @@ private fun StatelessPushNotificationScreen(
                                 val item = lazyNotifications[item] ?: return@items
 
                                 when (item.type) {
-                                    is NotificationType.DailyReportArrival -> {
+                                    is DailyReportArrival -> {
                                         PushAlarmCard(
                                             notification = item,
                                             onClick = {
                                                 onAction(
                                                     PushNotificationAction.GetDailyReportDetail(
-                                                        (item.type as NotificationType.DailyReportArrival).dailyReportId
+                                                        (item.type as DailyReportArrival).dailyReportId,
                                                     ),
                                                 )
                                             },
                                         )
                                     }
 
-                                    is NotificationType.TimeCapsuleArrival -> {
+                                    is TimeCapsuleArrival -> {
                                         PushAlarmCard(
                                             notification = item,
                                             onClick = {
                                                 onAction(
                                                     PushNotificationAction.GetTimeCapsuleDetail(
-                                                        (item.type as NotificationType.TimeCapsuleArrival).timeCapsuleId
+                                                        (item.type as TimeCapsuleArrival).timeCapsuleId,
                                                     ),
                                                 )
                                             },

--- a/feat/alarm/src/main/java/com/emotionstorage/alarm/ui/PushNotificationScreen.kt
+++ b/feat/alarm/src/main/java/com/emotionstorage/alarm/ui/PushNotificationScreen.kt
@@ -21,7 +21,6 @@ import androidx.compose.runtime.collectAsState
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.painterResource
-import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import com.emotionstorage.alarm.presentation.PushNotificationViewModel
@@ -118,8 +117,10 @@ private fun StatelessPushNotificationScreen(
                                     PushAlarmCard(
                                         notification = item,
                                         onClick = {
-                                            navToDailyReportDetail((item.type as NotificationType.DailyReportArrival).dailyReportId)
-                                        }
+                                            navToDailyReportDetail(
+                                                (item.type as NotificationType.DailyReportArrival).dailyReportId,
+                                            )
+                                        },
                                     )
                                 }
 
@@ -127,8 +128,10 @@ private fun StatelessPushNotificationScreen(
                                     PushAlarmCard(
                                         notification = item,
                                         onClick = {
-                                            navToTimeCapsuleDetail((item.type as NotificationType.TimeCapsuleArrival).timeCapsuleId)
-                                        }
+                                            navToTimeCapsuleDetail(
+                                                (item.type as NotificationType.TimeCapsuleArrival).timeCapsuleId,
+                                            )
+                                        },
                                     )
                                 }
 
@@ -144,7 +147,6 @@ private fun StatelessPushNotificationScreen(
     }
 }
 
-
 @PreviewScreenRatios
 @Composable
 fun EmptyPushNotificationScreenPreview() {
@@ -158,34 +160,34 @@ fun EmptyPushNotificationScreenPreview() {
     }
 }
 
-
 @PreviewScreenRatios
 @Composable
 fun PushNotificationScreenPreview() {
     MooiTheme {
         StatelessPushNotificationScreen(
-            value = listOf(
-                Notification(
-                    id = 0,
-                    type = NotificationType.RecordSchedule,
-                    arrivedAt = LocalDateTime.now().minusHours(1),
+            value =
+                listOf(
+                    Notification(
+                        id = 0,
+                        type = NotificationType.RecordSchedule,
+                        arrivedAt = LocalDateTime.now().minusHours(1),
+                    ),
+                    Notification(
+                        id = 1,
+                        type = NotificationType.DailyReportArrival(1),
+                        arrivedAt = LocalDateTime.now().minusHours(3),
+                    ),
+                    Notification(
+                        id = 2,
+                        type = NotificationType.TimeCapsuleArrival(1),
+                        arrivedAt = LocalDateTime.now().minusDays(0),
+                    ),
+                    Notification(
+                        id = 3,
+                        type = NotificationType.RecordReminder,
+                        arrivedAt = LocalDateTime.now().minusDays(3),
+                    ),
                 ),
-                Notification(
-                    id = 1,
-                    type = NotificationType.DailyReportArrival(1),
-                    arrivedAt = LocalDateTime.now().minusHours(3),
-                ),
-                Notification(
-                    id = 2,
-                    type = NotificationType.TimeCapsuleArrival(1),
-                    arrivedAt = LocalDateTime.now().minusDays(0),
-                ),
-                Notification(
-                    id = 3,
-                    type = NotificationType.RecordReminder,
-                    arrivedAt = LocalDateTime.now().minusDays(3),
-                )
-            ),
             navToBack = {},
             navToTimeCapsuleDetail = {},
             navToDailyReportDetail = {},

--- a/feat/alarm/src/main/java/com/emotionstorage/alarm/ui/PushNotificationScreen.kt
+++ b/feat/alarm/src/main/java/com/emotionstorage/alarm/ui/PushNotificationScreen.kt
@@ -23,34 +23,40 @@ import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
-import com.emotionstorage.alarm.presentation.PushNotificationState
 import com.emotionstorage.alarm.presentation.PushNotificationViewModel
 import com.emotionstorage.alarm.ui.component.EmptyPushHolder
 import com.emotionstorage.alarm.ui.component.PushAlarmCard
+import com.emotionstorage.domain.model.Notification
+import com.emotionstorage.domain.model.NotificationType
 import com.emotionstorage.ui.R
+import com.emotionstorage.ui.annotation.PreviewScreenRatios
 import com.emotionstorage.ui.component.appBar.TopAppBar
 import com.emotionstorage.ui.theme.MooiTheme
+import java.time.LocalDateTime
 
 @Composable
 fun PushNotificationScreen(
     viewModel: PushNotificationViewModel = hiltViewModel(),
-    onClick: () -> Unit = {},
+    navToTimeCapsuleDetail: (Long) -> Unit = {},
+    navToDailyReportDetail: (Long) -> Unit = {},
     navToBack: () -> Unit = {},
 ) {
     val state = viewModel.state.collectAsState()
 
     StatelessPushNotificationScreen(
-        navToBack = navToBack,
         value = state.value,
-        onClick = onClick,
+        navToBack = navToBack,
+        navToTimeCapsuleDetail = navToTimeCapsuleDetail,
+        navToDailyReportDetail = navToDailyReportDetail,
     )
 }
 
 @Composable
 private fun StatelessPushNotificationScreen(
+    value: List<Notification> = emptyList(),
     navToBack: () -> Unit,
-    value: List<PushNotificationState> = emptyList(),
-    onClick: () -> Unit = {},
+    navToTimeCapsuleDetail: (Long) -> Unit,
+    navToDailyReportDetail: (Long) -> Unit,
 ) {
     Scaffold(
         topBar = {
@@ -101,12 +107,27 @@ private fun StatelessPushNotificationScreen(
                     LazyColumn(
                         modifier = Modifier.padding(top = 22.dp),
                     ) {
-                        itemsIndexed(value) { index, item ->
+                        itemsIndexed(items = value, key = { _, item -> item.id }) { index, item ->
                             PushAlarmCard(
-                                id = item.id,
                                 title = item.title,
-                                timeText = item.timeText,
-                                onClick = onClick,
+                                body = item.body,
+                                arrivedAt = item.arrivedAt,
+                                onClick = {
+                                    // todo: add error toast, if error occurs on navigation
+                                    when (item.type) {
+                                        is NotificationType.TimeCapsuleArrival -> {
+                                            navToTimeCapsuleDetail((item.type as NotificationType.TimeCapsuleArrival).timeCapsuleId)
+                                        }
+
+                                        is NotificationType.DailyReportArrival -> {
+                                            navToDailyReportDetail((item.type as NotificationType.DailyReportArrival).dailyReportId)
+                                        }
+
+                                        else -> {
+                                            // do nothing
+                                        }
+                                    }
+                                }
                             )
                             if (index < value.size - 1) Spacer(modifier = Modifier.size(12.dp))
                         }
@@ -117,13 +138,59 @@ private fun StatelessPushNotificationScreen(
     }
 }
 
-@Preview(showBackground = true)
+
+@PreviewScreenRatios
+@Composable
+fun EmptyPushNotificationScreenPreview() {
+    MooiTheme {
+        StatelessPushNotificationScreen(
+            value = listOf(),
+            navToBack = {},
+            navToTimeCapsuleDetail = {},
+            navToDailyReportDetail = {},
+        )
+    }
+}
+
+
+@PreviewScreenRatios
 @Composable
 fun PushNotificationScreenPreview() {
     MooiTheme {
         StatelessPushNotificationScreen(
+            value = listOf(
+                Notification(
+                    id = 0,
+                    type = NotificationType.RecordSchedule,
+                    title = "오늘 어떻게 보냈어요?",
+                    body = "오늘 있었던 일, 아무거나 들어줄게요.",
+                    arrivedAt = LocalDateTime.now().minusHours(1),
+                ),
+                Notification(
+                    id = 1,
+                    type = NotificationType.DailyReportArrival(1),
+                    title = "어제의 나, 리포트로 돌아왔어요",
+                    body = "하루의 마음 여정을 한눈에 만나보세요.",
+                    arrivedAt = LocalDateTime.now().minusHours(3),
+                ),
+                Notification(
+                    id = 2,
+                    type = NotificationType.TimeCapsuleArrival(1),
+                    title = "기다리던 타임캡슐 도착!",
+                    body = "잠들어 있던 감정이 깨어났어요.",
+                    arrivedAt = LocalDateTime.now().minusDays(0),
+                ),
+                Notification(
+                    id = 3,
+                    type = NotificationType.RecordReminder,
+                    title = "우리 못본지 오래된 것 같아요...",
+                    body = "00님의 안부가 궁금해요.",
+                    arrivedAt = LocalDateTime.now().minusDays(3),
+                )
+            ),
             navToBack = {},
-            onClick = {},
+            navToTimeCapsuleDetail = {},
+            navToDailyReportDetail = {},
         )
     }
 }

--- a/feat/alarm/src/main/java/com/emotionstorage/alarm/ui/PushNotificationScreen.kt
+++ b/feat/alarm/src/main/java/com/emotionstorage/alarm/ui/PushNotificationScreen.kt
@@ -171,7 +171,7 @@ private fun StatelessPushNotificationScreen(
                                             onClick = {
                                                 onAction(
                                                     PushNotificationAction.GetDailyReportDetail(
-                                                        item.id,
+                                                        (item.type as NotificationType.DailyReportArrival).dailyReportId
                                                     ),
                                                 )
                                             },
@@ -184,7 +184,7 @@ private fun StatelessPushNotificationScreen(
                                             onClick = {
                                                 onAction(
                                                     PushNotificationAction.GetTimeCapsuleDetail(
-                                                        item.id,
+                                                        (item.type as NotificationType.TimeCapsuleArrival).timeCapsuleId
                                                     ),
                                                 )
                                             },

--- a/feat/alarm/src/main/java/com/emotionstorage/alarm/ui/component/PushAlarmCard.kt
+++ b/feat/alarm/src/main/java/com/emotionstorage/alarm/ui/component/PushAlarmCard.kt
@@ -76,11 +76,12 @@ fun PushAlarmCard(
                     contentAlignment = Alignment.CenterStart,
                 ) {
                     Text(
-                        text = when (notification.type) {
-                            is NotificationType.DailyReportArrival -> "어제의 일일리포트가 업데이트 되었습니다."
-                            is NotificationType.TimeCapsuleArrival -> "새로운 타임캡슐이 도착했어요!"
-                            else -> ""
-                        },
+                        text =
+                            when (notification.type) {
+                                is NotificationType.DailyReportArrival -> "어제의 일일리포트가 업데이트 되었습니다."
+                                is NotificationType.TimeCapsuleArrival -> "새로운 타임캡슐이 도착했어요!"
+                                else -> ""
+                            },
                         style = MooiTheme.typography.caption2,
                         color = Color.White,
                         maxLines = 1,
@@ -120,19 +121,21 @@ fun PushAlarmCardPreview() {
             verticalArrangement = Arrangement.spacedBy(13.dp),
         ) {
             PushAlarmCard(
-                notification = Notification(
-                    id = 0,
-                    type = NotificationType.DailyReportArrival(1),
-                    arrivedAt = LocalDateTime.now().minusHours(2),
-                )
+                notification =
+                    Notification(
+                        id = 0,
+                        type = NotificationType.DailyReportArrival(1),
+                        arrivedAt = LocalDateTime.now().minusHours(2),
+                    ),
             )
 
             PushAlarmCard(
-                notification = Notification(
-                    id = 1,
-                    type = NotificationType.TimeCapsuleArrival(1),
-                    arrivedAt = LocalDateTime.now().minusDays(2),
-                )
+                notification =
+                    Notification(
+                        id = 1,
+                        type = NotificationType.TimeCapsuleArrival(1),
+                        arrivedAt = LocalDateTime.now().minusDays(2),
+                    ),
             )
         }
     }

--- a/feat/alarm/src/main/java/com/emotionstorage/alarm/ui/component/PushAlarmCard.kt
+++ b/feat/alarm/src/main/java/com/emotionstorage/alarm/ui/component/PushAlarmCard.kt
@@ -34,9 +34,7 @@ import java.time.LocalDateTime
 
 @Composable
 fun PushAlarmCard(
-    title: String,
-    body: String,
-    arrivedAt: LocalDateTime,
+    notification: Notification,
     modifier: Modifier = Modifier,
     onClick: () -> Unit = {},
 ) {
@@ -78,7 +76,11 @@ fun PushAlarmCard(
                     contentAlignment = Alignment.CenterStart,
                 ) {
                     Text(
-                        text = title,
+                        text = when (notification.type) {
+                            is NotificationType.DailyReportArrival -> "어제의 일일리포트가 업데이트 되었습니다."
+                            is NotificationType.TimeCapsuleArrival -> "새로운 타임캡슐이 도착했어요!"
+                            else -> ""
+                        },
                         style = MooiTheme.typography.caption2,
                         color = Color.White,
                         maxLines = 1,
@@ -90,7 +92,7 @@ fun PushAlarmCard(
                     contentAlignment = Alignment.CenterStart,
                 ) {
                     Text(
-                        text = arrivedAt.timeAgo(),
+                        text = notification.arrivedAt.timeAgo(),
                         style = MooiTheme.typography.caption7,
                         color = MooiTheme.colorScheme.gray600,
                         maxLines = 1,
@@ -118,15 +120,19 @@ fun PushAlarmCardPreview() {
             verticalArrangement = Arrangement.spacedBy(13.dp),
         ) {
             PushAlarmCard(
-                title = "어제의 나, 리포트로 돌아왔어요",
-                body = "하루의 마음 여정을 한눈에 만나보세요.",
-                arrivedAt = LocalDateTime.now().minusHours(2),
+                notification = Notification(
+                    id = 0,
+                    type = NotificationType.DailyReportArrival(1),
+                    arrivedAt = LocalDateTime.now().minusHours(2),
+                )
             )
 
             PushAlarmCard(
-                title = "기다리던 타임캡슐 도착!",
-                body = "잠들어 있던 감정이 깨어났어요.",
-                arrivedAt = LocalDateTime.now().minusDays(3),
+                notification = Notification(
+                    id = 1,
+                    type = NotificationType.TimeCapsuleArrival(1),
+                    arrivedAt = LocalDateTime.now().minusDays(2),
+                )
             )
         }
     }

--- a/feat/alarm/src/main/java/com/emotionstorage/alarm/ui/component/PushAlarmCard.kt
+++ b/feat/alarm/src/main/java/com/emotionstorage/alarm/ui/component/PushAlarmCard.kt
@@ -1,5 +1,6 @@
 package com.emotionstorage.alarm.ui.component
 
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -24,23 +25,28 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
+import com.emotionstorage.common.timeAgo
+import com.emotionstorage.domain.model.Notification
+import com.emotionstorage.domain.model.NotificationType
 import com.emotionstorage.ui.theme.MooiTheme
 import com.emotionstorage.ui.R
+import java.time.LocalDateTime
 
 @Composable
 fun PushAlarmCard(
-    modifier: Modifier = Modifier,
-    id: String,
     title: String,
-    timeText: String,
-    onClick: () -> Unit,
+    body: String,
+    arrivedAt: LocalDateTime,
+    modifier: Modifier = Modifier,
+    onClick: () -> Unit = {},
 ) {
     Card(
         modifier =
             modifier
                 .widthIn(328.dp)
                 .heightIn(84.dp)
-                .clip(RoundedCornerShape(15.dp)),
+                .clip(RoundedCornerShape(15.dp))
+                .clickable(onClick = onClick),
         shape = RoundedCornerShape(15.dp),
         colors = CardDefaults.cardColors(MooiTheme.colorScheme.secondaryBlue700.copy(alpha = 0.1f)),
     ) {
@@ -84,7 +90,7 @@ fun PushAlarmCard(
                     contentAlignment = Alignment.CenterStart,
                 ) {
                     Text(
-                        text = timeText,
+                        text = arrivedAt.timeAgo(),
                         style = MooiTheme.typography.caption7,
                         color = MooiTheme.colorScheme.gray600,
                         maxLines = 1,
@@ -96,7 +102,7 @@ fun PushAlarmCard(
                     Modifier
                         .align(Alignment.CenterVertically),
                 painter = painterResource(R.drawable.ic_big_arrow_front),
-                contentDescription = "상세 목록",
+                contentDescription = "상세 보기",
                 tint = MooiTheme.colorScheme.gray300,
             )
         }
@@ -107,12 +113,21 @@ fun PushAlarmCard(
 @Composable
 fun PushAlarmCardPreview() {
     MooiTheme {
-        PushAlarmCard(
-            id = "1",
-            title = "새로운 타임캡슐이 도착했어요!",
-            timeText = "22시간 전",
-            onClick = {
-            },
-        )
+        Column(
+            modifier = Modifier.padding(16.dp),
+            verticalArrangement = Arrangement.spacedBy(13.dp),
+        ) {
+            PushAlarmCard(
+                title = "어제의 나, 리포트로 돌아왔어요",
+                body = "하루의 마음 여정을 한눈에 만나보세요.",
+                arrivedAt = LocalDateTime.now().minusHours(2),
+            )
+
+            PushAlarmCard(
+                title = "기다리던 타임캡슐 도착!",
+                body = "잠들어 있던 감정이 깨어났어요.",
+                arrivedAt = LocalDateTime.now().minusDays(3),
+            )
+        }
     }
 }

--- a/feat/time-capsule/src/main/java/com/emotionstorage/time_capsule/ui/FavoriteTimeCapsulesScreen.kt
+++ b/feat/time-capsule/src/main/java/com/emotionstorage/time_capsule/ui/FavoriteTimeCapsulesScreen.kt
@@ -62,7 +62,7 @@ fun FavoriteTimeCapsulesScreen(
     val context = LocalContext.current
 
     val state = viewModel.container.stateFlow.collectAsState()
-    val timeCapsulesState = state.value.timeCapsulesFlow?.collectAsLazyPagingItems()
+    val lazyTimeCapsules = state.value.timeCapsulesFlow?.collectAsLazyPagingItems()
     val favoriteState = favoriteViewModel.container.stateFlow.collectAsState()
 
     val snackState = remember { SnackbarHostState() }
@@ -75,9 +75,9 @@ fun FavoriteTimeCapsulesScreen(
     }
 
     // init favorite state
-    LaunchedEffect(timeCapsulesState?.itemSnapshotList) {
+    LaunchedEffect(lazyTimeCapsules?.itemSnapshotList) {
         val favorites =
-            timeCapsulesState
+            lazyTimeCapsules
                 ?.itemSnapshotList
                 ?.items
                 ?.filter { it.isFavorite }
@@ -140,7 +140,7 @@ private fun StatelessFavoriteTimeCapsulesScreen(
     navToTimeCapsuleDetail: (id: Long) -> Unit = {},
     navToBack: () -> Unit = {},
 ) {
-    val timeCapsules = state.timeCapsulesFlow?.collectAsLazyPagingItems()
+    val lazyTimeCapsules = state.timeCapsulesFlow?.collectAsLazyPagingItems()
 
     Scaffold(
         modifier =
@@ -193,8 +193,8 @@ private fun StatelessFavoriteTimeCapsulesScreen(
                     )
                 }
             }
-            if (timeCapsules != null && timeCapsules.loadState.refresh is LoadState.NotLoading) {
-                if (timeCapsules.itemCount == 0) {
+            if (lazyTimeCapsules != null && lazyTimeCapsules.loadState.refresh is LoadState.NotLoading) {
+                if (lazyTimeCapsules.itemCount == 0) {
                     item {
                         Text(
                             modifier = Modifier.padding(top = 224.dp),
@@ -222,8 +222,8 @@ private fun StatelessFavoriteTimeCapsulesScreen(
                             )
                         }
                     }
-                    items(count = timeCapsules.itemCount, key = { timeCapsules[it]?.id ?: it }) {
-                        timeCapsules[it]?.let {
+                    items(count = lazyTimeCapsules.itemCount, key = { lazyTimeCapsules[it]?.id ?: it }) {
+                        lazyTimeCapsules[it]?.let {
                             Column(verticalArrangement = Arrangement.spacedBy(10.dp)) {
                                 Row(
                                     modifier =

--- a/feat/time-capsule/src/main/java/com/emotionstorage/time_capsule/ui/component/TimeCapsuleBottomSheet.kt
+++ b/feat/time-capsule/src/main/java/com/emotionstorage/time_capsule/ui/component/TimeCapsuleBottomSheet.kt
@@ -58,7 +58,7 @@ fun TimeCapsuleBottomSheet(
     navToDailyReport: (() -> Unit)? = null,
     isNewDailyReport: Boolean = false,
 ) {
-    val timeCapsules = timeCapsulesFlow?.collectAsLazyPagingItems()
+    val lazyTimeCapsules = timeCapsulesFlow?.collectAsLazyPagingItems()
 
     BottomSheet(
         modifier = modifier,
@@ -89,10 +89,10 @@ fun TimeCapsuleBottomSheet(
             verticalArrangement = Arrangement.spacedBy(18.dp),
             contentPadding = PaddingValues(bottom = 51.dp),
         ) {
-            if (timeCapsules != null && timeCapsules.loadState.refresh is LoadState.NotLoading) {
-                if (timeCapsules.itemCount > 0) {
-                    items(count = timeCapsules.itemCount, key = { timeCapsules[it]?.id ?: it }) {
-                        timeCapsules[it]?.run {
+            if (lazyTimeCapsules != null && lazyTimeCapsules.loadState.refresh is LoadState.NotLoading) {
+                if (lazyTimeCapsules.itemCount > 0) {
+                    items(count = lazyTimeCapsules.itemCount, key = { lazyTimeCapsules[it]?.id ?: it }) {
+                        lazyTimeCapsules[it]?.run {
                             TimeCapsuleItem(
                                 modifier = Modifier.fillMaxWidth(),
                                 timeCapsule = this,


### PR DESCRIPTION
## Related Issue
- Closes #232 

## 작업 상세 내용
- 알림 내역 화면 api 연동 - 페이징 구현 
- 알림 내역 항목 클릭 시, 일일리포트/타임캡슐 상세 화면 이동 구현
- 일일리포트/타임캡슐 id로 조회 실패 시, 접근 불가 토스트 표시


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 알림 항목에 상대 시간 표시("분 전/시간 전/일 전") 추가
  * 푸시 알림 화면에서 하루 리포트 및 타임캡슐 상세 화면으로 즉시 이동 가능
  * 알림 목록 페이징(스크롤로 더 불러오기) 및 비동기 로드 지원

* **버그 픽스/개선**
  * 알림 로드 오류 시 스낵바 안내 및 빈 상태 표시 개선
  * 일부 화면의 알림 설정 바로가기 연결 제거(네비게이션 흐름 단순화)

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->