### PR TITLE
fix: add navigation launch singletop extension function

### DIFF
--- a/app/src/main/java/com/emotionstorage/emotionstorage/ui/AppNavHost.kt
+++ b/app/src/main/java/com/emotionstorage/emotionstorage/ui/AppNavHost.kt
@@ -24,12 +24,12 @@ import com.emotionstorage.daily_report.ui.DailyReportDetailScreen
 import com.emotionstorage.domain.model.ChatEntry
 import com.emotionstorage.domain.model.User.AuthProvider
 import com.emotionstorage.home.ui.HomeScreen
+import com.emotionstorage.my.ui.NicknameChangeScreen
+import com.emotionstorage.my.ui.TermsAndPrivacyScreen
 import com.emotionstorage.my.ui.accountInfo.AccountInfoScreen
 import com.emotionstorage.my.ui.keyDescription.KeyDescriptionScreen
 import com.emotionstorage.my.ui.myPage.MyPageScreen
-import com.emotionstorage.my.ui.NicknameChangeScreen
 import com.emotionstorage.my.ui.notificationSettings.NotificationSettingScreen
-import com.emotionstorage.my.ui.TermsAndPrivacyScreen
 import com.emotionstorage.my.ui.withdraw.WithDrawNoticeScreen
 import com.emotionstorage.time_capsule.ui.ArrivedTimeCapsulesScreen
 import com.emotionstorage.time_capsule.ui.CalendarScreen
@@ -39,11 +39,12 @@ import com.emotionstorage.time_capsule_detail.ui.TimeCapsuleDetailScreen
 import com.emotionstorage.tutorial.ui.OnBoardingNavHost
 import com.emotionstorage.tutorial.ui.SplashScreen
 import com.emotionstorage.tutorial.ui.TutorialScreen
+import com.emotionstorage.ui.R
 import com.emotionstorage.ui.component.appBar.BottomAppNavBar
 import com.emotionstorage.ui.component.appBar.BottomNavDest
 import com.emotionstorage.ui.theme.MooiTheme
+import com.emotionstorage.ui.util.navigateAsRoot
 import com.emotionstorage.ui.util.navigateWithClearStack
-import com.emotionstorage.ui.R
 import kotlinx.serialization.Serializable
 
 /**
@@ -417,10 +418,7 @@ internal fun AppNavHost(
                 id = arguments.id,
                 isNewTimeCapsule = arguments.isNewTimeCapsule,
                 navToMain = {
-                    navController.navigate(AppDestination.Home) {
-                        popUpTo(navController.graph.id) { inclusive = true }
-                        launchSingleTop = true
-                    }
+                    navController.navigateAsRoot(AppDestination.Home)
                 },
                 navToPrevious = {
                     // pop twice, to navigate to previous screen
@@ -457,7 +455,7 @@ internal fun AppNavHost(
                     navController.popBackStack()
                 },
                 navToLogin = {
-                    navController.navigateWithClearStack(AppDestination.Login)
+                    navController.navigateAsRoot(AppDestination.Login)
                 },
                 /*  navToNotificationSetting = {
                       navController.navigateWithClearStack(AppDestination.NotificationSetting)

--- a/core/ui/src/main/java/com/emotionstorage/ui/util/NavHostControllerExt.kt
+++ b/core/ui/src/main/java/com/emotionstorage/ui/util/NavHostControllerExt.kt
@@ -1,6 +1,7 @@
 package com.emotionstorage.ui.util
 
 import androidx.navigation.NavHostController
+import androidx.navigation.NavOptionsBuilder
 
 // navigate to destination with clear stack
 fun <T : Any> NavHostController.navigateWithClearStack(destRoute: T) {
@@ -10,5 +11,18 @@ fun <T : Any> NavHostController.navigateWithClearStack(destRoute: T) {
         popUpTo(currentRoute ?: destRoute.toString()) {
             inclusive = true
         }
+    }
+}
+
+fun <T : Any> NavHostController.navigateAsRoot(
+    destRoute: T,
+    builder: NavOptionsBuilder.() -> Unit = {},
+) {
+    navigate(destRoute) {
+        popUpTo(graph.id) {
+            inclusive = true
+        }
+        launchSingleTop = true
+        builder()
     }
 }


### PR DESCRIPTION
## Related Issue
- Issue #242

## 작업 상세 내용
- 회원 탈퇴 후 로그인 화면으로 넘어갔을 때 마이페이지 화면이 내비게이션 그래프 스택에 남아있지 않도록 수정

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **리팩토링**
  * 내비게이션 스택 처리 로직을 개선했습니다. 루트 내비게이션으로 통일하여 뒤로가기 스택을 더 안정적으로 관리합니다.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->