### PR TITLE
Feat/new timeapsule count 도착 타임캡슐 개수 조회 api 연동

### DIFF
--- a/core/remote/src/main/java/com/emotionstorage/remote/api/TimeCapsuleApiService.kt
+++ b/core/remote/src/main/java/com/emotionstorage/remote/api/TimeCapsuleApiService.kt
@@ -6,6 +6,7 @@ import com.emotionstorage.remote.request.timeCapsule.PatchTimeCapsuleNoteRequest
 import com.emotionstorage.remote.request.timeCapsule.PostTimeCapsuleOpenAtRequest
 import com.emotionstorage.remote.response.ResponseDto
 import com.emotionstorage.remote.response.timeCapsule.CreateTimeCapsuleResponse
+import com.emotionstorage.remote.response.timeCapsule.GetTimeCapsuleArrivedCountResponse
 import com.emotionstorage.remote.response.timeCapsule.GetTimeCapsulesResponse
 import com.emotionstorage.remote.response.timeCapsule.GetTimeCapsuleDatesReponse
 import com.emotionstorage.remote.response.timeCapsule.GetTimeCapsuleDetailResponse
@@ -39,6 +40,13 @@ interface TimeCapsuleApiService {
         @Query("year") year: Int,
         @Query("month") month: Int,
     ): ResponseDto<GetTimeCapsuleDatesReponse>
+
+    /**
+     * 최근 3주 내 도착 타임캡슐 개수 조회
+     */
+    @GET("api/v1/time-capsule/arrived/count")
+    suspend fun getTimeCapsuleArrivedCount(): ResponseDto<GetTimeCapsuleArrivedCountResponse>
+
 
     /**
      * 즐겨찾기한 타임캡슐 목록 조회

--- a/core/remote/src/main/java/com/emotionstorage/remote/api/TimeCapsuleApiService.kt
+++ b/core/remote/src/main/java/com/emotionstorage/remote/api/TimeCapsuleApiService.kt
@@ -47,7 +47,6 @@ interface TimeCapsuleApiService {
     @GET("api/v1/time-capsule/arrived/count")
     suspend fun getTimeCapsuleArrivedCount(): ResponseDto<GetTimeCapsuleArrivedCountResponse>
 
-
     /**
      * 즐겨찾기한 타임캡슐 목록 조회
      */

--- a/core/remote/src/main/java/com/emotionstorage/remote/dataSourceImpl/TimeCapsuleRemoteDataSourceImpl.kt
+++ b/core/remote/src/main/java/com/emotionstorage/remote/dataSourceImpl/TimeCapsuleRemoteDataSourceImpl.kt
@@ -156,6 +156,17 @@ class TimeCapsuleRemoteDataSourceImpl @Inject constructor(
         }
     }
 
