### PR TITLE
fix: fix resume chat modal dismiss logic 대화 이어하기 팝업 로직 고침

### DIFF
--- a/feat/home/src/main/java/com/emotionstorage/home/presentation/HomeViewModel.kt
+++ b/feat/home/src/main/java/com/emotionstorage/home/presentation/HomeViewModel.kt
@@ -38,7 +38,7 @@ sealed class HomeAction {
         val roomId: Long,
     ) : HomeAction()
 
-    data class DeleteAndEnterNewChat(
+    data class DeleteChat(
         val roomId: Long,
     ) : HomeAction()
 }
@@ -82,8 +82,8 @@ class HomeViewModel
                     handleEnterPendingChat(action.roomId)
                 }
 
-                is HomeAction.DeleteAndEnterNewChat -> {
-                    handleDeletePendingChatAndEnterNewChat(action.roomId)
+                is HomeAction.DeleteChat -> {
+                    handleDeletePendingChat(action.roomId)
                 }
             }
         }
@@ -198,13 +198,11 @@ class HomeViewModel
                 postSideEffect(HomeSideEffect.EnterChatRoom(roomId, ChatEntry.Resume))
             }
 
-        private fun handleDeletePendingChatAndEnterNewChat(roomId: Long) =
+        private fun handleDeletePendingChat(roomId: Long) =
             baseIntent {
                 deleteChatRoom(roomId).handle(
                     onSuccess = {
                         Logger.d("HomeViewModel: exitChatRoom success")
-                        // enter new chat
-                        handleEnterChat()
                     },
                     onError = { throwable, code, data ->
                         Logger.e("HomeViewModel: exitChatRoom failed $throwable")

--- a/feat/home/src/main/java/com/emotionstorage/home/ui/HomeScreen.kt
+++ b/feat/home/src/main/java/com/emotionstorage/home/ui/HomeScreen.kt
@@ -176,8 +176,8 @@ fun HomeScreen(
                 onResume = {
                     viewModel.onAction(HomeAction.ResumeChat(modalState.pendingRoomId))
                 },
-                onDropAndStartNew = {
-                    viewModel.onAction(HomeAction.DeleteAndEnterNewChat(modalState.pendingRoomId))
+                onDeleteChat = {
+                    viewModel.onAction(HomeAction.DeleteChat(modalState.pendingRoomId))
                 },
             )
         }

--- a/feat/home/src/main/java/com/emotionstorage/home/ui/modal/ResumeChatModal.kt
+++ b/feat/home/src/main/java/com/emotionstorage/home/ui/modal/ResumeChatModal.kt
@@ -27,7 +27,7 @@ import com.emotionstorage.ui.theme.MooiTheme
 fun ResumeChatModal(
     onDismissRequest: () -> Unit = {},
     onResume: () -> Unit = {},
-    onDropAndStartNew: () -> Unit = {},
+    onDeleteChat: () -> Unit = {},
 ) {
     Modal(
         onDismissRequest = onDismissRequest,
@@ -39,7 +39,7 @@ fun ResumeChatModal(
         confirmLabel = "대화를 이어서 진행할게요.",
         onConfirm = onResume,
         dismissLabel = "이전 대화를 그만할래요.",
-        onDismiss = onDropAndStartNew,
+        onDismiss = onDeleteChat,
     )
 }
 


### PR DESCRIPTION
## 작업 상세 내용
- 대화 이어하기 팝업 로직 - 기획 대로 고침
=> 새 대화 시작하지 않고 기존 대화 삭제 후 팝업 닫히도록 변경

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 버그 수정
* 채팅 삭제 동작 개선: 대기 중인 채팅을 삭제할 때, 채팅만 삭제되고 별도의 작업이 수행되지 않습니다.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->