### PR TITLE
fix: bottomsheet dismiss and back key forbid

### DIFF
--- a/feat/ai-chat/src/main/java/com/emotionstorage/ai_chat/ui/AIChatScreen.kt
+++ b/feat/ai-chat/src/main/java/com/emotionstorage/ai_chat/ui/AIChatScreen.kt
@@ -16,7 +16,6 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.LazyListState
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Scaffold
-import androidx.compose.material3.SheetValue
 import androidx.compose.material3.rememberModalBottomSheetState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect

--- a/feat/ai-chat/src/main/java/com/emotionstorage/ai_chat/ui/AIChatScreen.kt
+++ b/feat/ai-chat/src/main/java/com/emotionstorage/ai_chat/ui/AIChatScreen.kt
@@ -16,6 +16,7 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.LazyListState
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Scaffold
+import androidx.compose.material3.SheetValue
 import androidx.compose.material3.rememberModalBottomSheetState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
@@ -237,7 +238,14 @@ private fun StatelessAIChatScreen(
 
                 if (state.showForceQuitBottomSheet) {
                     ForceQuitChatBottomSheet(
-                        onDismissRequest = { onAction(AIChatAction.DismissForceQuitSheet) },
+                        sheetState =
+                            rememberModalBottomSheetState(
+                                skipPartiallyExpanded = true,
+                                confirmValueChange = { next ->
+                                    next != SheetValue.Hidden
+                                },
+                            ),
+                        onDismissRequest = { /* no-op */ },
                         onConfirm = {
                             onAction(AIChatAction.DismissForceQuitSheet)
                             onAction(AIChatAction.CreateTimeCapsule)

--- a/feat/ai-chat/src/main/java/com/emotionstorage/ai_chat/ui/AIChatScreen.kt
+++ b/feat/ai-chat/src/main/java/com/emotionstorage/ai_chat/ui/AIChatScreen.kt
@@ -238,14 +238,6 @@ private fun StatelessAIChatScreen(
 
                 if (state.showForceQuitBottomSheet) {
                     ForceQuitChatBottomSheet(
-                        sheetState =
-                            rememberModalBottomSheetState(
-                                skipPartiallyExpanded = true,
-                                confirmValueChange = { next ->
-                                    next != SheetValue.Hidden
-                                },
-                            ),
-                        onDismissRequest = { /* no-op */ },
                         onConfirm = {
                             onAction(AIChatAction.DismissForceQuitSheet)
                             onAction(AIChatAction.CreateTimeCapsule)

--- a/feat/ai-chat/src/main/java/com/emotionstorage/ai_chat/ui/bottomSheet/ForceQuitChatBottomSheet.kt
+++ b/feat/ai-chat/src/main/java/com/emotionstorage/ai_chat/ui/bottomSheet/ForceQuitChatBottomSheet.kt
@@ -6,6 +6,7 @@ import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.SheetState
+import androidx.compose.material3.SheetValue
 import androidx.compose.material3.rememberModalBottomSheetState
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
@@ -14,8 +15,6 @@ import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import com.emotionstorage.ui.component.bottomSheet.BottomSheet
 import com.emotionstorage.ui.theme.MooiTheme
-
-// TODO : 외부 화면을 눌렀을 때 반드시 Bottom Sheet Dismiss가 되지 않도록 해야한다
 
 /**
  * capsule_create_03
@@ -32,13 +31,19 @@ import com.emotionstorage.ui.theme.MooiTheme
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun ForceQuitChatBottomSheet(
-    sheetState: SheetState = rememberModalBottomSheetState(),
-    onDismissRequest: () -> Unit = {},
     onConfirm: () -> Unit = {},
 ) {
     BottomSheet(
-        onDismissRequest = onDismissRequest,
-        sheetState = sheetState,
+        sheetState =
+        rememberModalBottomSheetState(
+            skipPartiallyExpanded = true,
+            confirmValueChange = { next ->
+                next != SheetValue.Hidden
+            },
+        ),
+        onDismissRequest = {
+            // no operation
+        },
         hideDragHandle = true,
         shouldDismissOnBackPress = false,
         forbidDismiss = true,

--- a/feat/ai-chat/src/main/java/com/emotionstorage/ai_chat/ui/bottomSheet/ForceQuitChatBottomSheet.kt
+++ b/feat/ai-chat/src/main/java/com/emotionstorage/ai_chat/ui/bottomSheet/ForceQuitChatBottomSheet.kt
@@ -5,6 +5,8 @@ import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.SheetState
+import androidx.compose.material3.rememberModalBottomSheetState
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
@@ -30,12 +32,16 @@ import com.emotionstorage.ui.theme.MooiTheme
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun ForceQuitChatBottomSheet(
+    sheetState: SheetState = rememberModalBottomSheetState(),
     onDismissRequest: () -> Unit = {},
     onConfirm: () -> Unit = {},
 ) {
     BottomSheet(
         onDismissRequest = onDismissRequest,
+        sheetState = sheetState,
         hideDragHandle = true,
+        shouldDismissOnBackPress = false,
+        forbidDismiss = true,
         subTitle = "감정 대화를 충분히 나누었어요",
         title = "지금 이 감정,\n타임캡슐에 담아둘까요?",
         confirmLabel = "타임캡슐 만들러 가기",
@@ -44,6 +50,7 @@ fun ForceQuitChatBottomSheet(
     )
 }
 
+@OptIn(ExperimentalMaterial3Api::class)
 @Preview
 @Composable
 private fun ForceQuitChatBottomSheetPreview() {

--- a/feat/ai-chat/src/main/java/com/emotionstorage/ai_chat/ui/bottomSheet/ForceQuitChatBottomSheet.kt
+++ b/feat/ai-chat/src/main/java/com/emotionstorage/ai_chat/ui/bottomSheet/ForceQuitChatBottomSheet.kt
@@ -5,7 +5,6 @@ import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.material3.ExperimentalMaterial3Api
-import androidx.compose.material3.SheetState
 import androidx.compose.material3.SheetValue
 import androidx.compose.material3.rememberModalBottomSheetState
 import androidx.compose.runtime.Composable
@@ -30,17 +29,15 @@ import com.emotionstorage.ui.theme.MooiTheme
  */
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
-fun ForceQuitChatBottomSheet(
-    onConfirm: () -> Unit = {},
-) {
+fun ForceQuitChatBottomSheet(onConfirm: () -> Unit = {}) {
     BottomSheet(
         sheetState =
-        rememberModalBottomSheetState(
-            skipPartiallyExpanded = true,
-            confirmValueChange = { next ->
-                next != SheetValue.Hidden
-            },
-        ),
+            rememberModalBottomSheetState(
+                skipPartiallyExpanded = true,
+                confirmValueChange = { next ->
+                    next != SheetValue.Hidden
+                },
+            ),
         onDismissRequest = {
             // no operation
         },


### PR DESCRIPTION
## Related Issue
- Issue #244

## 작업 상세 내용
- 바텀 시트 dismiss & 뒤로가기 동작 막는 작업

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **개선 사항**
  * AI 채팅 강제 종료 대화창의 닫힘 동작을 강화했습니다 — 백 버튼·백그라운드 탭 등으로 실수로 닫히지 않도록 방지하여 안정성을 높였습니다.
  * 확인(종료) 동작은 기존과 동일하게 유지되어 의도한 종료만 처리됩니다.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->