+    override suspend fun getNewTimeCapsuleCount(): Int = try {
+        val response = apiService.getTimeCapsuleArrivedCount()
+        if (response.data != null) {
+            response.data.unopenedCount
+        } else {
+            throw Exception("getNewTimeCapsuleCount response data is empty, $response")
+        }
+    } catch (e: Exception) {
+        throw Exception("getNewTimeCapsuleCount api fail, ${e.message}", e)
+    }
+
     override suspend fun deleteTimeCapsule(id: Long): Boolean {
         try {
             apiService.deleteTimeCapsule(id)

--- a/core/remote/src/main/java/com/emotionstorage/remote/dataSourceImpl/TimeCapsuleRemoteDataSourceImpl.kt
+++ b/core/remote/src/main/java/com/emotionstorage/remote/dataSourceImpl/TimeCapsuleRemoteDataSourceImpl.kt
@@ -156,16 +156,17 @@ class TimeCapsuleRemoteDataSourceImpl @Inject constructor(
         }
     }
 
-    override suspend fun getNewTimeCapsuleCount(): Int = try {
-        val response = apiService.getTimeCapsuleArrivedCount()
-        if (response.data != null) {
-            response.data.unopenedCount
-        } else {
-            throw Exception("getNewTimeCapsuleCount response data is empty, $response")
+    override suspend fun getNewTimeCapsuleCount(): Int =
+        try {
+            val response = apiService.getTimeCapsuleArrivedCount()
+            if (response.data != null) {
+                response.data.unopenedCount
+            } else {
+                throw Exception("getNewTimeCapsuleCount response data is empty, $response")
+            }
+        } catch (e: Exception) {
+            throw Exception("getNewTimeCapsuleCount api fail, ${e.message}", e)
         }
-    } catch (e: Exception) {
-        throw Exception("getNewTimeCapsuleCount api fail, ${e.message}", e)
-    }
 
     override suspend fun deleteTimeCapsule(id: Long): Boolean {
         try {

--- a/core/remote/src/main/java/com/emotionstorage/remote/response/timeCapsule/GetTimeCapsuleArrivedCountResponse.kt
+++ b/core/remote/src/main/java/com/emotionstorage/remote/response/timeCapsule/GetTimeCapsuleArrivedCountResponse.kt
@@ -1,0 +1,8 @@
+package com.emotionstorage.remote.response.timeCapsule
+
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class GetTimeCapsuleArrivedCountResponse (
+    val unopenedCount: Int
+)

--- a/core/remote/src/main/java/com/emotionstorage/remote/response/timeCapsule/GetTimeCapsuleArrivedCountResponse.kt
+++ b/core/remote/src/main/java/com/emotionstorage/remote/response/timeCapsule/GetTimeCapsuleArrivedCountResponse.kt
@@ -3,6 +3,6 @@ package com.emotionstorage.remote.response.timeCapsule
 import kotlinx.serialization.Serializable
 
 @Serializable
-data class GetTimeCapsuleArrivedCountResponse (
-    val unopenedCount: Int
+data class GetTimeCapsuleArrivedCountResponse(
+    val unopenedCount: Int,
 )

--- a/data/src/main/java/com/emotionstorage/data/dataSource/remote/TimeCapsuleRemoteDataSource.kt
+++ b/data/src/main/java/com/emotionstorage/data/dataSource/remote/TimeCapsuleRemoteDataSource.kt
@@ -17,6 +17,8 @@ interface TimeCapsuleRemoteDataSource {
 
     suspend fun getTimeCapsuleDates(yearMonth: YearMonth): List<LocalDate>
 
+    suspend fun getNewTimeCapsuleCount(): Int
+
     suspend fun getFavoriteTimeCapsules(
         page: Int,
         limit: Int,

--- a/data/src/main/java/com/emotionstorage/data/repoImpl/TimeCapsuleRepositoryImpl.kt
+++ b/data/src/main/java/com/emotionstorage/data/repoImpl/TimeCapsuleRepositoryImpl.kt
@@ -163,6 +163,12 @@ class TimeCapsuleRepositoryImpl @Inject constructor(
             }
         }
 
+    override suspend fun getNewTimeCapsuleCount(): DataState<Int> = try {
+        DataState.Success(remoteDataSource.getNewTimeCapsuleCount())
+    } catch (e: Exception) {
+        DataState.Error(e)
+    }
+
     override suspend fun deleteTimeCapsule(id: Long): Flow<DataState<Boolean>> =
         flow {
             emit(DataState.Loading(isLoading = true))

--- a/data/src/main/java/com/emotionstorage/data/repoImpl/TimeCapsuleRepositoryImpl.kt
+++ b/data/src/main/java/com/emotionstorage/data/repoImpl/TimeCapsuleRepositoryImpl.kt
@@ -163,11 +163,12 @@ class TimeCapsuleRepositoryImpl @Inject constructor(
             }
         }
 
-    override suspend fun getNewTimeCapsuleCount(): DataState<Int> = try {
-        DataState.Success(remoteDataSource.getNewTimeCapsuleCount())
-    } catch (e: Exception) {
-        DataState.Error(e)
-    }
+    override suspend fun getNewTimeCapsuleCount(): DataState<Int> =
+        try {
+            DataState.Success(remoteDataSource.getNewTimeCapsuleCount())
+        } catch (e: Exception) {
+            DataState.Error(e)
+        }
 
     override suspend fun deleteTimeCapsule(id: Long): Flow<DataState<Boolean>> =
         flow {

--- a/domain/src/main/java/com/emotionstorage/domain/repo/TimeCapsuleRepository.kt
+++ b/domain/src/main/java/com/emotionstorage/domain/repo/TimeCapsuleRepository.kt
@@ -38,6 +38,8 @@ interface TimeCapsuleRepository {
 
     suspend fun getTimeCapsuleDates(yearMonth: YearMonth): Flow<DataState<List<LocalDate>>>
 
+    suspend fun getNewTimeCapsuleCount(): DataState<Int>
+
     suspend fun deleteTimeCapsule(id: Long): Flow<DataState<Boolean>>
 
     suspend fun createTimeCapsule(id: Long): DataState<Long>

--- a/domain/src/main/java/com/emotionstorage/domain/useCase/timeCapsule/GetHasNewTimeCapsuleUseCase.kt
+++ b/domain/src/main/java/com/emotionstorage/domain/useCase/timeCapsule/GetHasNewTimeCapsuleUseCase.kt
@@ -8,13 +8,14 @@ import kotlinx.coroutines.flow.flow
 import javax.inject.Inject
 
 class GetHasNewTimeCapsuleUseCase @Inject constructor(
-    private val timeCapsuleRepository: TimeCapsuleRepository
+    private val timeCapsuleRepository: TimeCapsuleRepository,
 ) {
-    operator fun invoke(): Flow<DataState<Boolean>> = flow {
-        emit(
-            timeCapsuleRepository.getNewTimeCapsuleCount().map {
-                it > 0
-            }
-        )
-    }
+    operator fun invoke(): Flow<DataState<Boolean>> =
+        flow {
+            emit(
+                timeCapsuleRepository.getNewTimeCapsuleCount().map {
+                    it > 0
+                },
+            )
+        }
 }

--- a/domain/src/main/java/com/emotionstorage/domain/useCase/timeCapsule/GetHasNewTimeCapsuleUseCase.kt
+++ b/domain/src/main/java/com/emotionstorage/domain/useCase/timeCapsule/GetHasNewTimeCapsuleUseCase.kt
@@ -1,20 +1,20 @@
 package com.emotionstorage.domain.useCase.timeCapsule
 
 import com.emotionstorage.domain.common.DataState
-import com.emotionstorage.domain.useCase.home.GetHomeUseCase
+import com.emotionstorage.domain.common.map
+import com.emotionstorage.domain.repo.TimeCapsuleRepository
 import kotlinx.coroutines.flow.Flow
-import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.flow
 import javax.inject.Inject
 
 class GetHasNewTimeCapsuleUseCase @Inject constructor(
-    private val getHomeUseCase: GetHomeUseCase,
+    private val timeCapsuleRepository: TimeCapsuleRepository
 ) {
-    suspend operator fun invoke(): Flow<DataState<Boolean>> =
-        getHomeUseCase().map {
-            if (it is DataState.Success) {
-                DataState.Success(it.data.hasNewTimeCapsule)
-            } else {
-                it
-            } as DataState<Boolean>
-        }
+    operator fun invoke(): Flow<DataState<Boolean>> = flow {
+        emit(
+            timeCapsuleRepository.getNewTimeCapsuleCount().map {
+                it > 0
+            }
+        )
+    }
 }


### PR DESCRIPTION
## Related Issue
- Closes #231 

## 작업 상세 내용
- 도착 타임캡슐 개수 조회 api 연동

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 도착한 미개봉 타임캡슐의 개수를 조회하는 기능 추가
  * 신규 개수 기반으로 "새로운 타임캡슐 존재 여부"를 실시간 스트림으로 제공하도록 개선

* **수정**
  * 관련 데이터 흐름과 예외 처리 일관성 향상

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->