### PR TITLE
Feat/my page login expired 마이페이지 탭 임시 오류 & 로그인 만료 오류 팝업 추가

### DIFF
--- a/app/src/main/java/com/emotionstorage/emotionstorage/ui/AppNavHost.kt
+++ b/app/src/main/java/com/emotionstorage/emotionstorage/ui/AppNavHost.kt
@@ -490,6 +490,9 @@ internal fun AppNavHost(
                 navToBack = {
                     navController.popBackStack()
                 },
+                navToLogin = {
+                    navController.navigateAsRoot(AppDestination.Login)
+                },
             )
         }
 

--- a/app/src/main/java/com/emotionstorage/emotionstorage/ui/AppNavHost.kt
+++ b/app/src/main/java/com/emotionstorage/emotionstorage/ui/AppNavHost.kt
@@ -504,6 +504,9 @@ internal fun AppNavHost(
                 navToBack = {
                     navController.popBackStack()
                 },
+                navToLogin = {
+                    navController.navigateAsRoot(AppDestination.Login)
+                },
             )
         }
 

--- a/app/src/main/java/com/emotionstorage/emotionstorage/ui/AppNavHost.kt
+++ b/app/src/main/java/com/emotionstorage/emotionstorage/ui/AppNavHost.kt
@@ -471,6 +471,9 @@ internal fun AppNavHost(
                 navToBack = {
                     navController.popBackStack()
                 },
+                navToLogin = {
+                    navController.navigateAsRoot(AppDestination.Login)
+                },
             )
         }
 

--- a/app/src/main/java/com/emotionstorage/emotionstorage/ui/AppNavHost.kt
+++ b/app/src/main/java/com/emotionstorage/emotionstorage/ui/AppNavHost.kt
@@ -479,6 +479,9 @@ internal fun AppNavHost(
                 navToBack = {
                     navController.popBackStack()
                 },
+                navToLogin = {
+                    navController.navigateAsRoot(AppDestination.Login)
+                },
             )
         }
 

