### PR TITLE
캘린더탭 진입 시, 앱 강제 종료 이슈 핫픽스

### DIFF
--- a/feat/time-capsule/src/main/java/com/emotionstorage/time_capsule/ui/component/TimeCapsuleCalendar.kt
+++ b/feat/time-capsule/src/main/java/com/emotionstorage/time_capsule/ui/component/TimeCapsuleCalendar.kt
@@ -38,15 +38,6 @@ private object TimeCapsuleCalendarDesignToken {
     val dateWidth = 30
 }
 
-private val DUMMY_TIME_CAPSULE_DATES =
-    (1..31)
-        .toList()
-        .filter {
-            it % 3 == 0
-        }.map {
-            LocalDate.of(LocalDate.now().year, LocalDate.now().month, it)
-        }
-
 @Composable
 fun TimeCapsuleCalendar(
     modifier: Modifier = Modifier,
@@ -200,7 +191,7 @@ private fun TimeCapsuleCalendarPreview() {
                 modifier = Modifier.align(Alignment.TopCenter),
                 calendarYearMonth = calendarYearMonth,
                 onCalendarYearMonthSelect = setCalendarYearMonth,
-                timeCapsuleDates = DUMMY_TIME_CAPSULE_DATES,
+                timeCapsuleDates = emptyList(),
             )
         }
     }


### PR DESCRIPTION
## 작업 상세 내용
- 원인: 프리뷰 생성용 더미 데이터 처리 시 에러 발생 (2월 30일 - Invalid Date Error)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리즈 노트

* **개선사항**
  * 시간 캡슐 캘린더 컴포넌트의 테스트 데이터를 정리했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->