### PR TITLE
Dev/chat inspection

### DIFF
--- a/app/src/main/java/com/emotionstorage/emotionstorage/ui/AppNavHost.kt
+++ b/app/src/main/java/com/emotionstorage/emotionstorage/ui/AppNavHost.kt
@@ -269,6 +269,7 @@ internal fun AppNavHost(
                         ChatEntry.Resume -> {
                             navController.navigate(AppDestination.AIChat(roomId))
                         }
+
                         ChatEntry.New -> {
                             val seen = introSeen.value
                             if (seen) {

--- a/app/src/main/java/com/emotionstorage/emotionstorage/ui/AppNavHost.kt
+++ b/app/src/main/java/com/emotionstorage/emotionstorage/ui/AppNavHost.kt
@@ -21,6 +21,7 @@ import com.emotionstorage.alarm.ui.PushNotificationScreen
 import com.emotionstorage.auth.ui.LoginScreen
 import com.emotionstorage.auth.ui.SignupCompleteScreen
 import com.emotionstorage.daily_report.ui.DailyReportDetailScreen
+import com.emotionstorage.domain.model.ChatEntry
 import com.emotionstorage.domain.model.User.AuthProvider
 import com.emotionstorage.home.ui.HomeScreen
 import com.emotionstorage.my.ui.accountInfo.AccountInfoScreen
@@ -263,13 +264,19 @@ internal fun AppNavHost(
         composable<AppDestination.Home> {
             HomeScreen(
                 bottomAppBar = bottomAppBar,
-                navToChat = { roomId ->
-                    // DataStore 의 값에 따라 분기 처리
-                    val seen = introSeen.value
-                    if (seen) {
-                        navController.navigate(AppDestination.AIChat(roomId))
-                    } else {
-                        navController.navigate(AppDestination.AIChatDesc(roomId))
+                navToChat = { roomId, entry ->
+                    when (entry) {
+                        ChatEntry.Resume -> {
+                            navController.navigate(AppDestination.AIChat(roomId))
+                        }
+                        ChatEntry.New -> {
+                            val seen = introSeen.value
+                            if (seen) {
+                                navController.navigate(AppDestination.AIChat(roomId))
+                            } else {
+                                navController.navigate(AppDestination.AIChatDesc(roomId))
+                            }
+                        }
                     }
                 },
                 navToKey = {

--- a/domain/src/main/java/com/emotionstorage/domain/model/ChatEntry.kt
+++ b/domain/src/main/java/com/emotionstorage/domain/model/ChatEntry.kt
@@ -1,0 +1,6 @@
+package com.emotionstorage.domain.model
+
+enum class ChatEntry {
+    New,
+    Resume,
+}

--- a/feat/ai-chat/src/main/java/com/emotionstorage/ai_chat/presentation/AIChatViewModel.kt
+++ b/feat/ai-chat/src/main/java/com/emotionstorage/ai_chat/presentation/AIChatViewModel.kt
@@ -21,7 +21,6 @@ import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.launch
 import org.orbitmvi.orbit.ContainerHost
 import org.orbitmvi.orbit.viewmodel.container
-import java.time.LocalDate
 import javax.inject.Inject
 
 private const val TIME_CAPSULE_CREATE_SCORE = 70
@@ -39,13 +38,8 @@ data class AIChatState(
     val hasShownForceQuitBottomSheet: Boolean = false,
     val showForceQuitBottomSheet: Boolean = false,
     val isMooiTyping: Boolean = false,
-) {
-    val isEmpty: Boolean get() = messages.isEmpty()
-    val hasTodayHistory: Boolean
-        get() = messages.any { it.timestamp.toLocalDate() == LocalDate.now() }
-    val isNewDayFirstChat: Boolean
-        get() = !isEmpty && !hasTodayHistory
-}
+    val isLoadingHistory: Boolean = false,
+)
 
 sealed class AIChatAction {
     data class ConnectChatRoom(
@@ -135,8 +129,7 @@ class AIChatViewModel @Inject constructor(
             connectChatRoom(roomId).collect { result ->
                 when (result) {
                     is DataState.Success -> {
-                        Logger.i("chat room connected")
-                        postSideEffect(AIChatSideEffect.ToastMessage("채팅방 연결 성공"))
+                        reduce { state.copy(isLoadingHistory = true) }
 
                         when (val history = getChatRoomMessagesUseCase(cursor = null)) {
                             is DataState.Success -> {
@@ -152,11 +145,13 @@ class AIChatViewModel @Inject constructor(
                                         gaugeScore = gauge,
                                         chatProgress = progress,
                                         canCreateTimesCapsule = canCreate,
+                                        isLoadingHistory = false,
                                     )
                                 }
                             }
 
                             is DataState.Error -> {
+                                reduce { state.copy(isLoadingHistory = false) }
                                 Logger.e("history load failed: ${history.throwable}")
                                 postSideEffect(AIChatSideEffect.ToastMessage("이전 대화 불러오기 실패"))
                             }

--- a/feat/ai-chat/src/main/java/com/emotionstorage/ai_chat/presentation/AIChatViewModel.kt
+++ b/feat/ai-chat/src/main/java/com/emotionstorage/ai_chat/presentation/AIChatViewModel.kt
@@ -192,8 +192,11 @@ class AIChatViewModel @Inject constructor(
                             val nextGauge: Int = message.gaugeScore ?: state.gaugeScore
                             val computed = (nextGauge / TIME_CAPSULE_CREATE_SCORE).coerceIn(0f, 1f)
                             val newProgress: Float =
-                                if (nextGauge == 0) state.chatProgress
-                                else maxOf(MIN_PROGRESS, computed)
+                                if (nextGauge == 0) {
+                                    state.chatProgress
+                                } else {
+                                    maxOf(MIN_PROGRESS, computed)
+                                }
                             val canCreate: Boolean = nextGauge >= TIME_CAPSULE_CREATE_SCORE
 
                             if (state.isWaitingReply && isComplete) {

--- a/feat/ai-chat/src/main/java/com/emotionstorage/ai_chat/presentation/AIChatViewModel.kt
+++ b/feat/ai-chat/src/main/java/com/emotionstorage/ai_chat/presentation/AIChatViewModel.kt
@@ -23,7 +23,8 @@ import org.orbitmvi.orbit.ContainerHost
 import org.orbitmvi.orbit.viewmodel.container
 import javax.inject.Inject
 
-private const val TIME_CAPSULE_CREATE_SCORE = 70
+private const val MIN_PROGRESS = 0.03f
+private const val TIME_CAPSULE_CREATE_SCORE = 70f
 
 data class AIChatState(
     val roomId: Long = 0L,
@@ -136,7 +137,8 @@ class AIChatViewModel @Inject constructor(
                                 val historyMessages: List<ChatMessage> = history.data
 
                                 val gauge: Int = historyMessages.lastOrNull()?.gaugeScore ?: 0
-                                val progress: Float = (gauge / 70f).coerceIn(0f, 1f)
+                                val computed = (gauge / TIME_CAPSULE_CREATE_SCORE).coerceIn(0f, 1f)
+                                val progress: Float = if (gauge == 0) MIN_PROGRESS else maxOf(MIN_PROGRESS, computed)
                                 val canCreate: Boolean = gauge >= TIME_CAPSULE_CREATE_SCORE
 
                                 reduce {
@@ -188,7 +190,10 @@ class AIChatViewModel @Inject constructor(
                         .onEach { message ->
                             val isComplete = message.isComplete
                             val nextGauge: Int = message.gaugeScore ?: state.gaugeScore
-                            val newProgress: Float = (nextGauge / 70f).coerceIn(0f, 1f)
+                            val computed = (nextGauge / TIME_CAPSULE_CREATE_SCORE).coerceIn(0f, 1f)
+                            val newProgress: Float =
+                                if (nextGauge == 0) state.chatProgress
+                                else maxOf(MIN_PROGRESS, computed)
                             val canCreate: Boolean = nextGauge >= TIME_CAPSULE_CREATE_SCORE
 
                             if (state.isWaitingReply && isComplete) {
@@ -200,7 +205,6 @@ class AIChatViewModel @Inject constructor(
                                 }
                             }
 
-                            // TODO : gauge 값이 간헐적으로 null이 안들어오게 된다면 !! turnScore 값을 non-null type으로 변경
                             reduce {
                                 val rawTurnCountScore = message.turnCountScore
 

--- a/feat/ai-chat/src/main/java/com/emotionstorage/ai_chat/ui/AIChatDescriptionScreen.kt
+++ b/feat/ai-chat/src/main/java/com/emotionstorage/ai_chat/ui/AIChatDescriptionScreen.kt
@@ -43,13 +43,14 @@ import com.emotionstorage.ui.theme.MooiTheme
 fun AIChatDescriptionScreen(
     roomId: Long,
     modifier: Modifier = Modifier,
+    skipDescription: Boolean = false,
     onCheckboxChanged: (Boolean) -> Unit = {},
     onStartChat: (Long) -> Unit = {},
 ) {
     var progressRect by remember { mutableStateOf(Rect.Zero) }
     var inputRect by remember { mutableStateOf(Rect.Zero) }
     var topbarRect by remember { mutableStateOf(Rect.Zero) }
-    var showDescription by rememberSaveable { mutableStateOf(true) }
+    var showDescription by rememberSaveable(skipDescription) { mutableStateOf(!skipDescription) }
 
     StatelessAIChatDescriptionScreen(
         modifier = modifier,

--- a/feat/ai-chat/src/main/java/com/emotionstorage/ai_chat/ui/AIChatScreen.kt
+++ b/feat/ai-chat/src/main/java/com/emotionstorage/ai_chat/ui/AIChatScreen.kt
@@ -49,6 +49,7 @@ import com.emotionstorage.ai_chat.ui.modal.TimeCapsuleCreateLoadingModal
 import com.emotionstorage.ai_chat.ui.component.TimeCapsuleCreateTopbarContent
 import com.emotionstorage.ui.component.HideKeyboard
 import com.emotionstorage.ui.component.appBar.TopAppBar
+import com.emotionstorage.ui.component.loading.LoadingOverlay
 import com.emotionstorage.ui.theme.MooiTheme
 import kotlinx.coroutines.delay
 
@@ -119,7 +120,7 @@ private fun StatelessAIChatScreen(
     val isKeyboardVisible = WindowInsets.ime.getBottom(density) > 0
 
     val hasMessage = state.messages.isNotEmpty()
-    val showEmptyScreen = !hasMessage
+    val showEmptyScreen = !hasMessage && !state.isLoadingHistory
 
     LaunchedEffect(state.messages.size) {
         val last = state.messages.lastIndex
@@ -216,6 +217,10 @@ private fun StatelessAIChatScreen(
                                 ),
                             isKeyboardVisible = isKeyboardVisible,
                         )
+                    }
+
+                    if (state.isLoadingHistory) {
+                        LoadingOverlay()
                     }
                 }
 

--- a/feat/ai-chat/src/main/java/com/emotionstorage/ai_chat/ui/component/ChatMessageInputBox.kt
+++ b/feat/ai-chat/src/main/java/com/emotionstorage/ai_chat/ui/component/ChatMessageInputBox.kt
@@ -159,7 +159,7 @@ fun ChatMessageInputBox(
             Box(
                 modifier =
                     Modifier
-                        .padding(end = 7.dp, bottom = 7.dp, top = 7.dp)
+                        .padding(7.dp)
                         .size(33.dp)
                         .clip(CircleShape)
                         .align(Alignment.Bottom)

--- a/feat/ai-chat/src/main/java/com/emotionstorage/ai_chat/ui/component/ChatMessageList.kt
+++ b/feat/ai-chat/src/main/java/com/emotionstorage/ai_chat/ui/component/ChatMessageList.kt
@@ -62,13 +62,7 @@ fun ChatMessageList(
                 Spacer(modifier = Modifier.height(24.dp))
             } else {
                 val previousChat = chatMessages[index - 1]
-                val topPadding =
-                    when {
-                        previousChat.source == MessageSource.SERVER && item.source == MessageSource.CLIENT -> 20.dp
-                        previousChat.source == MessageSource.CLIENT && item.source == MessageSource.SERVER -> 10.dp
-                        previousChat.source == MessageSource.SERVER && item.source == MessageSource.SERVER -> 8.dp
-                        else -> 20.dp
-                    }
+                val topPadding = topPaddingBetween(previousChat, item.source)
                 Spacer(Modifier.size(topPadding))
             }
 
@@ -90,11 +84,7 @@ fun ChatMessageList(
                 val showTypingProfile =
                     lastMessage == null || lastMessage.source != MessageSource.SERVER
 
-                val topPadding =
-                    when (lastMessage?.source) {
-                        MessageSource.SERVER -> 8.dp
-                        else -> 20.dp
-                    }
+                val topPadding = topPaddingBetween(lastMessage, MessageSource.SERVER)
 
                 Spacer(Modifier.height(topPadding))
 
@@ -241,6 +231,16 @@ private fun ChatMessageItem(
                 )
             }
         }
+    }
+}
+
+private fun topPaddingBetween(prev: ChatMessage?, curr: MessageSource): androidx.compose.ui.unit.Dp {
+    if (prev == null) return 0.dp
+    return when {
+        prev.source == MessageSource.SERVER && curr == MessageSource.CLIENT -> 20.dp
+        prev.source == MessageSource.CLIENT && curr == MessageSource.SERVER -> 10.dp
+        prev.source == MessageSource.SERVER && curr == MessageSource.SERVER -> 8.dp
+        else -> 20.dp
     }
 }
 

--- a/feat/ai-chat/src/main/java/com/emotionstorage/ai_chat/ui/component/ChatMessageList.kt
+++ b/feat/ai-chat/src/main/java/com/emotionstorage/ai_chat/ui/component/ChatMessageList.kt
@@ -234,7 +234,10 @@ private fun ChatMessageItem(
     }
 }
 
-private fun topPaddingBetween(prev: ChatMessage?, curr: MessageSource): androidx.compose.ui.unit.Dp {
+private fun topPaddingBetween(
+    prev: ChatMessage?,
+    curr: MessageSource,
+): androidx.compose.ui.unit.Dp {
     if (prev == null) return 0.dp
     return when {
         prev.source == MessageSource.SERVER && curr == MessageSource.CLIENT -> 20.dp

--- a/feat/home/src/main/java/com/emotionstorage/home/presentation/HomeViewModel.kt
+++ b/feat/home/src/main/java/com/emotionstorage/home/presentation/HomeViewModel.kt
@@ -3,6 +3,7 @@ package com.emotionstorage.home.presentation
 import com.emotionstorage.domain.common.DataState
 import com.emotionstorage.domain.common.ErrorCode
 import com.emotionstorage.domain.common.collectDataState
+import com.emotionstorage.domain.model.ChatEntry
 import com.emotionstorage.domain.useCase.chat.DeleteChatRoomUseCase
 import com.emotionstorage.domain.useCase.chat.GetChatRoomSessionUseCase
 import com.emotionstorage.domain.useCase.home.GetHomeUseCase
@@ -46,6 +47,7 @@ sealed class HomeSideEffect : BaseSideEffect {
 
     data class EnterChatRoom(
         val roomId: Long,
+        val entry: ChatEntry,
     ) : HomeSideEffect()
 }
 
@@ -178,7 +180,7 @@ class HomeViewModel
                                     pendingChatRoomId = null,
                                 )
                             }
-                            postSideEffect(HomeSideEffect.EnterChatRoom(session.roomId))
+                            postSideEffect(HomeSideEffect.EnterChatRoom(session.roomId, ChatEntry.New))
                         }
                     },
                     onError = { throwable, code, data ->
@@ -208,7 +210,7 @@ class HomeViewModel
                 }
 
                 // TODO : 채팅방 불러오기 작업
-                postSideEffect(HomeSideEffect.EnterChatRoom(roomId))
+                postSideEffect(HomeSideEffect.EnterChatRoom(roomId, ChatEntry.Resume))
             }
 
         private fun handleDismissResumeChat() =

--- a/feat/home/src/main/java/com/emotionstorage/home/ui/HomeScreen.kt
+++ b/feat/home/src/main/java/com/emotionstorage/home/ui/HomeScreen.kt
@@ -40,6 +40,7 @@ import androidx.compose.ui.unit.sp
 import androidx.compose.ui.zIndex
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.LifecycleResumeEffect
+import com.emotionstorage.domain.model.ChatEntry
 import com.emotionstorage.home.presentation.AttendanceViewModel
 import com.emotionstorage.home.presentation.HomeAction
 import com.emotionstorage.home.presentation.HomeSideEffect
@@ -64,7 +65,7 @@ fun HomeScreen(
     navToKey: () -> Unit = {},
     navToAlarm: () -> Unit = {},
     navToDailyReport: (Long) -> Unit = { },
-    navToChat: (Long) -> Unit = {},
+    navToChat: (Long, ChatEntry) -> Unit = { _, _ -> },
     navToArrivedTimeCapsules: () -> Unit = {},
 ) {
     val context = LocalContext.current
@@ -89,7 +90,7 @@ fun HomeScreen(
                 }
 
                 is HomeSideEffect.EnterChatRoom -> {
-                    navToChat(it.roomId)
+                    navToChat(it.roomId, it.entry)
                 }
 
                 is BaseSideEffect.NetworkError -> {


### PR DESCRIPTION
## Related Issue
- Issue #238 

## 작업 상세 내용
- 중단된 대화 이어하기 시 채팅 설명 Workthrough 나오지 않도록 수정 (QA-45)
- 전일 중단된 대화 만료 (QA-47 -> Server 측 수정 사항 확인 후에도 문제가 있으면 다시 Issue로 올릴 예정)
- 첫 채팅 시 서버 측 응답 메세지 튀는 현상 수정
- 채팅 불러올 시 빈 채팅 방의 Image가 등장하지 않도록 개선
- 첫 채팅 입력 시 게이지가 3 -> 0 으로 떨어졌다가 응답 게이지로 변경되는 사항 수정 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **새 기능**
  * 채팅 기록 로딩 중 화면에 로딩 표시기 추가
  * 채팅 진입 방식에 "새로 시작/재개" 구분 도입으로 재개 시 바로 이어서 보기 또는 설명 화면 선택 지원
  * 설명 화면 건너뛰기 옵션 추가

* **개선**
  * 채팅 진행도 게이지 계산 개선(최소값 보장)
  * 메시지 입력·목록 간격 및 레이아웃 정리로 시각적 일관성 향상

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->