### PR TITLE
Fix/google login issue 로그인 시 401 처리 로직 개선, 클라이언트 소셜 토큰 발급 에러 처리 추가

### DIFF
--- a/core/remote/src/main/java/com/emotionstorage/remote/interceptor/FailResponseInterceptor.kt
+++ b/core/remote/src/main/java/com/emotionstorage/remote/interceptor/FailResponseInterceptor.kt
@@ -26,9 +26,9 @@ class FailResponseInterceptor @Inject constructor(
             }.getOrNull()
 
         // handle unauthorized error with TokenAuthenticator, if it is not social token error
-        if (httpResponse.code == 401
-            && responseDto?.code != "INVALID_ID_TOKEN"
-            && responseDto?.code != "INVALID_KAKAO_ACCESS_TOKEN"
+        if (httpResponse.code == 401 &&
+            responseDto?.code != "INVALID_ID_TOKEN" &&
+            responseDto?.code != "INVALID_KAKAO_ACCESS_TOKEN"
         ) {
             return httpResponse
         }

--- a/core/remote/src/main/java/com/emotionstorage/remote/interceptor/FailResponseInterceptor.kt
+++ b/core/remote/src/main/java/com/emotionstorage/remote/interceptor/FailResponseInterceptor.kt
@@ -17,16 +17,21 @@ class FailResponseInterceptor @Inject constructor(
         val httpResponse = chain.proceed(httpRequest)
         // return successful response
         if (httpResponse.code in 200..226) return httpResponse
-        // return 401 error for token authenticator to handle
-        if (httpResponse.code == 401) return httpResponse
 
         // parse error response body & throw custom error
         val httpResponseBody = httpResponse.peekBody(Long.MAX_VALUE).string()
-
         val responseDto =
             runCatching {
                 json.decodeFromString<ResponseDto<String>>(httpResponseBody)
             }.getOrNull()
+
+        // handle unauthorized error with TokenAuthenticator, if it is not social token error
+        if (httpResponse.code == 401
+            && responseDto?.code != "INVALID_ID_TOKEN"
+            && responseDto?.code != "INVALID_KAKAO_ACCESS_TOKEN"
+        ) {
+            return httpResponse
+        }
 
         throw CustomHttpException(
             status = ResponseStatus.fromCode(responseDto?.status ?: httpResponse.code),

--- a/data/src/main/java/com/emotionstorage/data/repoImpl/AuthRepositoryImpl.kt
+++ b/data/src/main/java/com/emotionstorage/data/repoImpl/AuthRepositoryImpl.kt
@@ -32,7 +32,7 @@ class AuthRepositoryImpl @Inject constructor(
                     AuthProvider.KAKAO -> kakaoRemoteDataSource.getIdToken()
                     AuthProvider.GOOGLE -> googleRemoteDataSource.getIdToken()
                 }
-            Napier.d("GetIdToken success, provider: $provider, idToken: ${idToken.take(6) + "..."}")
+            Napier.d("GetIdToken success, provider: $provider")
         } catch (e: Exception) {
             return DataState.Error(
                 throwable = e,

--- a/data/src/main/java/com/emotionstorage/data/repoImpl/AuthRepositoryImpl.kt
+++ b/data/src/main/java/com/emotionstorage/data/repoImpl/AuthRepositoryImpl.kt
@@ -36,7 +36,7 @@ class AuthRepositoryImpl @Inject constructor(
         } catch (e: Exception) {
             return DataState.Error(
                 throwable = e,
-                code = ErrorCode.SOCIAL_ID_TOKEN_ISSUE_FAIL,
+                code = ErrorCode.CLIENT_ID_TOKEN_ISSUE_FAIL,
             )
         }
         // login with id token

--- a/data/src/main/java/com/emotionstorage/data/repoImpl/AuthRepositoryImpl.kt
+++ b/data/src/main/java/com/emotionstorage/data/repoImpl/AuthRepositoryImpl.kt
@@ -22,26 +22,30 @@ class AuthRepositoryImpl @Inject constructor(
     private val kakaoRemoteDataSource: KakaoRemoteDataSource,
     private val googleRemoteDataSource: GoogleRemoteDataSource,
 ) : AuthRepository {
-    override suspend fun login(provider: AuthProvider): DataState<String> =
+    override suspend fun login(provider: AuthProvider): DataState<String> {
+        var idToken: String? = null
+
+        // get id token from providers
         try {
-            // get id token from providers
-            val idToken =
+            idToken =
                 when (provider) {
                     AuthProvider.KAKAO -> kakaoRemoteDataSource.getIdToken()
                     AuthProvider.GOOGLE -> googleRemoteDataSource.getIdToken()
                 }
             Napier.d("GetIdToken success, provider: $provider, idToken: ${idToken.take(6) + "..."}")
-
-            loginWithIdToken(provider, idToken)
         } catch (e: Exception) {
-            DataState.Error(
-                e,
-                when (provider) {
-                    AuthProvider.GOOGLE -> ErrorCode.INVALID_ID_TOKEN
-                    AuthProvider.KAKAO -> ErrorCode.INVALID_KAKAO_ACCESS_TOKEN
-                },
+            return DataState.Error(
+                throwable = e,
+                code = ErrorCode.SOCIAL_ID_TOKEN_ISSUE_FAIL,
             )
         }
+        // login with id token
+        return try {
+            loginWithIdToken(provider, idToken)
+        } catch (e: Exception) {
+            DataState.Error(e)
+        }
+    }
 
     override suspend fun loginWithIdToken(
         provider: AuthProvider,

--- a/domain/src/main/java/com/emotionstorage/domain/common/ErrorCode.kt
+++ b/domain/src/main/java/com/emotionstorage/domain/common/ErrorCode.kt
@@ -6,6 +6,11 @@ import com.emotionstorage.domain.common.ErrorCode.REFRESH_TOKEN_EXPIRED
 import com.emotionstorage.domain.common.ErrorCode.REFRESH_TOKEN_NOT_FOUND
 import com.emotionstorage.domain.common.ErrorCode.UNAUTHORIZED
 
+/**
+ * Error Code
+ * - common/remote error: 서버 측 오류 코드, 응답 code와 동일하게 네이밍
+ * - client error: 앱 클라이언트 측 오류 코드, CLIENT_로 시작하는 이름으로 네이밍
+ */
 enum class ErrorCode {
     // common
     UNKNOWN,

--- a/domain/src/main/java/com/emotionstorage/domain/common/ErrorCode.kt
+++ b/domain/src/main/java/com/emotionstorage/domain/common/ErrorCode.kt
@@ -27,8 +27,8 @@ enum class ErrorCode {
     INVALID_NICKNAME,
 
     // auth client
-    SOCIAL_ID_TOKEN_ISSUE_FAIL,
-    LOGIN_CLIENT_ERROR,
+    CLIENT_ID_TOKEN_ISSUE_FAIL,
+    CLIENT_LOGIN_ERROR,
 
     // chat remote
     CHAT_ROOM_NOT_FOUND,

--- a/domain/src/main/java/com/emotionstorage/domain/common/ErrorCode.kt
+++ b/domain/src/main/java/com/emotionstorage/domain/common/ErrorCode.kt
@@ -27,6 +27,7 @@ enum class ErrorCode {
     INVALID_NICKNAME,
 
     // auth client
+    SOCIAL_ID_TOKEN_ISSUE_FAIL,
     LOGIN_CLIENT_ERROR,
 
     // chat remote

--- a/domain/src/main/java/com/emotionstorage/domain/useCase/auth/HandleLoginUseCase.kt
+++ b/domain/src/main/java/com/emotionstorage/domain/useCase/auth/HandleLoginUseCase.kt
@@ -32,7 +32,7 @@ class HandleLoginUseCase @Inject constructor(
             }
         } catch (e: Exception) {
             Napier.e("handle login client error", e)
-            return DataState.Error(e, ErrorCode.LOGIN_CLIENT_ERROR, accessToken)
+            return DataState.Error(e, ErrorCode.CLIENT_LOGIN_ERROR, accessToken)
         }
     }
 }

--- a/feat/auth/src/main/java/com/emotionstorage/auth/presentation/LoginViewModel.kt
+++ b/feat/auth/src/main/java/com/emotionstorage/auth/presentation/LoginViewModel.kt
@@ -92,7 +92,7 @@ class LoginViewModel
                         Logger.d("login error - need sign up")
                         retryCount = 0
                         postSideEffect(LoginSideEffect.NeedSignUp(provider, data as String))
-                    } else if (code == ErrorCode.LOGIN_CLIENT_ERROR) {
+                    } else if (code == ErrorCode.CLIENT_LOGIN_ERROR) {
                         Logger.d("login error - client error")
                         retryCount++
                         postSideEffect(LoginSideEffect.RetryHandleLogin(data as String))

--- a/feat/auth/src/main/java/com/emotionstorage/auth/presentation/LoginViewModel.kt
+++ b/feat/auth/src/main/java/com/emotionstorage/auth/presentation/LoginViewModel.kt
@@ -51,98 +51,98 @@ sealed class LoginSideEffect : BaseSideEffect {
 @OptIn(OrbitExperimental::class)
 @HiltViewModel
 class LoginViewModel
-@Inject constructor(
-    private val login: LoginUseCase,
-    private val handleLoginUseCase: HandleLoginUseCase,
-) : BaseViewModel<LoginState>(
-    LoginState(),
-) {
-    private var retryCount: Int = 0
+    @Inject constructor(
+        private val login: LoginUseCase,
+        private val handleLoginUseCase: HandleLoginUseCase,
+    ) : BaseViewModel<LoginState>(
+            LoginState(),
+        ) {
+        private var retryCount: Int = 0
 
-    fun onAction(action: LoginAction) {
-        when (action) {
-            is LoginAction.Login -> {
-                handleLogin(action.provider)
-            }
+        fun onAction(action: LoginAction) {
+            when (action) {
+                is LoginAction.Login -> {
+                    handleLogin(action.provider)
+                }
 
-            is LoginAction.RetryLogin -> {
-                handleRetryLogin(action.accessToken)
+                is LoginAction.RetryLogin -> {
+                    handleRetryLogin(action.accessToken)
+                }
             }
         }
-    }
 
-    private fun handleLogin(provider: AuthProvider) =
-        baseIntent {
-            reduce {
-                state.copy(isLoading = true)
-            }
-            retryCount = 0
-            login(provider).handle(onSuccess = {
+        private fun handleLogin(provider: AuthProvider) =
+            baseIntent {
                 reduce {
-                    state.copy(isLoading = false)
+                    state.copy(isLoading = true)
                 }
-                postSideEffect(LoginSideEffect.LoginSuccess)
-            }, onError = { throwable, code, data ->
-                reduce {
-                    state.copy(isLoading = false)
-                }
-                if (code == ErrorCode.CLIENT_ID_TOKEN_ISSUE_FAIL) {
-                    Logger.d("login error - social token issue fail")
-                    retryCount = 0
-                    postSideEffect(LoginSideEffect.SocialTokenIssueError)
-                } else if (code == ErrorCode.NEED_SIGN_UP) {
-                    Logger.d("login error - need sign up")
-                    retryCount = 0
-                    postSideEffect(LoginSideEffect.NeedSignUp(provider, data as String))
-                } else if (code == ErrorCode.INVALID_ID_TOKEN || code == ErrorCode.INVALID_KAKAO_ACCESS_TOKEN) {
-                    Logger.d("login error - invalid social id")
-                    retryCount = 0
-                    postSideEffect(LoginSideEffect.InvalidSocialTokenError)
-                } else if (code == ErrorCode.CLIENT_LOGIN_ERROR) {
-                    Logger.d("login error - client error")
-                    retryCount++
-                    postSideEffect(LoginSideEffect.RetryHandleLogin(data as String))
-                } else {
-                    Logger.e("login error - unknown error, code: $code, throwable: $throwable")
-                    throw BaseException(
-                        code = code,
-                        message = throwable.message,
-                        cause = throwable,
-                    )
-                }
-            })
-        }
-
-    private fun handleRetryLogin(accessToken: String) =
-        baseIntent {
-            reduce {
-                state.copy(isLoading = true)
-            }
-            handleLoginUseCase(accessToken).handle(
-                onSuccess = {
+                retryCount = 0
+                login(provider).handle(onSuccess = {
                     reduce {
                         state.copy(isLoading = false)
                     }
-                    retryCount = 0
                     postSideEffect(LoginSideEffect.LoginSuccess)
-                },
-                onError = { throwable, code, data ->
+                }, onError = { throwable, code, data ->
                     reduce {
                         state.copy(isLoading = false)
                     }
-                    if (retryCount < 3) {
+                    if (code == ErrorCode.CLIENT_ID_TOKEN_ISSUE_FAIL) {
+                        Logger.d("login error - social token issue fail")
+                        retryCount = 0
+                        postSideEffect(LoginSideEffect.SocialTokenIssueError)
+                    } else if (code == ErrorCode.NEED_SIGN_UP) {
+                        Logger.d("login error - need sign up")
+                        retryCount = 0
+                        postSideEffect(LoginSideEffect.NeedSignUp(provider, data as String))
+                    } else if (code == ErrorCode.INVALID_ID_TOKEN || code == ErrorCode.INVALID_KAKAO_ACCESS_TOKEN) {
+                        Logger.d("login error - invalid social id")
+                        retryCount = 0
+                        postSideEffect(LoginSideEffect.InvalidSocialTokenError)
+                    } else if (code == ErrorCode.CLIENT_LOGIN_ERROR) {
+                        Logger.d("login error - client error")
                         retryCount++
                         postSideEffect(LoginSideEffect.RetryHandleLogin(data as String))
                     } else {
-                        retryCount = 0
-                        postSideEffect(
-                            LoginSideEffect.InquireLoginError(
-                                code,
-                                throwable,
-                            ),
+                        Logger.e("login error - unknown error, code: $code, throwable: $throwable")
+                        throw BaseException(
+                            code = code,
+                            message = throwable.message,
+                            cause = throwable,
                         )
                     }
-                },
-            )
-        }
-}
+                })
+            }
+
+        private fun handleRetryLogin(accessToken: String) =
+            baseIntent {
+                reduce {
+                    state.copy(isLoading = true)
+                }
+                handleLoginUseCase(accessToken).handle(
+                    onSuccess = {
+                        reduce {
+                            state.copy(isLoading = false)
+                        }
+                        retryCount = 0
+                        postSideEffect(LoginSideEffect.LoginSuccess)
+                    },
+                    onError = { throwable, code, data ->
+                        reduce {
+                            state.copy(isLoading = false)
+                        }
+                        if (retryCount < 3) {
+                            retryCount++
+                            postSideEffect(LoginSideEffect.RetryHandleLogin(data as String))
+                        } else {
+                            retryCount = 0
+                            postSideEffect(
+                                LoginSideEffect.InquireLoginError(
+                                    code,
+                                    throwable,
+                                ),
+                            )
+                        }
+                    },
+                )
+            }
+    }

--- a/feat/auth/src/main/java/com/emotionstorage/auth/presentation/LoginViewModel.kt
+++ b/feat/auth/src/main/java/com/emotionstorage/auth/presentation/LoginViewModel.kt
@@ -27,7 +27,9 @@ sealed class LoginAction {
 }
 
 sealed class LoginSideEffect : BaseSideEffect {
-    object SocialLoginError : LoginSideEffect()
+    object SocialTokenIssueError : LoginSideEffect()
+
+    object InvalidSocialTokenError : LoginSideEffect()
 
     data class NeedSignUp(
         val provider: AuthProvider,
@@ -49,94 +51,98 @@ sealed class LoginSideEffect : BaseSideEffect {
 @OptIn(OrbitExperimental::class)
 @HiltViewModel
 class LoginViewModel
-    @Inject constructor(
-        private val login: LoginUseCase,
-        private val handleLoginUseCase: HandleLoginUseCase,
-    ) : BaseViewModel<LoginState>(
-            LoginState(),
-        ) {
-        private var retryCount: Int = 0
+@Inject constructor(
+    private val login: LoginUseCase,
+    private val handleLoginUseCase: HandleLoginUseCase,
+) : BaseViewModel<LoginState>(
+    LoginState(),
+) {
+    private var retryCount: Int = 0
 
-        fun onAction(action: LoginAction) {
-            when (action) {
-                is LoginAction.Login -> {
-                    handleLogin(action.provider)
-                }
+    fun onAction(action: LoginAction) {
+        when (action) {
+            is LoginAction.Login -> {
+                handleLogin(action.provider)
+            }
 
-                is LoginAction.RetryLogin -> {
-                    handleRetryLogin(action.accessToken)
-                }
+            is LoginAction.RetryLogin -> {
+                handleRetryLogin(action.accessToken)
             }
         }
+    }
 
-        private fun handleLogin(provider: AuthProvider) =
-            baseIntent {
+    private fun handleLogin(provider: AuthProvider) =
+        baseIntent {
+            reduce {
+                state.copy(isLoading = true)
+            }
+            retryCount = 0
+            login(provider).handle(onSuccess = {
                 reduce {
-                    state.copy(isLoading = true)
+                    state.copy(isLoading = false)
                 }
-                retryCount = 0
-                login(provider).handle(onSuccess = {
+                postSideEffect(LoginSideEffect.LoginSuccess)
+            }, onError = { throwable, code, data ->
+                reduce {
+                    state.copy(isLoading = false)
+                }
+                if (code == ErrorCode.CLIENT_ID_TOKEN_ISSUE_FAIL) {
+                    Logger.d("login error - social token issue fail")
+                    retryCount = 0
+                    postSideEffect(LoginSideEffect.SocialTokenIssueError)
+                } else if (code == ErrorCode.NEED_SIGN_UP) {
+                    Logger.d("login error - need sign up")
+                    retryCount = 0
+                    postSideEffect(LoginSideEffect.NeedSignUp(provider, data as String))
+                } else if (code == ErrorCode.INVALID_ID_TOKEN || code == ErrorCode.INVALID_KAKAO_ACCESS_TOKEN) {
+                    Logger.d("login error - invalid social id")
+                    retryCount = 0
+                    postSideEffect(LoginSideEffect.InvalidSocialTokenError)
+                } else if (code == ErrorCode.CLIENT_LOGIN_ERROR) {
+                    Logger.d("login error - client error")
+                    retryCount++
+                    postSideEffect(LoginSideEffect.RetryHandleLogin(data as String))
+                } else {
+                    Logger.e("login error - unknown error, code: $code, throwable: $throwable")
+                    throw BaseException(
+                        code = code,
+                        message = throwable.message,
+                        cause = throwable,
+                    )
+                }
+            })
+        }
+
+    private fun handleRetryLogin(accessToken: String) =
+        baseIntent {
+            reduce {
+                state.copy(isLoading = true)
+            }
+            handleLoginUseCase(accessToken).handle(
+                onSuccess = {
                     reduce {
                         state.copy(isLoading = false)
                     }
+                    retryCount = 0
                     postSideEffect(LoginSideEffect.LoginSuccess)
-                }, onError = { throwable, code, data ->
+                },
+                onError = { throwable, code, data ->
                     reduce {
                         state.copy(isLoading = false)
                     }
-                    if (code == ErrorCode.INVALID_ID_TOKEN || code == ErrorCode.INVALID_KAKAO_ACCESS_TOKEN) {
-                        Logger.d("login error - invalid social id")
-                        retryCount = 0
-                        postSideEffect(LoginSideEffect.SocialLoginError)
-                    } else if (code == ErrorCode.NEED_SIGN_UP) {
-                        Logger.d("login error - need sign up")
-                        retryCount = 0
-                        postSideEffect(LoginSideEffect.NeedSignUp(provider, data as String))
-                    } else if (code == ErrorCode.CLIENT_LOGIN_ERROR) {
-                        Logger.d("login error - client error")
+                    if (retryCount < 3) {
                         retryCount++
                         postSideEffect(LoginSideEffect.RetryHandleLogin(data as String))
                     } else {
-                        Logger.e("login error - unknown error, code: $code, throwable: $throwable")
-                        throw BaseException(
-                            code = code,
-                            message = throwable.message,
-                            cause = throwable,
+                        retryCount = 0
+                        postSideEffect(
+                            LoginSideEffect.InquireLoginError(
+                                code,
+                                throwable,
+                            ),
                         )
                     }
-                })
-            }
-
-        private fun handleRetryLogin(accessToken: String) =
-            baseIntent {
-                reduce {
-                    state.copy(isLoading = true)
-                }
-                handleLoginUseCase(accessToken).handle(
-                    onSuccess = {
-                        reduce {
-                            state.copy(isLoading = false)
-                        }
-                        retryCount = 0
-                        postSideEffect(LoginSideEffect.LoginSuccess)
-                    },
-                    onError = { throwable, code, data ->
-                        reduce {
-                            state.copy(isLoading = false)
-                        }
-                        if (retryCount < 3) {
-                            retryCount++
-                            postSideEffect(LoginSideEffect.RetryHandleLogin(data as String))
-                        } else {
-                            retryCount = 0
-                            postSideEffect(
-                                LoginSideEffect.InquireLoginError(
-                                    code,
-                                    throwable,
-                                ),
-                            )
-                        }
-                    },
-                )
-            }
-    }
+                },
+            )
+        }
+}

--- a/feat/auth/src/main/java/com/emotionstorage/auth/presentation/LoginViewModel.kt
+++ b/feat/auth/src/main/java/com/emotionstorage/auth/presentation/LoginViewModel.kt
@@ -7,6 +7,7 @@ import com.emotionstorage.domain.useCase.auth.LoginUseCase
 import com.emotionstorage.presentation.BaseException
 import com.emotionstorage.presentation.BaseSideEffect
 import com.emotionstorage.presentation.BaseViewModel
+import com.orhanobut.logger.Logger
 import dagger.hilt.android.lifecycle.HiltViewModel
 import org.orbitmvi.orbit.annotation.OrbitExperimental
 import javax.inject.Inject
@@ -84,19 +85,19 @@ class LoginViewModel
                         state.copy(isLoading = false)
                     }
                     if (code == ErrorCode.INVALID_ID_TOKEN || code == ErrorCode.INVALID_KAKAO_ACCESS_TOKEN) {
-                        // invalid social id - show toast
+                        Logger.d("login error - invalid social id")
                         retryCount = 0
                         postSideEffect(LoginSideEffect.SocialLoginError)
                     } else if (code == ErrorCode.NEED_SIGN_UP) {
-                        // need sign up - nav to on boarding
+                        Logger.d("login error - need sign up")
                         retryCount = 0
                         postSideEffect(LoginSideEffect.NeedSignUp(provider, data as String))
                     } else if (code == ErrorCode.LOGIN_CLIENT_ERROR) {
-                        // client login handling error - show login error modal
+                        Logger.d("login error - client error")
                         retryCount++
                         postSideEffect(LoginSideEffect.RetryHandleLogin(data as String))
                     } else {
-                        // throw base exception for base viewmodel to handle
+                        Logger.e("login error - unknown error, code: $code, throwable: $throwable")
                         throw BaseException(
                             code = code,
                             message = throwable.message,

--- a/feat/auth/src/main/java/com/emotionstorage/auth/ui/LoginScreen.kt
+++ b/feat/auth/src/main/java/com/emotionstorage/auth/ui/LoginScreen.kt
@@ -90,7 +90,7 @@ fun LoginScreen(
                 }
 
                 is LoginSideEffect.SocialLoginError -> {
-                    snackbarHostState.showSnackbar("소셜 로그인 실패")
+                    snackbarHostState.showSnackbar("소셜 로그인 토큰 인증 실패")
                 }
 
                 is LoginSideEffect.RetryHandleLogin -> {

--- a/feat/auth/src/main/java/com/emotionstorage/auth/ui/LoginScreen.kt
+++ b/feat/auth/src/main/java/com/emotionstorage/auth/ui/LoginScreen.kt
@@ -89,7 +89,11 @@ fun LoginScreen(
                     navToOnBoarding(effect.provider, effect.idToken)
                 }
 
-                is LoginSideEffect.SocialLoginError -> {
+                is LoginSideEffect.SocialTokenIssueError -> {
+                    snackbarHostState.showSnackbar("소셜 로그인 실패")
+                }
+
+                is LoginSideEffect.InvalidSocialTokenError -> {
                     snackbarHostState.showSnackbar("소셜 로그인 토큰 인증 실패")
                 }
 


### PR DESCRIPTION
## Related Issue
- Issue #235

## 작업 상세 내용
- 로그인 시 401 처리 로직 개선 - 에러 코드 401인 경우, 응답 code 확인 
  - 소셜 토큰 에러인 경우, CustomHttpException 던지기 
  - 그 외 경우, TokenAuthenticator로 토큰 재발급 & 요청 재시도
- 클라이언트 소셜 토큰 발급 에러 처리 추가 
  - 클라이언트 에러 코드 분리 -> 클라이언트 소셜 토큰 발급 오류 / 서버 소셜 토큰 인증 오류 토스트 구분 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **버그 수정**
  * 소셜 로그인 오류 처리 개선으로 로그인 흐름 안정성 향상
  * 401 응답 중 소셜 토큰 관련 오류를 올바르게 분기 처리하여 불필요한 예외 발생 방지

* **신규**
  * 토큰 획득 실패와 토큰 인증 실패를 명확히 구분해 각각에 맞는 오류 상태 및 알림 제공
  * 사용자에게 보여지는 오류 메시지 및 재시도 흐름이 더 세분화되어 문제 파악과 복구가 쉬워짐

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->