--- a/core/presentation/src/main/java/com/emotionstorage/presentation/BaseViewModel.kt
+++ b/core/presentation/src/main/java/com/emotionstorage/presentation/BaseViewModel.kt
@@ -50,7 +50,8 @@ open class BaseViewModel<STATE : Any>(
     protected suspend fun handleError(error: Throwable) =
         subIntent {
             with(
-                error as? BaseException ?: BaseException(message = error.message, code = ErrorCode.UNKNOWN, cause = error),
+                error as? BaseException
+                    ?: BaseException(message = error.message, code = ErrorCode.UNKNOWN, cause = error),
             ) {
                 if (code == ErrorCode.NETWORK_ERROR) {
                     // handle network error

--- a/core/presentation/src/main/java/com/emotionstorage/presentation/BaseViewModel.kt
+++ b/core/presentation/src/main/java/com/emotionstorage/presentation/BaseViewModel.kt
@@ -50,11 +50,7 @@ open class BaseViewModel<STATE : Any>(
     protected suspend fun handleError(error: Throwable) =
         subIntent {
             with(
-                if (error is BaseException) {
-                    error
-                } else {
-                    BaseException(message = error.message, code = ErrorCode.UNKNOWN, cause = error)
-                },
+                error as? BaseException ?: BaseException(message = error.message, code = ErrorCode.UNKNOWN, cause = error),
             ) {
                 if (code == ErrorCode.NETWORK_ERROR) {
                     // handle network error

--- a/feat/auth/src/main/java/com/emotionstorage/auth/ui/LoginScreen.kt
+++ b/feat/auth/src/main/java/com/emotionstorage/auth/ui/LoginScreen.kt
@@ -50,19 +50,19 @@ import com.emotionstorage.ui.component.toast.AppSnackbarHost
 import com.emotionstorage.ui.theme.MooiTheme
 import com.emotionstorage.ui.util.buildHighlightAnnotatedString
 
-private sealed class LoginModalState {
-    object None : LoginModalState()
+private sealed class ModalState {
+    object None : ModalState()
 
     data class RetryHandleLogin(
         val accessToken: String,
-    ) : LoginModalState()
+    ) : ModalState()
 
     data class InquireLoginError(
         val errorCode: ErrorCode,
         val throwable: Throwable,
-    ) : LoginModalState()
+    ) : ModalState()
 
-    object TempError : LoginModalState()
+    object TempError : ModalState()
 }
 
 @Composable
@@ -75,7 +75,7 @@ fun LoginScreen(
     val state = viewModel.container.stateFlow.collectAsState()
     val snackbarHostState = remember { SnackbarHostState() }
     var modalState by remember {
-        mutableStateOf<LoginModalState>(LoginModalState.None)
+        mutableStateOf<ModalState>(ModalState.None)
     }
 
     LaunchedEffect(Unit) {
@@ -95,14 +95,14 @@ fun LoginScreen(
 
                 is LoginSideEffect.RetryHandleLogin -> {
                     modalState =
-                        LoginModalState.RetryHandleLogin(
+                        ModalState.RetryHandleLogin(
                             effect.accessToken,
                         )
                 }
 
                 is LoginSideEffect.InquireLoginError -> {
                     modalState =
-                        LoginModalState.InquireLoginError(
+                        ModalState.InquireLoginError(
                             effect.errorCode,
                             effect.throwable,
                         )
@@ -113,7 +113,7 @@ fun LoginScreen(
                 }
 
                 is BaseSideEffect.TemporalError -> {
-                    modalState = LoginModalState.TempError
+                    modalState = ModalState.TempError
                 }
             }
         }
@@ -127,13 +127,13 @@ fun LoginScreen(
     )
 
     when (modalState) {
-        is LoginModalState.None -> {}
+        is ModalState.None -> {}
 
-        is LoginModalState.RetryHandleLogin -> {
-            val retryState = modalState as LoginModalState.RetryHandleLogin
+        is ModalState.RetryHandleLogin -> {
+            val retryState = modalState as ModalState.RetryHandleLogin
             RetryHandleLoginModal(
                 onDismissRequest = {
-                    modalState = LoginModalState.None
+                    modalState = ModalState.None
                 },
                 onConfirm = {
                     viewModel.onAction(
@@ -145,20 +145,20 @@ fun LoginScreen(
             )
         }
 
-        is LoginModalState.InquireLoginError -> {
-            val inquireModalState = modalState as LoginModalState.InquireLoginError
+        is ModalState.InquireLoginError -> {
+            val inquireModalState = modalState as ModalState.InquireLoginError
             InquireLoginErrorModal(
                 inquireModalState.errorCode,
                 inquireModalState.throwable,
                 onDismissRequest = {
-                    modalState = LoginModalState.None
+                    modalState = ModalState.None
                 },
             )
         }
 
-        is LoginModalState.TempError -> {
+        is ModalState.TempError -> {
             TempErrorModal {
-                modalState = LoginModalState.None
+                modalState = ModalState.None
             }
         }
     }

--- a/feat/home/src/main/java/com/emotionstorage/home/ui/HomeScreen.kt
+++ b/feat/home/src/main/java/com/emotionstorage/home/ui/HomeScreen.kt
@@ -61,16 +61,16 @@ import com.emotionstorage.ui.component.modal.TempErrorModal
 import com.emotionstorage.ui.component.toast.AppSnackbarHost
 import com.emotionstorage.ui.theme.MooiTheme
 
-private sealed class HomeModalState {
-    object None : HomeModalState()
+private sealed class ModalState {
+    object None : ModalState()
 
     data class ResumeChat(
         val pendingRoomId: Long,
-    ) : HomeModalState()
+    ) : ModalState()
 
-    object LoginSessionExpired : HomeModalState()
+    object LoginSessionExpired : ModalState()
 
-    object TempError : HomeModalState()
+    object TempError : ModalState()
 }
 
 @Composable
@@ -91,7 +91,7 @@ fun HomeScreen(
     val state = viewModel.container.stateFlow.collectAsState()
     val attendanceState = attendanceViewModel.uiState.collectAsState()
     val snackbarState = remember { SnackbarHostState() }
-    val (modalState, setModalState) = remember { mutableStateOf<HomeModalState>(HomeModalState.None) }
+    val (modalState, setModalState) = remember { mutableStateOf<ModalState>(ModalState.None) }
 
     val summary = attendanceState.value.summary
 
@@ -110,7 +110,7 @@ fun HomeScreen(
                 }
 
                 is HomeSideEffect.ShowResumeChatModal -> {
-                    setModalState(HomeModalState.ResumeChat(it.pendingRoomId))
+                    setModalState(ModalState.ResumeChat(it.pendingRoomId))
                 }
 
                 is HomeSideEffect.EnterChatRoom -> {
@@ -122,11 +122,11 @@ fun HomeScreen(
                 }
 
                 is BaseSideEffect.SessionExpired -> {
-                    setModalState(HomeModalState.LoginSessionExpired)
+                    setModalState(ModalState.LoginSessionExpired)
                 }
 
                 is BaseSideEffect.TemporalError -> {
-                    setModalState(HomeModalState.TempError)
+                    setModalState(ModalState.TempError)
                 }
             }
         }
@@ -164,14 +164,14 @@ fun HomeScreen(
     }
 
     when (modalState) {
-        is HomeModalState.None -> {
+        is ModalState.None -> {
             // no modal
         }
 
-        is HomeModalState.ResumeChat -> {
+        is ModalState.ResumeChat -> {
             ResumeChatModal(
                 onDismissRequest = {
-                    setModalState(HomeModalState.None)
+                    setModalState(ModalState.None)
                 },
                 onResume = {
                     viewModel.onAction(HomeAction.ResumeChat(modalState.pendingRoomId))
@@ -182,19 +182,19 @@ fun HomeScreen(
             )
         }
 
-        is HomeModalState.LoginSessionExpired -> {
+        is ModalState.LoginSessionExpired -> {
             LoginSessionExpiredModal(
                 onDismissRequest = {
-                    setModalState(HomeModalState.None)
+                    setModalState(ModalState.None)
                 },
                 navToLogin = navToLogin,
             )
         }
 
-        is HomeModalState.TempError -> {
+        is ModalState.TempError -> {
             TempErrorModal(
                 onDismissRequest = {
-                    setModalState(HomeModalState.None)
+                    setModalState(ModalState.None)
                 },
             )
         }

--- a/feat/my/src/main/java/com/emotionstorage/my/presentation/AccountInfoViewModel.kt
+++ b/feat/my/src/main/java/com/emotionstorage/my/presentation/AccountInfoViewModel.kt
@@ -1,24 +1,37 @@
 package com.emotionstorage.my.presentation
 
-import androidx.lifecycle.ViewModel
-import androidx.lifecycle.viewModelScope
 import com.emotionstorage.domain.useCase.myPage.GetAccountInfoUseCase
+import com.emotionstorage.presentation.BaseException
+import com.emotionstorage.presentation.BaseViewModel
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.launch
 import javax.inject.Inject
 
+data class AccountInfoState(
+    val email: String = "",
+    val authProvider: AuthProvider = AuthProvider.KAKAO,
+    val gender: String = "",
+    val birthYear: Int = 0,
+    val birthMonth: Int = 0,
+    val birthDay: Int = 0,
+    val isLoading: Boolean = false,
+)
+
+enum class AuthProvider { GOOGLE, KAKAO }
+
+
 @HiltViewModel
 class AccountInfoViewModel @Inject constructor(
-    private val getAccountInfoUseCase: GetAccountInfoUseCase,
-) : ViewModel() {
+    private val getAccountInfo: GetAccountInfoUseCase,
+) : BaseViewModel<Unit>(Unit) {
     private val _state = MutableStateFlow(AccountInfoState())
     val state: StateFlow<AccountInfoState> = _state
 
     init {
-        viewModelScope.launch {
-            getAccountInfoUseCase().handle(
+        baseViewModelScope.launch {
+            getAccountInfo().handle(
                 onSuccess = { data ->
                     _state.value =
                         _state.value.copy(
@@ -35,12 +48,16 @@ class AccountInfoViewModel @Inject constructor(
                             birthDay = data.birthDay,
                         )
                 },
-                onError = { throwable, _ ->
+                onError = { throwable, code, data ->
                     _state.value =
                         _state.value.copy(
-                            error = throwable.message ?: "Unknown error",
                             isLoading = false,
                         )
+                    throw BaseException(
+                        message = throwable.message ?: "getAccountInfoUseCase Error",
+                        code = code,
+                        cause = throwable,
+                    )
                 },
                 onLoading = { isLoading ->
                     // do Nothing
@@ -49,16 +66,3 @@ class AccountInfoViewModel @Inject constructor(
         }
     }
 }
-
-data class AccountInfoState(
-    val email: String = "",
-    val authProvider: AuthProvider = AuthProvider.KAKAO,
-    val gender: String = "",
-    val birthYear: Int = 0,
-    val birthMonth: Int = 0,
-    val birthDay: Int = 0,
-    val error: String? = null,
-    val isLoading: Boolean = false,
-)
-
-enum class AuthProvider { GOOGLE, KAKAO }

--- a/feat/my/src/main/java/com/emotionstorage/my/presentation/AccountInfoViewModel.kt
+++ b/feat/my/src/main/java/com/emotionstorage/my/presentation/AccountInfoViewModel.kt
@@ -1,5 +1,6 @@
 package com.emotionstorage.my.presentation
 
+import com.emotionstorage.domain.model.User
 import com.emotionstorage.domain.useCase.myPage.GetAccountInfoUseCase
 import com.emotionstorage.presentation.BaseException
 import com.emotionstorage.presentation.BaseViewModel
@@ -11,15 +12,13 @@ import javax.inject.Inject
 
 data class AccountInfoState(
     val email: String = "",
-    val authProvider: AuthProvider = AuthProvider.KAKAO,
+    val authProvider: User.AuthProvider = User.AuthProvider.KAKAO,
     val gender: String = "",
     val birthYear: Int = 0,
     val birthMonth: Int = 0,
     val birthDay: Int = 0,
     val isLoading: Boolean = false,
 )
-
-enum class AuthProvider { GOOGLE, KAKAO }
 
 @HiltViewModel
 class AccountInfoViewModel @Inject constructor(
@@ -35,7 +34,7 @@ class AccountInfoViewModel @Inject constructor(
                     _state.value =
                         _state.value.copy(
                             email = data.email,
-                            authProvider = AuthProvider.valueOf(data.socialType.uppercase()),
+                            authProvider = User.AuthProvider.valueOf(data.socialType.uppercase()),
                             gender =
                                 when (data.gender.uppercase()) {
                                     "MALE" -> "남성"

--- a/feat/my/src/main/java/com/emotionstorage/my/presentation/AccountInfoViewModel.kt
+++ b/feat/my/src/main/java/com/emotionstorage/my/presentation/AccountInfoViewModel.kt
@@ -21,7 +21,6 @@ data class AccountInfoState(
 
 enum class AuthProvider { GOOGLE, KAKAO }
 
-
 @HiltViewModel
 class AccountInfoViewModel @Inject constructor(
     private val getAccountInfo: GetAccountInfoUseCase,

--- a/feat/my/src/main/java/com/emotionstorage/my/presentation/KeyBalanceViewModel.kt
+++ b/feat/my/src/main/java/com/emotionstorage/my/presentation/KeyBalanceViewModel.kt
@@ -1,8 +1,8 @@
 package com.emotionstorage.my.presentation
 
-import androidx.lifecycle.ViewModel
-import androidx.lifecycle.viewModelScope
 import com.emotionstorage.domain.useCase.key.GetKeyCountUseCase
+import com.emotionstorage.presentation.BaseException
+import com.emotionstorage.presentation.BaseViewModel
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
@@ -12,23 +12,28 @@ import javax.inject.Inject
 
 @HiltViewModel
 class KeyBalanceViewModel @Inject constructor(
-    private val getKeyCountUseCase: GetKeyCountUseCase,
-) : ViewModel() {
+    private val getKeyCount: GetKeyCountUseCase,
+) : BaseViewModel<Unit>(Unit) {
     private val _keyCountState = MutableStateFlow(KeyCountState())
     val keyCountState: StateFlow<KeyCountState> = _keyCountState
 
     fun refreshKeyCount() =
-        viewModelScope.launch {
-            _keyCountState.update { it.copy(isLoading = true, error = null) }
-            getKeyCountUseCase.invoke().handle(
+        baseViewModelScope.launch {
+            _keyCountState.update { it.copy(isLoading = true) }
+            getKeyCount.invoke().handle(
                 onSuccess = { count ->
                     _keyCountState.update { it.copy(keyCount = count, isLoading = false) }
                 },
                 onLoading = {
                     _keyCountState.update { it.copy(isLoading = true) }
                 },
-                onError = { throwable, _ ->
-                    _keyCountState.update { it.copy(error = throwable.message, isLoading = false) }
+                onError = { throwable, code, data ->
+                    _keyCountState.update { it.copy(isLoading = false) }
+                    throw BaseException(
+                        message = throwable.message ?: "getKeyCount Error",
+                        code = code,
+                        cause = throwable,
+                    )
                 },
             )
         }
@@ -49,7 +54,6 @@ class KeyBalanceViewModel @Inject constructor(
 data class KeyCountState(
     val keyCount: Int? = null,
     val isLoading: Boolean = false,
-    val error: String? = null,
     val dialog: KeyDescriptionDialog? = null,
 )
 

--- a/feat/my/src/main/java/com/emotionstorage/my/presentation/MyPageViewModel.kt
+++ b/feat/my/src/main/java/com/emotionstorage/my/presentation/MyPageViewModel.kt
@@ -1,14 +1,14 @@
 package com.emotionstorage.my.presentation
 
-import androidx.lifecycle.ViewModel
 import com.emotionstorage.domain.common.DataState
 import com.emotionstorage.domain.useCase.auth.LogoutUseCase
 import com.emotionstorage.domain.useCase.myPage.GetMyPageOverviewUseCase
 import com.emotionstorage.my.BuildConfig
+import com.emotionstorage.presentation.BaseException
+import com.emotionstorage.presentation.BaseSideEffect
+import com.emotionstorage.presentation.BaseViewModel
 import com.orhanobut.logger.Logger
 import dagger.hilt.android.lifecycle.HiltViewModel
-import org.orbitmvi.orbit.ContainerHost
-import org.orbitmvi.orbit.viewmodel.container
 import javax.inject.Inject
 
 data class MyPageState(
@@ -27,23 +27,17 @@ sealed class MyPageAction {
     object Logout : MyPageAction()
 }
 
-sealed class MyPageSideEffect {
+sealed class MyPageSideEffect () : BaseSideEffect {
     object LogoutSuccess : MyPageSideEffect()
 
     object LogoutError : MyPageSideEffect()
-
-    data class ShowToast(
-        val message: String,
-    ) : MyPageSideEffect()
 }
 
 @HiltViewModel
 class MyPageViewModel @Inject constructor(
-    private val logoutUseCase: LogoutUseCase,
-    private val myPageOverviewUseCase: GetMyPageOverviewUseCase,
-) : ViewModel(),
-    ContainerHost<MyPageState, MyPageSideEffect> {
-    override val container = container<MyPageState, MyPageSideEffect>(MyPageState())
+    private val logout: LogoutUseCase,
+    private val getMyPageOverview: GetMyPageOverviewUseCase,
+) : BaseViewModel<MyPageState>(MyPageState()) {
 
     fun onAction(action: MyPageAction) {
         when (action) {
@@ -58,8 +52,8 @@ class MyPageViewModel @Inject constructor(
     }
 
     private fun handleInitiate() =
-        intent {
-            myPageOverviewUseCase().collect { result ->
+        baseIntent {
+            getMyPageOverview().collect { result ->
                 when (result) {
                     is DataState.Success -> {
                         reduce {
@@ -74,7 +68,11 @@ class MyPageViewModel @Inject constructor(
 
                     is DataState.Error -> {
                         reduce { state.copy(isLoading = false) }
-                        postSideEffect(MyPageSideEffect.ShowToast(result.throwable.message ?: "마이페이지 불러오기 실패"))
+                        throw BaseException(
+                            cause = result.throwable,
+                            code = result.code,
+                            message = result.throwable.message ?: "MyPageViewModel: Initiate error"
+                        )
                     }
 
                     is DataState.Loading -> {
@@ -85,9 +83,9 @@ class MyPageViewModel @Inject constructor(
         }
 
     private fun handleLogout() =
-        intent {
+        baseIntent {
             try {
-                if (logoutUseCase()) {
+                if (logout()) {
                     postSideEffect(MyPageSideEffect.LogoutSuccess)
                 } else {
                     postSideEffect(MyPageSideEffect.LogoutError)

--- a/feat/my/src/main/java/com/emotionstorage/my/presentation/MyPageViewModel.kt
+++ b/feat/my/src/main/java/com/emotionstorage/my/presentation/MyPageViewModel.kt
@@ -16,6 +16,7 @@ data class MyPageState(
     val signupDday: Int = 0,
     val keyCount: Int = 0,
     val replyEmail: String = BuildConfig.MOOI_REPLY_EMAIL,
+    // todo: 버전명 동적으로 표시되어야 함
     val versionName: String = "0.0.0",
     val isLoading: Boolean = false,
 )

--- a/feat/my/src/main/java/com/emotionstorage/my/presentation/MyPageViewModel.kt
+++ b/feat/my/src/main/java/com/emotionstorage/my/presentation/MyPageViewModel.kt
@@ -27,7 +27,7 @@ sealed class MyPageAction {
     object Logout : MyPageAction()
 }
 
-sealed class MyPageSideEffect () : BaseSideEffect {
+sealed class MyPageSideEffect : BaseSideEffect {
     object LogoutSuccess : MyPageSideEffect()
 
     object LogoutError : MyPageSideEffect()
@@ -38,7 +38,6 @@ class MyPageViewModel @Inject constructor(
     private val logout: LogoutUseCase,
     private val getMyPageOverview: GetMyPageOverviewUseCase,
 ) : BaseViewModel<MyPageState>(MyPageState()) {
-
     fun onAction(action: MyPageAction) {
         when (action) {
             is MyPageAction.Initiate -> {
@@ -71,7 +70,7 @@ class MyPageViewModel @Inject constructor(
                         throw BaseException(
                             cause = result.throwable,
                             code = result.code,
-                            message = result.throwable.message ?: "MyPageViewModel: Initiate error"
+                            message = result.throwable.message ?: "MyPageViewModel: Initiate error",
                         )
                     }
 

--- a/feat/my/src/main/java/com/emotionstorage/my/presentation/NicknameChangeViewModel.kt
+++ b/feat/my/src/main/java/com/emotionstorage/my/presentation/NicknameChangeViewModel.kt
@@ -1,12 +1,14 @@
 package com.emotionstorage.my.presentation
 
-import androidx.lifecycle.ViewModel
-import androidx.lifecycle.viewModelScope
 import com.emotionstorage.domain.common.DataState
 import com.emotionstorage.domain.useCase.user.NicknameState
 import com.emotionstorage.domain.useCase.user.UpdateUserNicknameUseCase
 import com.emotionstorage.domain.useCase.user.ValidateNicknameUseCase
+import com.emotionstorage.presentation.BaseException
+import com.emotionstorage.presentation.BaseViewModel
 import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.FlowPreview
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.debounce
@@ -21,18 +23,18 @@ interface InputNicknameEvent {
     fun onNicknameChange(nickname: String)
 }
 
+@OptIn(FlowPreview::class, ExperimentalCoroutinesApi::class)
 @HiltViewModel
 class NicknameChangeViewModel @Inject constructor(
-    private val validateNicknameUseCase: ValidateNicknameUseCase,
-    private val updateNicknameUseCase: UpdateUserNicknameUseCase,
-) : ViewModel(),
+    private val validateNickname: ValidateNicknameUseCase,
+    private val updateNickname: UpdateUserNicknameUseCase,
+) : BaseViewModel<Unit>(Unit),
     InputNicknameEvent {
     data class State(
         val nickname: String = "",
         val inputState: InputState = InputState.EMPTY,
         val helperMessage: String? = null,
         val submitting: Boolean = false,
-        val submitError: String? = null,
     ) {
         enum class InputState { EMPTY, INVALID, VALID }
 
@@ -48,13 +50,13 @@ class NicknameChangeViewModel @Inject constructor(
     }
 
     init {
-        viewModelScope.launch {
+        baseViewModelScope.launch {
             state
                 .map { it.nickname }
                 .distinctUntilChanged()
                 .debounce(120)
                 .mapLatest { nickname ->
-                    validateNicknameUseCase(nickname)
+                    validateNickname(nickname)
                 }.collect { result ->
                     if (result is DataState.Success) {
                         val (st, msg) =
@@ -77,9 +79,9 @@ class NicknameChangeViewModel @Inject constructor(
     fun submit(onSuccess: (String) -> Unit = {}) {
         val state = _state.value
         if (!state.buttonEnabled) return
-        viewModelScope.launch {
-            _state.update { it.copy(submitting = true, submitError = null) }
-            when (updateNicknameUseCase(state.nickname)) {
+        baseViewModelScope.launch {
+            _state.update { it.copy(submitting = true) }
+            when (val result = updateNickname(state.nickname)) {
                 is DataState.Success -> {
                     _state.update { it.copy(submitting = false) }
                     onSuccess(state.nickname)
@@ -89,15 +91,19 @@ class NicknameChangeViewModel @Inject constructor(
                     _state.update {
                         it.copy(
                             submitting = false,
-                            submitError = null,
                             inputState = State.InputState.INVALID,
                             helperMessage = null,
                         )
                     }
+                    throw BaseException(
+                        message = result.throwable.message ?: "updateNickNameUseCase error",
+                        code = result.code,
+                        cause = result.throwable,
+                    )
                 }
 
-                else -> {
-                    _state.update { it.copy(submitting = false) }
+                is DataState.Loading -> {
+                    // do nothing
                 }
             }
         }

--- a/feat/my/src/main/java/com/emotionstorage/my/presentation/NotificationSettingViewModel.kt
+++ b/feat/my/src/main/java/com/emotionstorage/my/presentation/NotificationSettingViewModel.kt
@@ -1,7 +1,5 @@
 package com.emotionstorage.my.presentation
 
-import androidx.lifecycle.ViewModel
-import androidx.lifecycle.viewModelScope
 import com.emotionstorage.domain.common.DataState
 import com.emotionstorage.domain.model.NotificationSettings
 import com.emotionstorage.domain.useCase.myPage.GetNotificationSettingsUseCase

--- a/feat/my/src/main/java/com/emotionstorage/my/presentation/NotificationSettingViewModel.kt
+++ b/feat/my/src/main/java/com/emotionstorage/my/presentation/NotificationSettingViewModel.kt
@@ -6,6 +6,7 @@ import com.emotionstorage.domain.common.DataState
 import com.emotionstorage.domain.model.NotificationSettings
 import com.emotionstorage.domain.useCase.myPage.GetNotificationSettingsUseCase
 import com.emotionstorage.domain.useCase.myPage.UpdateNotificationSettingsUseCase
+import com.emotionstorage.presentation.BaseViewModel
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
@@ -19,12 +20,12 @@ import javax.inject.Inject
 class NotificationSettingViewModel @Inject constructor(
     private val getNotificationSettings: GetNotificationSettingsUseCase,
     private val updateNotificationSettings: UpdateNotificationSettingsUseCase,
-) : ViewModel() {
+) : BaseViewModel<Unit>(Unit) {
     private val _state = MutableStateFlow(NotificationSettingState())
     val state: StateFlow<NotificationSettingState> = _state
 
     init {
-        viewModelScope.launch {
+        baseViewModelScope.launch {
             getNotificationSettings().collect { dataState ->
                 if (dataState is DataState.Success) {
                     val settings = dataState.data
@@ -94,7 +95,7 @@ class NotificationSettingViewModel @Inject constructor(
         }
 
         val snapShot = state.value
-        viewModelScope
+        baseViewModelScope
             .launch {
                 updateNotificationSettings(
                     NotificationSettings(

--- a/feat/my/src/main/java/com/emotionstorage/my/presentation/WithdrawNoticeViewModel.kt
+++ b/feat/my/src/main/java/com/emotionstorage/my/presentation/WithdrawNoticeViewModel.kt
@@ -44,7 +44,7 @@ class WithdrawNoticeViewModel @Inject constructor(
     }
 
     private fun handleWithDraw() =
-        intent {
+        baseIntent {
             reduce {
                 state.copy(isLoading = true)
             }

--- a/feat/my/src/main/java/com/emotionstorage/my/ui/NicknameChangeScreen.kt
+++ b/feat/my/src/main/java/com/emotionstorage/my/ui/NicknameChangeScreen.kt
@@ -45,7 +45,7 @@ import com.emotionstorage.ui.component.modal.LoginSessionExpiredModal
 import com.emotionstorage.ui.component.modal.TempErrorModal
 import com.emotionstorage.ui.theme.MooiTheme
 
-private enum class ModalState  {
+private enum class ModalState {
     None,
     TempError,
     LoginSessionExpired,

--- a/feat/my/src/main/java/com/emotionstorage/my/ui/NicknameChangeScreen.kt
+++ b/feat/my/src/main/java/com/emotionstorage/my/ui/NicknameChangeScreen.kt
@@ -18,8 +18,11 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalDensity
@@ -32,19 +35,44 @@ import androidx.hilt.navigation.compose.hiltViewModel
 import com.emotionstorage.my.presentation.InputNicknameEvent
 import com.emotionstorage.my.presentation.NicknameChangeViewModel
 import com.emotionstorage.my.presentation.NicknameChangeViewModel.State.InputState
+import com.emotionstorage.presentation.BaseSideEffect
 import com.emotionstorage.ui.component.button.CtaButton
 import com.emotionstorage.ui.component.HideKeyboard
 import com.emotionstorage.ui.component.text.TextInput
 import com.emotionstorage.ui.component.text.TextInputState
 import com.emotionstorage.ui.component.appBar.TopAppBar
+import com.emotionstorage.ui.component.modal.LoginSessionExpiredModal
+import com.emotionstorage.ui.component.modal.TempErrorModal
 import com.emotionstorage.ui.theme.MooiTheme
+
+private enum class ModalState{
+    None,
+    TempError,
+    LoginSessionExpired,
+}
 
 @Composable
 fun NicknameChangeScreen(
+    navToBack: () -> Unit,
+    navToLogin: () -> Unit,
     viewModel: NicknameChangeViewModel = hiltViewModel(),
-    navToBack: () -> Unit = {},
 ) {
     val state = viewModel.state.collectAsState()
+    val (modalState, setModalState) = remember { mutableStateOf(ModalState.None) }
+
+    LaunchedEffect(Unit) {
+        viewModel.container.sideEffectFlow.collect {
+            when (it) {
+                is BaseSideEffect.TemporalError -> {
+                    setModalState(ModalState.TempError)
+                }
+
+                is BaseSideEffect.SessionExpired -> {
+                    setModalState(ModalState.LoginSessionExpired)
+                }
+            }
+        }
+    }
 
     StatelessNicknameChangeScreen(
         state = state.value,
@@ -56,6 +84,26 @@ fun NicknameChangeScreen(
         },
         navToBack = navToBack,
     )
+
+
+    when (modalState) {
+        ModalState.None -> {
+            // no modal
+        }
+
+        ModalState.TempError -> {
+            TempErrorModal(
+                onDismissRequest = { setModalState(ModalState.None) },
+            )
+        }
+
+        ModalState.LoginSessionExpired -> {
+            LoginSessionExpiredModal(
+                onDismissRequest = { setModalState(ModalState.None) },
+                navToLogin = navToLogin,
+            )
+        }
+    }
 }
 
 @Composable

--- a/feat/my/src/main/java/com/emotionstorage/my/ui/NicknameChangeScreen.kt
+++ b/feat/my/src/main/java/com/emotionstorage/my/ui/NicknameChangeScreen.kt
@@ -45,7 +45,7 @@ import com.emotionstorage.ui.component.modal.LoginSessionExpiredModal
 import com.emotionstorage.ui.component.modal.TempErrorModal
 import com.emotionstorage.ui.theme.MooiTheme
 
-private enum class ModalState{
+private enum class ModalState  {
     None,
     TempError,
     LoginSessionExpired,
@@ -84,7 +84,6 @@ fun NicknameChangeScreen(
         },
         navToBack = navToBack,
     )
-
 
     when (modalState) {
         ModalState.None -> {

--- a/feat/my/src/main/java/com/emotionstorage/my/ui/accountInfo/AccountInfoContent.kt
+++ b/feat/my/src/main/java/com/emotionstorage/my/ui/accountInfo/AccountInfoContent.kt
@@ -25,7 +25,7 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
-import com.emotionstorage.my.presentation.AuthProvider
+import com.emotionstorage.domain.model.User
 import com.emotionstorage.ui.theme.MooiTheme
 import com.emotionstorage.ui.R
 
@@ -35,7 +35,7 @@ enum class PillStyle { Start, Center }
 fun AccountInfoContent(
     modifier: Modifier = Modifier,
     email: String,
-    socialType: AuthProvider,
+    socialType: User.AuthProvider,
     gender: String,
     birthYear: Int,
     birthMonth: Int,
@@ -55,7 +55,7 @@ fun AccountInfoContent(
                 style = PillStyle.Start,
                 trailing = {
                     when (socialType) {
-                        AuthProvider.GOOGLE -> {
+                        User.AuthProvider.GOOGLE -> {
                             Image(
                                 modifier = Modifier.size(20.dp),
                                 painter = painterResource(R.drawable.ic_google),
@@ -63,7 +63,7 @@ fun AccountInfoContent(
                             )
                         }
 
-                        AuthProvider.KAKAO -> {
+                        User.AuthProvider.KAKAO -> {
                             Image(
                                 modifier = Modifier.size(20.dp),
                                 painter = painterResource(R.drawable.ic_kakao),
@@ -179,7 +179,7 @@ private fun AccountInfoContentPreview() {
             AccountInfoContent(
                 modifier = Modifier,
                 email = "mooi.reply@gmail.com",
-                socialType = AuthProvider.KAKAO,
+                socialType = User.AuthProvider.KAKAO,
                 gender = "남성",
                 birthYear = 1999,
                 birthMonth = 7,

--- a/feat/my/src/main/java/com/emotionstorage/my/ui/accountInfo/AccountInfoScreen.kt
+++ b/feat/my/src/main/java/com/emotionstorage/my/ui/accountInfo/AccountInfoScreen.kt
@@ -29,7 +29,7 @@ import com.emotionstorage.ui.component.modal.LoginSessionExpiredModal
 import com.emotionstorage.ui.component.modal.TempErrorModal
 import com.emotionstorage.ui.theme.MooiTheme
 
-private enum class AccountInfoModalState {
+private enum class ModalState {
     None,
     TempError,
     LoginSessionExpired,
@@ -42,16 +42,16 @@ fun AccountInfoScreen(
     viewModel: AccountInfoViewModel = hiltViewModel(),
 ) {
     val state = viewModel.state.collectAsState()
-    val (modalState, setModalState) = remember { mutableStateOf(AccountInfoModalState.None) }
+    val (modalState, setModalState) = remember { mutableStateOf(ModalState.None) }
 
     LaunchedEffect(Unit) {
         viewModel.container.sideEffectFlow.collect {
             when (it) {
                 is BaseSideEffect.SessionExpired -> {
-                    setModalState(AccountInfoModalState.LoginSessionExpired)
+                    setModalState(ModalState.LoginSessionExpired)
                 }
                 is BaseSideEffect.TemporalError -> {
-                    setModalState(AccountInfoModalState.TempError)
+                    setModalState(ModalState.TempError)
                 }
             }
         }
@@ -63,19 +63,19 @@ fun AccountInfoScreen(
     )
 
     when (modalState) {
-        AccountInfoModalState.None -> {
+        ModalState.None -> {
             // no modal
         }
 
-        AccountInfoModalState.TempError -> {
+        ModalState.TempError -> {
             TempErrorModal(
-                onDismissRequest = { setModalState(AccountInfoModalState.None) },
+                onDismissRequest = { setModalState(ModalState.None) },
             )
         }
 
-        AccountInfoModalState.LoginSessionExpired -> {
+        ModalState.LoginSessionExpired -> {
             LoginSessionExpiredModal(
-                onDismissRequest = { setModalState(AccountInfoModalState.None) },
+                onDismissRequest = { setModalState(ModalState.None) },
                 navToLogin = navToLogin,
             )
         }

--- a/feat/my/src/main/java/com/emotionstorage/my/ui/accountInfo/AccountInfoScreen.kt
+++ b/feat/my/src/main/java/com/emotionstorage/my/ui/accountInfo/AccountInfoScreen.kt
@@ -50,6 +50,7 @@ fun AccountInfoScreen(
                 is BaseSideEffect.SessionExpired -> {
                     setModalState(ModalState.LoginSessionExpired)
                 }
+
                 is BaseSideEffect.TemporalError -> {
                     setModalState(ModalState.TempError)
                 }

--- a/feat/my/src/main/java/com/emotionstorage/my/ui/accountInfo/AccountInfoScreen.kt
+++ b/feat/my/src/main/java/com/emotionstorage/my/ui/accountInfo/AccountInfoScreen.kt
@@ -13,27 +13,74 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import com.emotionstorage.my.presentation.AccountInfoState
 import com.emotionstorage.my.presentation.AccountInfoViewModel
+import com.emotionstorage.presentation.BaseSideEffect
 import com.emotionstorage.ui.component.appBar.TopAppBar
+import com.emotionstorage.ui.component.modal.LoginSessionExpiredModal
+import com.emotionstorage.ui.component.modal.TempErrorModal
+import com.emotionstorage.ui.component.toast.AppSnackbarController
 import com.emotionstorage.ui.theme.MooiTheme
+
+private enum class AccountInfoModalState{
+    None,
+    TempError,
+    LoginSessionExpired,
+}
 
 @Composable
 fun AccountInfoScreen(
+    navToBack: () -> Unit,
+    navToLogin: () -> Unit,
     viewModel: AccountInfoViewModel = hiltViewModel(),
-    navToBack: () -> Unit = {},
 ) {
     val state = viewModel.state.collectAsState()
+    val (modalState, setModalState) = remember{ mutableStateOf(AccountInfoModalState.None) }
+
+    LaunchedEffect(Unit) {
+        viewModel.container.sideEffectFlow.collect {
+            when(it){
+                is BaseSideEffect.SessionExpired -> {
+                    setModalState(AccountInfoModalState.LoginSessionExpired)
+                }
+                is BaseSideEffect.TemporalError -> {
+                    setModalState(AccountInfoModalState.TempError)
+                }
+            }
+        }
+    }
 
     StatelessAccountInfoScreen(
         state = state.value,
         navToBack = navToBack,
     )
+
+    when(modalState){
+        AccountInfoModalState.None -> {
+            // no modal
+        }
+
+        AccountInfoModalState.TempError -> {
+            TempErrorModal(
+                onDismissRequest = { setModalState(AccountInfoModalState.None) },
+            )
+        }
+
+        AccountInfoModalState.LoginSessionExpired -> {
+            LoginSessionExpiredModal(
+                onDismissRequest = { setModalState(AccountInfoModalState.None) },
+                navToLogin = navToLogin,
+            )
+        }
+    }
 }
 
 @Composable

--- a/feat/my/src/main/java/com/emotionstorage/my/ui/accountInfo/AccountInfoScreen.kt
+++ b/feat/my/src/main/java/com/emotionstorage/my/ui/accountInfo/AccountInfoScreen.kt
@@ -27,10 +27,9 @@ import com.emotionstorage.presentation.BaseSideEffect
 import com.emotionstorage.ui.component.appBar.TopAppBar
 import com.emotionstorage.ui.component.modal.LoginSessionExpiredModal
 import com.emotionstorage.ui.component.modal.TempErrorModal
-import com.emotionstorage.ui.component.toast.AppSnackbarController
 import com.emotionstorage.ui.theme.MooiTheme
 
-private enum class AccountInfoModalState{
+private enum class AccountInfoModalState  {
     None,
     TempError,
     LoginSessionExpired,
@@ -43,11 +42,11 @@ fun AccountInfoScreen(
     viewModel: AccountInfoViewModel = hiltViewModel(),
 ) {
     val state = viewModel.state.collectAsState()
-    val (modalState, setModalState) = remember{ mutableStateOf(AccountInfoModalState.None) }
+    val (modalState, setModalState) = remember { mutableStateOf(AccountInfoModalState.None) }
 
     LaunchedEffect(Unit) {
         viewModel.container.sideEffectFlow.collect {
-            when(it){
+            when (it) {
                 is BaseSideEffect.SessionExpired -> {
                     setModalState(AccountInfoModalState.LoginSessionExpired)
                 }
@@ -63,7 +62,7 @@ fun AccountInfoScreen(
         navToBack = navToBack,
     )
 
-    when(modalState){
+    when (modalState) {
         AccountInfoModalState.None -> {
             // no modal
         }

--- a/feat/my/src/main/java/com/emotionstorage/my/ui/accountInfo/AccountInfoScreen.kt
+++ b/feat/my/src/main/java/com/emotionstorage/my/ui/accountInfo/AccountInfoScreen.kt
@@ -29,7 +29,7 @@ import com.emotionstorage.ui.component.modal.LoginSessionExpiredModal
 import com.emotionstorage.ui.component.modal.TempErrorModal
 import com.emotionstorage.ui.theme.MooiTheme
 
-private enum class AccountInfoModalState  {
+private enum class AccountInfoModalState {
     None,
     TempError,
     LoginSessionExpired,

--- a/feat/my/src/main/java/com/emotionstorage/my/ui/keyDescription/KeyDescriptionScreen.kt
+++ b/feat/my/src/main/java/com/emotionstorage/my/ui/keyDescription/KeyDescriptionScreen.kt
@@ -40,7 +40,7 @@ import com.emotionstorage.ui.component.modal.TempErrorModal
 import com.emotionstorage.ui.theme.MooiTheme
 import com.emotionstorage.ui.util.rememberAdaptiveHeightDp
 
-private enum class KeyDescriptionModalState  {
+private enum class ModalState {
     None,
     TempError,
     LoginSessionExpired,
@@ -54,16 +54,16 @@ fun KeyDescriptionScreen(
     viewModel: KeyBalanceViewModel = hiltViewModel(),
 ) {
     val state by viewModel.keyCountState.collectAsStateWithLifecycle()
-    val (modalState, setModalState) = remember { mutableStateOf(KeyDescriptionModalState.None) }
+    val (modalState, setModalState) = remember { mutableStateOf(ModalState.None) }
 
     LaunchedEffect(Unit) {
         viewModel.container.sideEffectFlow.collect {
             when (it) {
                 is BaseSideEffect.TemporalError -> {
-                    setModalState(KeyDescriptionModalState.TempError)
+                    setModalState(ModalState.TempError)
                 }
                 is BaseSideEffect.SessionExpired -> {
-                    setModalState(KeyDescriptionModalState.LoginSessionExpired)
+                    setModalState(ModalState.LoginSessionExpired)
                 }
             }
         }
@@ -83,19 +83,19 @@ fun KeyDescriptionScreen(
     )
 
     when (modalState) {
-        KeyDescriptionModalState.None -> {
+        ModalState.None -> {
             // no modal
         }
 
-        KeyDescriptionModalState.TempError -> {
+        ModalState.TempError -> {
             TempErrorModal(
-                onDismissRequest = { setModalState(KeyDescriptionModalState.None) },
+                onDismissRequest = { setModalState(ModalState.None) },
             )
         }
 
-        KeyDescriptionModalState.LoginSessionExpired -> {
+        ModalState.LoginSessionExpired -> {
             LoginSessionExpiredModal(
-                onDismissRequest = { setModalState(KeyDescriptionModalState.None) },
+                onDismissRequest = { setModalState(ModalState.None) },
                 navToLogin = navToLogin,
             )
         }

--- a/feat/my/src/main/java/com/emotionstorage/my/ui/keyDescription/KeyDescriptionScreen.kt
+++ b/feat/my/src/main/java/com/emotionstorage/my/ui/keyDescription/KeyDescriptionScreen.kt
@@ -13,7 +13,10 @@ import androidx.compose.foundation.layout.size
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
@@ -28,19 +31,43 @@ import com.emotionstorage.my.presentation.KeyCountState
 import com.emotionstorage.my.presentation.KeyDescriptionDialog
 import com.emotionstorage.my.ui.keyDescription.component.CountRow
 import com.emotionstorage.my.ui.keyDescription.component.WhenToUseKeyDialog
+import com.emotionstorage.presentation.BaseSideEffect
 import com.emotionstorage.ui.R
 import com.emotionstorage.ui.annotation.PreviewScreenRatios
 import com.emotionstorage.ui.component.appBar.TopAppBar
+import com.emotionstorage.ui.component.modal.LoginSessionExpiredModal
+import com.emotionstorage.ui.component.modal.TempErrorModal
 import com.emotionstorage.ui.theme.MooiTheme
 import com.emotionstorage.ui.util.rememberAdaptiveHeightDp
 
+private enum class KeyDescriptionModalState{
+    None,
+    TempError,
+    LoginSessionExpired,
+}
+
 @Composable
 fun KeyDescriptionScreen(
+    navToBack: () -> Unit,
+    navToLogin: () -> Unit,
     modifier: Modifier = Modifier,
     viewModel: KeyBalanceViewModel = hiltViewModel(),
-    navToBack: () -> Unit,
 ) {
     val state by viewModel.keyCountState.collectAsStateWithLifecycle()
+    val (modalState, setModalState) = remember{ mutableStateOf(KeyDescriptionModalState.None) }
+
+    LaunchedEffect(Unit) {
+        viewModel.container.sideEffectFlow.collect{
+            when(it){
+                is BaseSideEffect.TemporalError -> {
+                    setModalState(KeyDescriptionModalState.TempError)
+                }
+                is BaseSideEffect.SessionExpired -> {
+                    setModalState(KeyDescriptionModalState.LoginSessionExpired)
+                }
+            }
+        }
+    }
 
     LifecycleStartEffect("onStart") {
         viewModel.refreshKeyCount()
@@ -54,6 +81,25 @@ fun KeyDescriptionScreen(
         onDismissDialog = viewModel::dismissDialog,
         navToBack = navToBack,
     )
+
+    when(modalState){
+        KeyDescriptionModalState.None -> {
+            // no modal
+        }
+
+        KeyDescriptionModalState.TempError -> {
+            TempErrorModal(
+                onDismissRequest = { setModalState(KeyDescriptionModalState.None) },
+            )
+        }
+
+        KeyDescriptionModalState.LoginSessionExpired -> {
+            LoginSessionExpiredModal(
+                onDismissRequest = { setModalState(KeyDescriptionModalState.None) },
+                navToLogin = navToLogin,
+            )
+        }
+    }
 }
 
 @Composable

--- a/feat/my/src/main/java/com/emotionstorage/my/ui/keyDescription/KeyDescriptionScreen.kt
+++ b/feat/my/src/main/java/com/emotionstorage/my/ui/keyDescription/KeyDescriptionScreen.kt
@@ -62,6 +62,7 @@ fun KeyDescriptionScreen(
                 is BaseSideEffect.TemporalError -> {
                     setModalState(ModalState.TempError)
                 }
+
                 is BaseSideEffect.SessionExpired -> {
                     setModalState(ModalState.LoginSessionExpired)
                 }

--- a/feat/my/src/main/java/com/emotionstorage/my/ui/keyDescription/KeyDescriptionScreen.kt
+++ b/feat/my/src/main/java/com/emotionstorage/my/ui/keyDescription/KeyDescriptionScreen.kt
@@ -40,7 +40,7 @@ import com.emotionstorage.ui.component.modal.TempErrorModal
 import com.emotionstorage.ui.theme.MooiTheme
 import com.emotionstorage.ui.util.rememberAdaptiveHeightDp
 
-private enum class KeyDescriptionModalState{
+private enum class KeyDescriptionModalState  {
     None,
     TempError,
     LoginSessionExpired,
@@ -54,11 +54,11 @@ fun KeyDescriptionScreen(
     viewModel: KeyBalanceViewModel = hiltViewModel(),
 ) {
     val state by viewModel.keyCountState.collectAsStateWithLifecycle()
-    val (modalState, setModalState) = remember{ mutableStateOf(KeyDescriptionModalState.None) }
+    val (modalState, setModalState) = remember { mutableStateOf(KeyDescriptionModalState.None) }
 
     LaunchedEffect(Unit) {
-        viewModel.container.sideEffectFlow.collect{
-            when(it){
+        viewModel.container.sideEffectFlow.collect {
+            when (it) {
                 is BaseSideEffect.TemporalError -> {
                     setModalState(KeyDescriptionModalState.TempError)
                 }
@@ -82,7 +82,7 @@ fun KeyDescriptionScreen(
         navToBack = navToBack,
     )
 
-    when(modalState){
+    when (modalState) {
         KeyDescriptionModalState.None -> {
             // no modal
         }

--- a/feat/my/src/main/java/com/emotionstorage/my/ui/myPage/MyPageScreen.kt
+++ b/feat/my/src/main/java/com/emotionstorage/my/ui/myPage/MyPageScreen.kt
@@ -52,7 +52,7 @@ import com.emotionstorage.ui.theme.MooiTheme
 import com.orhanobut.logger.Logger
 import kotlinx.coroutines.launch
 
-private enum class MyPageModalState {
+private enum class ModalState {
     NONE,
     LOGOUT_CONFIRM,
     LOGOUT_ERROR,
@@ -74,7 +74,7 @@ fun MyPageScreen(
 //    navToNotificationSetting: () -> Unit = {},
 ) {
     val state = viewModel.container.stateFlow.collectAsState()
-    val (modalState, setModalState) = remember { mutableStateOf<MyPageModalState>(MyPageModalState.NONE) }
+    val (modalState, setModalState) = remember { mutableStateOf<ModalState>(ModalState.NONE) }
 
     LifecycleResumeEffect(Unit) {
         Logger.d("MyPageScreen: onResume triggered")
@@ -92,15 +92,15 @@ fun MyPageScreen(
                 }
 
                 is MyPageSideEffect.LogoutError -> {
-                    setModalState(MyPageModalState.LOGOUT_ERROR)
+                    setModalState(ModalState.LOGOUT_ERROR)
                 }
 
                 is BaseSideEffect.TemporalError -> {
-                    setModalState(MyPageModalState.TEMP_ERROR)
+                    setModalState(ModalState.TEMP_ERROR)
                 }
 
                 is BaseSideEffect.SessionExpired -> {
-                    setModalState(MyPageModalState.LOGIN_EXPIRED)
+                    setModalState(ModalState.LOGIN_EXPIRED)
                 }
             }
         }
@@ -126,23 +126,23 @@ fun MyPageScreen(
     )
 
     when (modalState) {
-        MyPageModalState.NONE -> {
+        ModalState.NONE -> {
             // no modal
         }
 
-        MyPageModalState.LOGOUT_CONFIRM -> {
+        ModalState.LOGOUT_CONFIRM -> {
             ConfirmLogoutModal(
                 onDismissRequest = {
-                    setModalState(MyPageModalState.NONE)
+                    setModalState(ModalState.NONE)
                 },
                 onLogout = { viewModel.onAction(MyPageAction.Logout) },
             )
         }
 
-        MyPageModalState.LOGOUT_ERROR -> {
+        ModalState.LOGOUT_ERROR -> {
             LogoutErrorModal(
                 onDismissRequest = {
-                    setModalState(MyPageModalState.NONE)
+                    setModalState(ModalState.NONE)
                 },
                 onRetry = {
                     viewModel.onAction(MyPageAction.Logout)
@@ -150,19 +150,19 @@ fun MyPageScreen(
             )
         }
 
-        MyPageModalState.LOGIN_EXPIRED -> {
+        ModalState.LOGIN_EXPIRED -> {
             LoginSessionExpiredModal(
                 onDismissRequest = {
-                    setModalState(MyPageModalState.NONE)
+                    setModalState(ModalState.NONE)
                 },
                 navToLogin = navToLogin,
             )
         }
 
-        MyPageModalState.TEMP_ERROR -> {
+        ModalState.TEMP_ERROR -> {
             TempErrorModal(
                 onDismissRequest = {
-                    setModalState(MyPageModalState.NONE)
+                    setModalState(ModalState.NONE)
                 },
             )
         }
@@ -173,7 +173,7 @@ fun MyPageScreen(
 private fun StatelessMyPageScreen(
     modifier: Modifier = Modifier,
     bottomAppBar: @Composable () -> Unit = {},
-    setModalState: (MyPageModalState) -> Unit = {},
+    setModalState: (ModalState) -> Unit = {},
     state: MyPageState = MyPageState(),
     navToWithdraw: () -> Unit = {},
     navToNickNameChange: () -> Unit = {},
@@ -247,7 +247,7 @@ private fun StatelessMyPageScreen(
                         }
                     },
                     onTermsAndPrivacyClick = navToTermsAndPrivacy,
-                    onLogoutClick = { setModalState(MyPageModalState.LOGOUT_CONFIRM) },
+                    onLogoutClick = { setModalState(ModalState.LOGOUT_CONFIRM) },
 //                    onNotificationClick = navToNotificationSetting,
                 )
 

--- a/feat/my/src/main/java/com/emotionstorage/my/ui/myPage/MyPageScreen.kt
+++ b/feat/my/src/main/java/com/emotionstorage/my/ui/myPage/MyPageScreen.kt
@@ -44,7 +44,10 @@ import com.emotionstorage.my.ui.modal.ConfirmLogoutModal
 import com.emotionstorage.my.ui.modal.LogoutErrorModal
 import com.emotionstorage.my.ui.myPage.component.MenuSection
 import com.emotionstorage.my.ui.myPage.component.ProfileHeader
+import com.emotionstorage.presentation.BaseSideEffect
 import com.emotionstorage.ui.component.loading.LoadingOverlay
+import com.emotionstorage.ui.component.modal.LoginSessionExpiredModal
+import com.emotionstorage.ui.component.modal.TempErrorModal
 import com.emotionstorage.ui.theme.MooiTheme
 import com.orhanobut.logger.Logger
 import kotlinx.coroutines.launch
@@ -53,10 +56,9 @@ private enum class MyPageModalState {
     NONE,
     LOGOUT_CONFIRM,
     LOGOUT_ERROR,
+    LOGIN_EXPIRED,
+    TEMP_ERROR,
 }
-
-// TODO : Screen 전환 방지를 위한 임시 상수
-private const val ENABLE_NOTIFICATION_SETTING_NAVIGATION = false
 
 @Composable
 fun MyPageScreen(
@@ -93,9 +95,14 @@ fun MyPageScreen(
                     setModalState(MyPageModalState.LOGOUT_ERROR)
                 }
 
-                is MyPageSideEffect.ShowToast -> {
-                    // todo: add error toast
+                is BaseSideEffect.TemporalError -> {
+                    setModalState(MyPageModalState.TEMP_ERROR)
                 }
+
+                is BaseSideEffect.SessionExpired -> {
+                    setModalState(MyPageModalState.LOGIN_EXPIRED)
+                }
+
             }
         }
     }
@@ -140,6 +147,23 @@ fun MyPageScreen(
                 },
                 onRetry = {
                     viewModel.onAction(MyPageAction.Logout)
+                },
+            )
+        }
+
+        MyPageModalState.LOGIN_EXPIRED -> {
+            LoginSessionExpiredModal(
+                onDismissRequest = {
+                    setModalState(MyPageModalState.NONE)
+                },
+                navToLogin = navToLogin,
+            )
+        }
+
+        MyPageModalState.TEMP_ERROR -> {
+            TempErrorModal(
+                onDismissRequest = {
+                    setModalState(MyPageModalState.NONE)
                 },
             )
         }

--- a/feat/my/src/main/java/com/emotionstorage/my/ui/myPage/MyPageScreen.kt
+++ b/feat/my/src/main/java/com/emotionstorage/my/ui/myPage/MyPageScreen.kt
@@ -102,7 +102,6 @@ fun MyPageScreen(
                 is BaseSideEffect.SessionExpired -> {
                     setModalState(MyPageModalState.LOGIN_EXPIRED)
                 }
-
             }
         }
     }

--- a/feat/my/src/main/java/com/emotionstorage/my/ui/notificationSettings/NotificationSettingScreen.kt
+++ b/feat/my/src/main/java/com/emotionstorage/my/ui/notificationSettings/NotificationSettingScreen.kt
@@ -39,30 +39,51 @@ import com.emotionstorage.my.ui.notificationSettings.component.DayOfWeekSelector
 import com.emotionstorage.my.ui.notificationSettings.component.ReminderTimeComponent
 import com.emotionstorage.my.ui.notificationSettings.component.ToggleRow
 import com.emotionstorage.my.ui.notificationSettings.component.RequestPermissionBottomSheet
+import com.emotionstorage.presentation.BaseSideEffect
 import com.emotionstorage.presentation.notification.NotificationPermissionGateViewModel
 import com.emotionstorage.ui.annotation.PreviewScreenRatios
 import com.emotionstorage.ui.component.appBar.TopAppBar
 import com.emotionstorage.ui.component.bottomSheet.TimePickerBottomSheet
 import com.emotionstorage.ui.component.loading.LoadingOverlay
+import com.emotionstorage.ui.component.modal.LoginSessionExpiredModal
+import com.emotionstorage.ui.component.modal.TempErrorModal
 import com.emotionstorage.ui.theme.MooiTheme
 import com.orhanobut.logger.Logger
 import java.time.DayOfWeek
 
-enum class Sheet { None, Permission, TimePicker }
+private enum class ModalState { None, TempError, LoginSessionExpired }
+private enum class SheetState { None, Permission, TimePicker }
+
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun NotificationSettingScreen(
+    navToBack: () -> Unit,
+    navToLogin: () -> Unit,
     viewModel: NotificationSettingViewModel = hiltViewModel(),
     permissionGateViewModel: NotificationPermissionGateViewModel = hiltViewModel(),
-    navToBack: () -> Unit,
 ) {
     val context = LocalContext.current
     val state = viewModel.state.collectAsState()
+
+    val (modalState, setModalState) = remember { mutableStateOf(ModalState.None) }
+    val (sheetState, setSheetState) = remember { mutableStateOf(SheetState.None) }
+
+    LaunchedEffect(Unit){
+        viewModel.container.sideEffectFlow.collect{
+            when(it){
+                is BaseSideEffect.TemporalError -> {
+                    setModalState(ModalState.TempError)
+                }
+
+                is BaseSideEffect.SessionExpired -> {
+                    setModalState(ModalState.LoginSessionExpired)
+                }
+            }
+        }
+    }
+
     val permissionInfo by permissionGateViewModel.info.collectAsState()
-
-    var activeSheet by remember { mutableStateOf(Sheet.None) }
-
     val locallyAllowed = permissionInfo.status == NotificationPermissionStatus.Granted
 
     LifecycleResumeEffect(Unit) {
@@ -77,7 +98,9 @@ fun NotificationSettingScreen(
     }
 
     LaunchedEffect(locallyAllowed) {
-        activeSheet = if (locallyAllowed) Sheet.None else Sheet.Permission
+        setSheetState(
+            if (locallyAllowed) SheetState.None else SheetState.Permission
+        )
     }
 
     StatelessNotificationSettingScreen(
@@ -86,7 +109,7 @@ fun NotificationSettingScreen(
             if (locallyAllowed) {
                 viewModel.setAppPush(isOn)
             } else {
-                activeSheet = Sheet.Permission
+                setSheetState(SheetState.Permission)
             }
         },
         onToggleEmotionReminder = viewModel::setEmotionReminder,
@@ -95,38 +118,59 @@ fun NotificationSettingScreen(
         onDayClick = viewModel::toggleDay,
         onClickTime = {
             if (state.value.emotionReminderNotify) {
-                activeSheet = Sheet.TimePicker
+                setSheetState(SheetState.TimePicker)
             }
         },
         navToBack = navToBack,
     )
 
-    when (activeSheet) {
-        Sheet.Permission -> {
+    when(modalState){
+        ModalState.None -> {
+            // no modal
+        }
+
+        ModalState.TempError -> {
+            TempErrorModal(
+                onDismissRequest = { setModalState(ModalState.None) },
+            )
+        }
+
+        ModalState.LoginSessionExpired -> {
+            LoginSessionExpiredModal (
+                onDismissRequest = { setModalState(ModalState.None) },
+                navToLogin = navToLogin,
+            )
+        }
+    }
+
+    when (sheetState) {
+        SheetState.Permission -> {
             Logger.d("Show RequestPermissionBottomSheet")
             RequestPermissionBottomSheet(
                 onDismiss = {
-                    activeSheet = Sheet.None
+                    setSheetState(SheetState.None)
                 },
                 sheetState =
                     rememberModalBottomSheetState(skipPartiallyExpanded = true),
             )
         }
 
-        Sheet.TimePicker -> {
+        SheetState.TimePicker -> {
             Logger.d("Show TimePickerBottomSheet")
             TimePickerBottomSheet(
                 sheetState = rememberModalBottomSheetState(skipPartiallyExpanded = true),
                 initialTime = state.value.emotionReminderTime,
-                onDismissRequest = { activeSheet = Sheet.None },
+                onDismissRequest = {
+                    setSheetState(SheetState.None)
+                },
                 onTimeSelected = {
                     viewModel.setTime(it)
-                    activeSheet = Sheet.None
+                    setSheetState(SheetState.None)
                 },
             )
         }
 
-        Sheet.None -> {
+        SheetState.None -> {
             Logger.d("Close Sheets")
         }
     }

--- a/feat/my/src/main/java/com/emotionstorage/my/ui/notificationSettings/NotificationSettingScreen.kt
+++ b/feat/my/src/main/java/com/emotionstorage/my/ui/notificationSettings/NotificationSettingScreen.kt
@@ -52,8 +52,8 @@ import com.orhanobut.logger.Logger
 import java.time.DayOfWeek
 
 private enum class ModalState { None, TempError, LoginSessionExpired }
-private enum class SheetState { None, Permission, TimePicker }
 
+private enum class SheetState { None, Permission, TimePicker }
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
@@ -69,9 +69,9 @@ fun NotificationSettingScreen(
     val (modalState, setModalState) = remember { mutableStateOf(ModalState.None) }
     val (sheetState, setSheetState) = remember { mutableStateOf(SheetState.None) }
 
-    LaunchedEffect(Unit){
-        viewModel.container.sideEffectFlow.collect{
-            when(it){
+    LaunchedEffect(Unit) {
+        viewModel.container.sideEffectFlow.collect {
+            when (it) {
                 is BaseSideEffect.TemporalError -> {
                     setModalState(ModalState.TempError)
                 }
@@ -99,7 +99,7 @@ fun NotificationSettingScreen(
 
     LaunchedEffect(locallyAllowed) {
         setSheetState(
-            if (locallyAllowed) SheetState.None else SheetState.Permission
+            if (locallyAllowed) SheetState.None else SheetState.Permission,
         )
     }
 
@@ -124,7 +124,7 @@ fun NotificationSettingScreen(
         navToBack = navToBack,
     )
 
-    when(modalState){
+    when (modalState) {
         ModalState.None -> {
             // no modal
         }
@@ -136,7 +136,7 @@ fun NotificationSettingScreen(
         }
 
         ModalState.LoginSessionExpired -> {
-            LoginSessionExpiredModal (
+            LoginSessionExpiredModal(
                 onDismissRequest = { setModalState(ModalState.None) },
                 navToLogin = navToLogin,
             )

--- a/feat/my/src/main/java/com/emotionstorage/my/ui/withdraw/WithDrawNoticeScreen.kt
+++ b/feat/my/src/main/java/com/emotionstorage/my/ui/withdraw/WithDrawNoticeScreen.kt
@@ -30,19 +30,19 @@ import com.emotionstorage.ui.component.button.CtaButtonType
 import com.emotionstorage.ui.component.loading.LoadingOverlay
 import com.emotionstorage.ui.theme.MooiTheme
 
-private sealed class WithdrawNoticeModalState {
-    object None : WithdrawNoticeModalState()
+private sealed class ModalState {
+    object None : ModalState()
 
-    object ConfirmWithdraw : WithdrawNoticeModalState()
+    object ConfirmWithdraw : ModalState()
 
-    object WithdrawSuccess : WithdrawNoticeModalState()
+    object WithdrawSuccess : ModalState()
 
     data class InquireWithdrawError(
         val errorCode: ErrorCode,
         val throwable: Throwable,
         val userEmail: String? = null,
         val userNickname: String? = null,
-    ) : WithdrawNoticeModalState()
+    ) : ModalState()
 }
 
 @Composable
@@ -55,19 +55,19 @@ fun WithDrawNoticeScreen(
     val state by viewModel.container.stateFlow.collectAsState()
     val (modalState, setModalState) =
         remember {
-            mutableStateOf<WithdrawNoticeModalState>(WithdrawNoticeModalState.None)
+            mutableStateOf<ModalState>(ModalState.None)
         }
 
     LaunchedEffect(Unit) {
         viewModel.container.sideEffectFlow.collect { sideEffect ->
             when (sideEffect) {
                 is WithdrawNoticeEffect.WithDrawSuccess -> {
-                    setModalState(WithdrawNoticeModalState.WithdrawSuccess)
+                    setModalState(ModalState.WithdrawSuccess)
                 }
 
                 is WithdrawNoticeEffect.WithdrawError -> {
                     setModalState(
-                        WithdrawNoticeModalState.InquireWithdrawError(
+                        ModalState.InquireWithdrawError(
                             sideEffect.errorCode,
                             sideEffect.throwable,
                             sideEffect.userEmail,
@@ -89,14 +89,14 @@ fun WithDrawNoticeScreen(
     )
 
     when (modalState) {
-        is WithdrawNoticeModalState.None -> {
+        is ModalState.None -> {
             // no modal
         }
 
-        is WithdrawNoticeModalState.ConfirmWithdraw -> {
+        is ModalState.ConfirmWithdraw -> {
             ConfirmWithdrawModal(
                 onDismissRequest = {
-                    setModalState(WithdrawNoticeModalState.None)
+                    setModalState(ModalState.None)
                 },
                 onWithDraw = {
                     viewModel.onAction(WithdrawNoticeAction.WithDraw)
@@ -107,23 +107,23 @@ fun WithDrawNoticeScreen(
             )
         }
 
-        is WithdrawNoticeModalState.WithdrawSuccess -> {
+        is ModalState.WithdrawSuccess -> {
             WithdrawSuccessModal(
                 onDismissRequest = {
-                    setModalState(WithdrawNoticeModalState.None)
+                    setModalState(ModalState.None)
                     navToLogin()
                 },
             )
         }
 
-        is WithdrawNoticeModalState.InquireWithdrawError -> {
+        is ModalState.InquireWithdrawError -> {
             InquireWithdrawErrorModal(
                 errorCode = modalState.errorCode,
                 throwable = modalState.throwable,
                 userEmail = modalState.userEmail,
                 userNickname = modalState.userNickname,
                 onDismissRequest = {
-                    setModalState(WithdrawNoticeModalState.None)
+                    setModalState(ModalState.None)
                 },
             )
         }
@@ -133,7 +133,7 @@ fun WithDrawNoticeScreen(
 @Composable
 private fun StatelessWithDrawNoticeScreen(
     onBackClick: () -> Unit,
-    setModalState: (WithdrawNoticeModalState) -> Unit,
+    setModalState: (ModalState) -> Unit,
 ) {
     Scaffold(
         modifier =
@@ -166,7 +166,7 @@ private fun StatelessWithDrawNoticeScreen(
                 type = CtaButtonType.OUTLINED,
                 labelString = "MOOI 서비스 탈퇴하기",
                 onClick = {
-                    setModalState(WithdrawNoticeModalState.ConfirmWithdraw)
+                    setModalState(ModalState.ConfirmWithdraw)
                 },
                 isDefaultWidth = false,
                 textStyle =

--- a/feat/tutorial/src/main/java/com/emotionstorage/tutorial/ui/OnBoardingNavHost.kt
+++ b/feat/tutorial/src/main/java/com/emotionstorage/tutorial/ui/OnBoardingNavHost.kt
@@ -50,17 +50,17 @@ enum class OnBoardingRoute(
     MARKETING_DETAIL("on_boarding/agree_terms/marketing_detail"),
 }
 
-private sealed class OnBoardingModalState {
-    object None : OnBoardingModalState()
+private sealed class ModalState {
+    object None : ModalState()
 
-    object SocialTokenExpired : OnBoardingModalState()
+    object SocialTokenExpired : ModalState()
 
-    object DuplicateAccount : OnBoardingModalState()
+    object DuplicateAccount : ModalState()
 
     data class SignupError(
         val errorCode: ErrorCode,
         val throwable: Throwable,
-    ) : OnBoardingModalState()
+    ) : ModalState()
 }
 
 @Composable
@@ -74,7 +74,7 @@ fun OnBoardingNavHost(
 ) {
     val navController = rememberNavController()
     val state by sharedViewModel.container.stateFlow.collectAsState()
-    var modalState by remember { mutableStateOf<OnBoardingModalState>(OnBoardingModalState.None) }
+    var modalState by remember { mutableStateOf<ModalState>(ModalState.None) }
 
     LaunchedEffect(provider, idToken) {
         sharedViewModel.onAction(OnBoardingAction.Initiate(provider, idToken))
@@ -87,16 +87,16 @@ fun OnBoardingNavHost(
                 }
 
                 is OnBoardingSideEffect.SocialTokenExpired -> {
-                    modalState = OnBoardingModalState.SocialTokenExpired
+                    modalState = ModalState.SocialTokenExpired
                 }
 
                 is OnBoardingSideEffect.DuplicateAccount -> {
-                    modalState = OnBoardingModalState.DuplicateAccount
+                    modalState = ModalState.DuplicateAccount
                 }
 
                 is BaseSideEffect.TemporalError -> {
                     modalState =
-                        OnBoardingModalState.SignupError(sideEffect.code, sideEffect.throwable)
+                        ModalState.SignupError(sideEffect.code, sideEffect.throwable)
                 }
 
                 is BaseSideEffect.NetworkError -> {
@@ -118,12 +118,12 @@ fun OnBoardingNavHost(
     )
 
     when (modalState) {
-        OnBoardingModalState.None -> {}
+        ModalState.None -> {}
 
-        OnBoardingModalState.SocialTokenExpired -> {
+        ModalState.SocialTokenExpired -> {
             SocialTokenExpiredModal(
                 onDismissRequest = {
-                    modalState = OnBoardingModalState.None
+                    modalState = ModalState.None
                 },
                 onConfirm = {
                     // nav back to login screen
@@ -132,10 +132,10 @@ fun OnBoardingNavHost(
             )
         }
 
-        OnBoardingModalState.DuplicateAccount -> {
+        ModalState.DuplicateAccount -> {
             DuplicateAccountModal(
                 onDismissRequest = {
-                    modalState = OnBoardingModalState.None
+                    modalState = ModalState.None
                 },
                 onConfirm = {
                     // nav back to login screen
@@ -144,13 +144,13 @@ fun OnBoardingNavHost(
             )
         }
 
-        is OnBoardingModalState.SignupError -> {
-            val inquireModalState = modalState as OnBoardingModalState.SignupError
+        is ModalState.SignupError -> {
+            val inquireModalState = modalState as ModalState.SignupError
             InquireSignupErrorModal(
                 inquireModalState.errorCode,
                 inquireModalState.throwable,
                 onDismissRequest = {
-                    modalState = OnBoardingModalState.None
+                    modalState = ModalState.None
                 },
             )
         }


### PR DESCRIPTION
## Related Issue
- Issue #191 

## 작업 상세 내용
- 마이페이지 탭(마이페이지, 계정 정보, 열쇠 상세, 닉네임 변경, 알림 설정) 임시 오류 & 로그인 만료 오류 팝업 추가


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 여러 화면에서 로그인 화면으로 즉시 이동할 수 있는 직접 네비게이션 추가

* **개선 사항**
  * 세션 만료 및 임시 오류 시 일관된 모달 표시로 사용자 흐름 개선
  * 계정 정보·키·마이페이지 등 화면에서 상태 관리 및 로딩/오류 처리 일관성 강화
  * 마이페이지에 버전 정보 표시 필드 추가 (동적 표시 예정)

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->