### PR TITLE
Feat/login expired 홈 화면 로그인 만료 팝업 추가 & 모달 로직 리팩토링

### DIFF
--- a/app/src/main/java/com/emotionstorage/emotionstorage/ui/AppNavHost.kt
+++ b/app/src/main/java/com/emotionstorage/emotionstorage/ui/AppNavHost.kt
@@ -295,7 +295,7 @@ internal fun AppNavHost(
                 },
                 navToLogin = {
                     navController.navigateAsRoot(AppDestination.Login)
-                }
+                },
             )
         }
         composable<AppDestination.TimeCapsuleCalendar> {

--- a/app/src/main/java/com/emotionstorage/emotionstorage/ui/AppNavHost.kt
+++ b/app/src/main/java/com/emotionstorage/emotionstorage/ui/AppNavHost.kt
@@ -293,6 +293,9 @@ internal fun AppNavHost(
                 navToDailyReport = { id ->
                     navController.navigate(AppDestination.DailyReportDetail(id))
                 },
+                navToLogin = {
+                    navController.navigateAsRoot(AppDestination.Login)
+                }
             )
         }
         composable<AppDestination.TimeCapsuleCalendar> {

--- a/core/ui/src/main/java/com/emotionstorage/ui/component/modal/LoginSessionExpiredModal.kt
+++ b/core/ui/src/main/java/com/emotionstorage/ui/component/modal/LoginSessionExpiredModal.kt
@@ -1,0 +1,43 @@
+package com.emotionstorage.ui.component.modal
+
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.tooling.preview.Preview
+
+/**
+ *
+ *
+ * common_session_expired
+ * - Case : 로그인 세션 만료(Access Token/Refresh Token 만료)
+ *      - 앱이 종료되지 않은 상태에서 액세스 및 리프레시 토큰이 만료되어 로그인이 풀렸을 때 표출
+ * - CTA 및 이동
+ *     - [다시 로그인하기] -> 로그인 화면으로 이동
+ * - 차단
+ *     - 뒤로가기 X
+ *     - 배경 터치 X
+ */
+@Composable
+fun LoginSessionExpiredModal(
+    onDismissRequest: () -> Unit,
+    navToLogin: () -> Unit,
+) {
+    Modal(
+        onDismissRequest = onDismissRequest,
+        dismissOnBackPress = false,
+        dismissOnClickOutside = false,
+        title = "로그인 세션이 만료되었어요.\n다시 로그인해주세요.",
+        confirmLabel = "다시 로그인하기",
+        onConfirm = navToLogin,
+    )
+}
+
+@Preview(showBackground = true)
+@Composable
+private fun LoginSessionExpiredPreview() {
+    // background ui
+    Box(modifier = Modifier.fillMaxSize())
+
+    LoginSessionExpiredModal(onDismissRequest = {}, navToLogin = {})
+}

--- a/feat/ai-chat/src/main/java/com/emotionstorage/ai_chat/presentation/AIChatViewModel.kt
+++ b/feat/ai-chat/src/main/java/com/emotionstorage/ai_chat/presentation/AIChatViewModel.kt
@@ -393,7 +393,7 @@ class AIChatViewModel @Inject constructor(
                 return@intent
             }
 
-            when (val save = tempSaveChatRoomUseCase(roomId)) {
+            when (tempSaveChatRoomUseCase(roomId)) {
                 is DataState.Success -> {
                     postSideEffect(AIChatSideEffect.ToastMessage("임시 저장 완료"))
                 }

--- a/feat/home/src/main/java/com/emotionstorage/home/presentation/HomeViewModel.kt
+++ b/feat/home/src/main/java/com/emotionstorage/home/presentation/HomeViewModel.kt
@@ -34,11 +34,11 @@ sealed class HomeAction {
 
     object EnterChat : HomeAction()
 
-    data class ResumePendingChat(
+    data class ResumeChat(
         val roomId: Long,
     ) : HomeAction()
 
-    data class DeletePendingChat(
+    data class DeleteAndEnterNewChat(
         val roomId: Long,
     ) : HomeAction()
 }
@@ -78,12 +78,12 @@ class HomeViewModel
                     handleEnterChat()
                 }
 
-                is HomeAction.ResumePendingChat -> {
+                is HomeAction.ResumeChat -> {
                     handleEnterPendingChat(action.roomId)
                 }
 
-                is HomeAction.DeletePendingChat -> {
-                    handleDeletePendingChat(action.roomId)
+                is HomeAction.DeleteAndEnterNewChat -> {
+                    handleDeletePendingChatAndEnterNewChat(action.roomId)
                 }
             }
         }
@@ -198,14 +198,21 @@ class HomeViewModel
                 postSideEffect(HomeSideEffect.EnterChatRoom(roomId, ChatEntry.Resume))
             }
 
-        private fun handleDeletePendingChat(roomId: Long) =
+        private fun handleDeletePendingChatAndEnterNewChat(roomId: Long) =
             baseIntent {
                 deleteChatRoom(roomId).handle(
                     onSuccess = {
                         Logger.d("HomeViewModel: exitChatRoom success")
+                        // enter new chat
+                        handleEnterChat()
                     },
                     onError = { throwable, code, data ->
                         Logger.e("HomeViewModel: exitChatRoom failed $throwable")
+                        throw BaseException(
+                            cause = throwable,
+                            code = code,
+                            message = throwable.message ?: "Home exit chat error",
+                        )
                     },
                 )
             }

--- a/feat/home/src/main/java/com/emotionstorage/home/presentation/HomeViewModel.kt
+++ b/feat/home/src/main/java/com/emotionstorage/home/presentation/HomeViewModel.kt
@@ -34,11 +34,11 @@ sealed class HomeAction {
 
     object EnterChat : HomeAction()
 
-    data class ConfirmResumeChat(
+    data class ResumePendingChat(
         val roomId: Long,
     ) : HomeAction()
 
-    data class DismissResumeChat(
+    data class DeletePendingChat(
         val roomId: Long,
     ) : HomeAction()
 }
@@ -48,7 +48,7 @@ sealed class HomeSideEffect : BaseSideEffect {
 
     data class ShowResumeChatModal(
         val pendingRoomId: Long,
-    ): HomeSideEffect()
+    ) : HomeSideEffect()
 
     data class EnterChatRoom(
         val roomId: Long,
@@ -78,12 +78,12 @@ class HomeViewModel
                     handleEnterChat()
                 }
 
-                is HomeAction.ConfirmResumeChat -> {
-                    handleConfirmResumeChat(action.roomId)
+                is HomeAction.ResumePendingChat -> {
+                    handleEnterPendingChat(action.roomId)
                 }
 
-                is HomeAction.DismissResumeChat -> {
-                    handleDismissResumeChat(action.roomId)
+                is HomeAction.DeletePendingChat -> {
+                    handleDeletePendingChat(action.roomId)
                 }
             }
         }
@@ -192,13 +192,13 @@ class HomeViewModel
                 )
             }
 
-        private fun handleConfirmResumeChat(roomId: Long) =
+        private fun handleEnterPendingChat(roomId: Long) =
             baseIntent {
                 // TODO : 채팅방 불러오기 작업
                 postSideEffect(HomeSideEffect.EnterChatRoom(roomId, ChatEntry.Resume))
             }
 
-        private fun handleDismissResumeChat(roomId: Long) =
+        private fun handleDeletePendingChat(roomId: Long) =
             baseIntent {
                 deleteChatRoom(roomId).handle(
                     onSuccess = {

--- a/feat/home/src/main/java/com/emotionstorage/home/presentation/HomeViewModel.kt
+++ b/feat/home/src/main/java/com/emotionstorage/home/presentation/HomeViewModel.kt
@@ -1,6 +1,5 @@
 package com.emotionstorage.home.presentation
 
-import com.emotionstorage.domain.common.DataState
 import com.emotionstorage.domain.common.ErrorCode
 import com.emotionstorage.domain.common.collectDataState
 import com.emotionstorage.domain.model.ChatEntry
@@ -28,8 +27,6 @@ data class HomeState(
     val newTimeCapsuleArrived: Boolean = false,
     val newReportArrived: Boolean = false,
     val newReportId: Long? = null,
-    val showResumeChatModal: Boolean = false,
-    val pendingChatRoomId: Long? = null,
 )
 
 sealed class HomeAction {
@@ -37,13 +34,21 @@ sealed class HomeAction {
 
     object EnterChat : HomeAction()
 
-    object ConfirmResumeChat : HomeAction()
+    data class ConfirmResumeChat(
+        val roomId: Long,
+    ) : HomeAction()
 
-    object DismissResumeChat : HomeAction()
+    data class DismissResumeChat(
+        val roomId: Long,
+    ) : HomeAction()
 }
 
 sealed class HomeSideEffect : BaseSideEffect {
     object TicketNotEnough : HomeSideEffect()
+
+    data class ShowResumeChatModal(
+        val pendingRoomId: Long,
+    ): HomeSideEffect()
 
     data class EnterChatRoom(
         val roomId: Long,
@@ -74,11 +79,11 @@ class HomeViewModel
                 }
 
                 is HomeAction.ConfirmResumeChat -> {
-                    handleConfirmResumeChat()
+                    handleConfirmResumeChat(action.roomId)
                 }
 
                 is HomeAction.DismissResumeChat -> {
-                    handleDismissResumeChat()
+                    handleDismissResumeChat(action.roomId)
                 }
             }
         }
@@ -167,19 +172,8 @@ class HomeViewModel
                 getChatRoomSession().handle(
                     onSuccess = { session ->
                         if (session.isTempSave) {
-                            reduce {
-                                state.copy(
-                                    showResumeChatModal = true,
-                                    pendingChatRoomId = session.roomId,
-                                )
-                            }
+                            postSideEffect(HomeSideEffect.ShowResumeChatModal(session.roomId))
                         } else {
-                            reduce {
-                                state.copy(
-                                    showResumeChatModal = false,
-                                    pendingChatRoomId = null,
-                                )
-                            }
                             postSideEffect(HomeSideEffect.EnterChatRoom(session.roomId, ChatEntry.New))
                         }
                     },
@@ -198,43 +192,21 @@ class HomeViewModel
                 )
             }
 
-        private fun handleConfirmResumeChat() =
+        private fun handleConfirmResumeChat(roomId: Long) =
             baseIntent {
-                val roomId = state.pendingChatRoomId ?: return@baseIntent
-
-                reduce {
-                    state.copy(
-                        showResumeChatModal = false,
-                        pendingChatRoomId = null,
-                    )
-                }
-
                 // TODO : 채팅방 불러오기 작업
                 postSideEffect(HomeSideEffect.EnterChatRoom(roomId, ChatEntry.Resume))
             }
 
-        private fun handleDismissResumeChat() =
+        private fun handleDismissResumeChat(roomId: Long) =
             baseIntent {
-                val roomId = state.pendingChatRoomId ?: return@baseIntent
-
-                reduce {
-                    state.copy(
-                        showResumeChatModal = false,
-                        pendingChatRoomId = null,
-                    )
-                }
-
-                when (val result = deleteChatRoom(roomId)) {
-                    is DataState.Success -> {
+                deleteChatRoom(roomId).handle(
+                    onSuccess = {
                         Logger.d("HomeViewModel: exitChatRoom success")
-                    }
-
-                    is DataState.Loading -> {
-                    }
-
-                    is DataState.Error -> {
-                        Logger.e("HomeViewModel: exitChatRoom failed ${result.throwable}")
-                    }
-                }
+                    },
+                    onError = { throwable, code, data ->
+                        Logger.e("HomeViewModel: exitChatRoom failed $throwable")
+                    },
+                )
             }
     }

--- a/feat/home/src/main/java/com/emotionstorage/home/ui/HomeScreen.kt
+++ b/feat/home/src/main/java/com/emotionstorage/home/ui/HomeScreen.kt
@@ -45,7 +45,6 @@ import com.emotionstorage.domain.model.ChatEntry
 import com.emotionstorage.home.presentation.AttendanceAction
 import com.emotionstorage.home.presentation.AttendanceViewModel
 import com.emotionstorage.home.presentation.HomeAction
-import com.emotionstorage.home.presentation.HomeAction.*
 import com.emotionstorage.home.presentation.HomeSideEffect
 import com.emotionstorage.home.presentation.HomeState
 import com.emotionstorage.home.presentation.HomeViewModel
@@ -65,7 +64,9 @@ import com.emotionstorage.ui.theme.MooiTheme
 private sealed class HomeModalState {
     object None : HomeModalState()
 
-    data class ResumeChat(val pendingRoomId: Long) : HomeModalState()
+    data class ResumeChat(
+        val pendingRoomId: Long,
+    ) : HomeModalState()
 
     object LoginSessionExpired : HomeModalState()
 
@@ -133,7 +134,7 @@ fun HomeScreen(
 
     LifecycleResumeEffect("onResume") {
         // init screen state on resume
-        viewModel.onAction(Initiate)
+        viewModel.onAction(HomeAction.Initiate)
         onPauseOrDispose {}
     }
 
@@ -162,20 +163,20 @@ fun HomeScreen(
         )
     }
 
-    when(modalState){
+    when (modalState) {
         is HomeModalState.None -> {
             // no modal
         }
         is HomeModalState.ResumeChat -> {
             ResumeChatModal(
                 onDismissRequest = {
-                    viewModel.onAction(DismissResumeChat(modalState.pendingRoomId))
+                    viewModel.onAction(HomeAction.DeletePendingChat(modalState.pendingRoomId))
                 },
                 onResume = {
-                    viewModel.onAction(ConfirmResumeChat(modalState.pendingRoomId))
+                    viewModel.onAction(HomeAction.ResumePendingChat(modalState.pendingRoomId))
                 },
                 onDropAndStartNew = {
-                    viewModel.onAction(DismissResumeChat(modalState.pendingRoomId))
+                    viewModel.onAction(HomeAction.DeletePendingChat(modalState.pendingRoomId))
                 },
             )
         }
@@ -195,7 +196,6 @@ fun HomeScreen(
             )
         }
     }
-
 }
 
 @Composable
@@ -399,8 +399,7 @@ private fun StartChatButton(
             modifier
                 .width(
                     if (canStartChat) 198.dp else 197.dp,
-                )
-                .height(
+                ).height(
                     if (canStartChat) 54.dp else 65.dp,
                 ),
         enabled = canStartChat,

--- a/feat/home/src/main/java/com/emotionstorage/home/ui/HomeScreen.kt
+++ b/feat/home/src/main/java/com/emotionstorage/home/ui/HomeScreen.kt
@@ -170,7 +170,7 @@ fun HomeScreen(
         is HomeModalState.ResumeChat -> {
             ResumeChatModal(
                 onDismissRequest = {
-                    viewModel.onAction(HomeAction.DeletePendingChat(modalState.pendingRoomId))
+                    setModalState(HomeModalState.None)
                 },
                 onResume = {
                     viewModel.onAction(HomeAction.ResumePendingChat(modalState.pendingRoomId))

--- a/feat/home/src/main/java/com/emotionstorage/home/ui/HomeScreen.kt
+++ b/feat/home/src/main/java/com/emotionstorage/home/ui/HomeScreen.kt
@@ -167,6 +167,7 @@ fun HomeScreen(
         is HomeModalState.None -> {
             // no modal
         }
+
         is HomeModalState.ResumeChat -> {
             ResumeChatModal(
                 onDismissRequest = {
@@ -181,6 +182,7 @@ fun HomeScreen(
                 },
             )
         }
+
         is HomeModalState.LoginSessionExpired -> {
             LoginSessionExpiredModal(
                 onDismissRequest = {
@@ -189,6 +191,7 @@ fun HomeScreen(
                 navToLogin = navToLogin,
             )
         }
+
         is HomeModalState.TempError -> {
             TempErrorModal(
                 onDismissRequest = {

--- a/feat/home/src/main/java/com/emotionstorage/home/ui/HomeScreen.kt
+++ b/feat/home/src/main/java/com/emotionstorage/home/ui/HomeScreen.kt
@@ -177,6 +177,7 @@ fun HomeScreen(
                 },
                 onDropAndStartNew = {
                     viewModel.onAction(HomeAction.DeletePendingChat(modalState.pendingRoomId))
+                    viewModel.onAction(HomeAction.EnterChat)
                 },
             )
         }

--- a/feat/home/src/main/java/com/emotionstorage/home/ui/HomeScreen.kt
+++ b/feat/home/src/main/java/com/emotionstorage/home/ui/HomeScreen.kt
@@ -174,11 +174,10 @@ fun HomeScreen(
                     setModalState(HomeModalState.None)
                 },
                 onResume = {
-                    viewModel.onAction(HomeAction.ResumePendingChat(modalState.pendingRoomId))
+                    viewModel.onAction(HomeAction.ResumeChat(modalState.pendingRoomId))
                 },
                 onDropAndStartNew = {
-                    viewModel.onAction(HomeAction.DeletePendingChat(modalState.pendingRoomId))
-                    viewModel.onAction(HomeAction.EnterChat)
+                    viewModel.onAction(HomeAction.DeleteAndEnterNewChat(modalState.pendingRoomId))
                 },
             )
         }

--- a/feat/home/src/main/java/com/emotionstorage/home/ui/HomeScreen.kt
+++ b/feat/home/src/main/java/com/emotionstorage/home/ui/HomeScreen.kt
@@ -22,6 +22,7 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -44,6 +45,7 @@ import com.emotionstorage.domain.model.ChatEntry
 import com.emotionstorage.home.presentation.AttendanceAction
 import com.emotionstorage.home.presentation.AttendanceViewModel
 import com.emotionstorage.home.presentation.HomeAction
+import com.emotionstorage.home.presentation.HomeAction.*
 import com.emotionstorage.home.presentation.HomeSideEffect
 import com.emotionstorage.home.presentation.HomeState
 import com.emotionstorage.home.presentation.HomeViewModel
@@ -55,26 +57,41 @@ import com.emotionstorage.ui.R
 import com.emotionstorage.ui.component.IconWithCount
 import com.emotionstorage.ui.component.button.CtaButton
 import com.emotionstorage.ui.component.loading.LoadingOverlay
+import com.emotionstorage.ui.component.modal.LoginSessionExpiredModal
+import com.emotionstorage.ui.component.modal.TempErrorModal
 import com.emotionstorage.ui.component.toast.AppSnackbarHost
 import com.emotionstorage.ui.theme.MooiTheme
 
+private sealed class HomeModalState {
+    object None : HomeModalState()
+
+    data class ResumeChat(val pendingRoomId: Long) : HomeModalState()
+
+    object LoginSessionExpired : HomeModalState()
+
+    object TempError : HomeModalState()
+}
+
 @Composable
 fun HomeScreen(
+    navToKey: () -> Unit,
+    navToAlarm: () -> Unit,
+    navToDailyReport: (Long) -> Unit,
+    navToChat: (Long, ChatEntry) -> Unit,
+    navToArrivedTimeCapsules: () -> Unit,
+    navToLogin: () -> Unit,
     modifier: Modifier = Modifier,
     viewModel: HomeViewModel = hiltViewModel(),
     attendanceViewModel: AttendanceViewModel = hiltViewModel(),
     bottomAppBar: @Composable (() -> Unit) = {},
-    navToKey: () -> Unit = {},
-    navToAlarm: () -> Unit = {},
-    navToDailyReport: (Long) -> Unit = { },
-    navToChat: (Long, ChatEntry) -> Unit = { _, _ -> },
-    navToArrivedTimeCapsules: () -> Unit = {},
 ) {
     val context = LocalContext.current
 
     val state = viewModel.container.stateFlow.collectAsState()
     val attendanceState = attendanceViewModel.uiState.collectAsState()
     val snackbarState = remember { SnackbarHostState() }
+    val (modalState, setModalState) = remember { mutableStateOf<HomeModalState>(HomeModalState.None) }
+
     val summary = attendanceState.value.summary
 
 //    NotificationPermissionAutoRequest()
@@ -87,8 +104,12 @@ fun HomeScreen(
         viewModel.container.sideEffectFlow.collect {
             when (it) {
                 is HomeSideEffect.TicketNotEnough -> {
-                    // todo: 티켓 개수 부족한 경우 에러 처리
+                    // todo: 티켓 개수 부족한 경우 에러 처리 - 기획과 상의 필요
                     snackbarState.showSnackbar("감정 대화 티켓이 부족해요 😢")
+                }
+
+                is HomeSideEffect.ShowResumeChatModal -> {
+                    setModalState(HomeModalState.ResumeChat(it.pendingRoomId))
                 }
 
                 is HomeSideEffect.EnterChatRoom -> {
@@ -100,11 +121,11 @@ fun HomeScreen(
                 }
 
                 is BaseSideEffect.SessionExpired -> {
-                    // todo: show session expired modal
+                    setModalState(HomeModalState.LoginSessionExpired)
                 }
 
                 is BaseSideEffect.TemporalError -> {
-                    // todo: show temporal error modal
+                    setModalState(HomeModalState.TempError)
                 }
             }
         }
@@ -112,7 +133,7 @@ fun HomeScreen(
 
     LifecycleResumeEffect("onResume") {
         // init screen state on resume
-        viewModel.onAction(HomeAction.Initiate)
+        viewModel.onAction(Initiate)
         onPauseOrDispose {}
     }
 
@@ -141,18 +162,40 @@ fun HomeScreen(
         )
     }
 
-    ResumeChatModal(
-        isModalOpen = state.value.showResumeChatModal && state.value.pendingChatRoomId != null,
-        onDismissRequest = {
-            viewModel.onAction(HomeAction.DismissResumeChat)
-        },
-        onResume = {
-            viewModel.onAction(HomeAction.ConfirmResumeChat)
-        },
-        onDropAndStartNew = {
-            viewModel.onAction(HomeAction.DismissResumeChat)
-        },
-    )
+    when(modalState){
+        is HomeModalState.None -> {
+            // no modal
+        }
+        is HomeModalState.ResumeChat -> {
+            ResumeChatModal(
+                onDismissRequest = {
+                    viewModel.onAction(DismissResumeChat(modalState.pendingRoomId))
+                },
+                onResume = {
+                    viewModel.onAction(ConfirmResumeChat(modalState.pendingRoomId))
+                },
+                onDropAndStartNew = {
+                    viewModel.onAction(DismissResumeChat(modalState.pendingRoomId))
+                },
+            )
+        }
+        is HomeModalState.LoginSessionExpired -> {
+            LoginSessionExpiredModal(
+                onDismissRequest = {
+                    setModalState(HomeModalState.None)
+                },
+                navToLogin = navToLogin,
+            )
+        }
+        is HomeModalState.TempError -> {
+            TempErrorModal(
+                onDismissRequest = {
+                    setModalState(HomeModalState.None)
+                },
+            )
+        }
+    }
+
 }
 
 @Composable
@@ -356,7 +399,8 @@ private fun StartChatButton(
             modifier
                 .width(
                     if (canStartChat) 198.dp else 197.dp,
-                ).height(
+                )
+                .height(
                     if (canStartChat) 54.dp else 65.dp,
                 ),
         enabled = canStartChat,

--- a/feat/home/src/main/java/com/emotionstorage/home/ui/modal/ResumeChatModal.kt
+++ b/feat/home/src/main/java/com/emotionstorage/home/ui/modal/ResumeChatModal.kt
@@ -23,30 +23,27 @@ import com.emotionstorage.ui.theme.MooiTheme
  */
 @Composable
 fun ResumeChatModal(
-    isModalOpen: Boolean,
     onDismissRequest: () -> Unit = {},
     onResume: () -> Unit = {},
     onDropAndStartNew: () -> Unit = {},
 ) {
-    if (isModalOpen) {
-        Modal(
-            onDismissRequest = onDismissRequest,
-            dismissOnBackPress = false,
-            dismissOnClickOutside = false,
-            title = "이전 감정 대화를\n마치지 않았어요.\n이어서 계속 대화할까요?",
-            bottomDescription = "'그만하기'를 누르면 이전 대화는 삭제돼요.",
-            confirmLabel = "대화를 이어서 진행할게요.",
-            onConfirm = onResume,
-            dismissLabel = "이전 대화를 그만할래요.",
-            onDismiss = onDropAndStartNew,
-        )
-    }
+    Modal(
+        onDismissRequest = onDismissRequest,
+        dismissOnBackPress = false,
+        dismissOnClickOutside = false,
+        title = "이전 감정 대화를\n마치지 않았어요.\n이어서 계속 대화할까요?",
+        bottomDescription = "'그만하기'를 누르면 이전 대화는 삭제돼요.",
+        confirmLabel = "대화를 이어서 진행할게요.",
+        onConfirm = onResume,
+        dismissLabel = "이전 대화를 그만할래요.",
+        onDismiss = onDropAndStartNew,
+    )
 }
 
 @Preview
 @Composable
 private fun ResumeChatModalPreview() {
     MooiTheme {
-        ResumeChatModal(isModalOpen = true)
+        ResumeChatModal()
     }
 }


### PR DESCRIPTION
## Related Issue
- Issue #191

## 작업 상세 내용
- 로그인 만료 팝업(common_session_expired) - 공통 컴포넌트 추가
- 홈 화면 
  - 일시적인 오류 팝업 &  로그인 세션 만료 팝업 추가
  - 임시저장 채팅 이어하기 팝업 표시 로직 state -> side effect 기반으로 리팩토링

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 로그인 세션 만료 시 표시되는 강제(비(非)닫기) 모달 추가
  * 홈 화면에서 캘린더·알람·일일 리포트·채팅·도착한 타임캡슐·로그인으로 이동하는 네비게이션 진입점 추가

* **개선**
  * 채팅 재개 흐름이 사이드 이펙트 기반 모달로 전환되어 안내와 재진입이 명확해짐
  * 홈 화면의 모달 관리가 중앙화되어 여러 모달을 일관되게 처리하도록 정리됨

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->